### PR TITLE
Github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,5 @@
 name: CI
 
-# on: push
-# TMP: only run on this branch
-# I suppose that doesn't matter as other branches won't have the config!
-# on:
-#   push:
-#     branches: ['actions']
-
 # Runs when a pull request is created or its head is updead
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
 on: pull_request


### PR DESCRIPTION
This  PR adds automated building and testing  via GitHub Actions (closes #8)

## What does it do?

* It adds a CI action called Build and Test
* This installs node, pnpm and node_modules, then runs a build and test on all packages
* This runs for every open PR whenever a commit is pushed

## What does it look like?

Click the green tick on the latest commit to see what this looks like.

## Note on multiple jobs

I played a bit with  defining multiple jobs - which creates a nice graph in the github UI, but requires a lot of duplication of setup steps, needs the node_modules cache to be cloned etc, and spins up a new environment for each job. It feels like a lot of effort, not to mention financial and environmental cost, just to show a pretty  graph. So I've abandoned that for now and run all the steps in a single job.

## Benefits

We get some amount of minutes of free CI time with our github organisation - 2,000 if we're on the free package. Here's the [pricing page](https://github.com/pricing#compare-features).

This build took 30 seconds. You might expect a PR to build 5 times. We expect at least 50 PRs to import the adaptors. That's 250 builds, or 125 minutes CI time. So I guess 2000 minutes feels pretty good?

Using Github Actions means we don't need to pay for Circle CI and we can wind that account down (poor Circle, this stuff is bad news for them).

There are actions templates for publishing changesets and publishing docs to github.io, both of which will be super useful to our workflow.

So this feels like a really good CI solution to me.

## Future Work

This enables #15 and #22.