### PR TITLE
Remove `travis` build url in readme

### DIFF
--- a/.changeset/hot-tomatoes-poke.md
+++ b/.changeset/hot-tomatoes-poke.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-primero': patch
+---
+
+remove travis url in readme

--- a/.changeset/wet-swans-speak.md
+++ b/.changeset/wet-swans-speak.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-template': patch
+---
+
+remove travis build url

--- a/packages/_template/README.md
+++ b/packages/_template/README.md
@@ -1,4 +1,4 @@
-# language-template [<img src="https://avatars2.githubusercontent.com/u/9555108?s=200&v=4)" alt="alt text" height="20">](https://www.openfn.org) [![Build Status](https://travis-ci.org/OpenFn/language-template.svg?branch=master)](https://travis-ci.org/OpenFn/language-template)
+# language-template [<img src="https://avatars2.githubusercontent.com/u/9555108?s=200&v=4)" alt="alt text" height="20">](https://www.openfn.org)
 
 An OpenFn **_adaptor_** for building integration jobs for use with the \_\_\_\_
 API.

--- a/packages/primero/README.md
+++ b/packages/primero/README.md
@@ -1,6 +1,6 @@
 <img src="https://user-images.strikinglycdn.com/res/hrscywv4p/image/upload/c_limit,fl_lossy,h_9000,w_1200,f_auto,q_auto/195711/_IMS-logos_all_TM-02_vagcfc.png" height="100">
 
-# language-primero [<img src="https://avatars2.githubusercontent.com/u/9555108?s=200&v=4)" alt="alt text" height="20">](https://www.openfn.org) [![Build Status](https://travis-ci.org/OpenFn/language-primero.svg?branch=master)](https://travis-ci.org/OpenFn/language-primero)
+# language-primero [<img src="https://avatars2.githubusercontent.com/u/9555108?s=200&v=4)" alt="alt text" height="20">](https://www.openfn.org)
 
 An OpenFn **_adaptor_** for building integration jobs for use with UNICEF's
 Primero API.


### PR DESCRIPTION
### Description 
Remove `travis` build status url in readme for `_template` and `primero`