### PR TITLE
Fix module exports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           cache: 'pnpm'
       - name: Setup pnpm
         run: pnpm install --frozen-lockfile
-      - name: Unit Tests
-        run: pnpm run test
       - name: Build
         run: pnpm run build
+      - name: Unit Tests
+        run: pnpm run test

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,7 +2,6 @@
   "name": "@openfn/language-common",
   "version": "1.7.3",
   "description": "Common Expressions for OpenFn",
-  "main": "dist/index.cjs",
   "homepage": "https://docs.openfn.org",
   "repository": {
     "type": "git",

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';


### PR DESCRIPTION
So we have a problem in how exports are defined in `index.js`, and this is breaking ESM style imports.

This fixes the second part of #88, but not the first.

The problem is that the index.js was exporting a default object and a named export called Adaptor. When you try and do `import { fn } from 'common'` the import fails because it us looking for a name export called `fn` (which doesn't exist), rather than deconstructing the default export.

if you look at the built ESM file in dist, the export structure is a mess. I've been aware of this for a long time, and it's bugged me, but only this afternoon have I managed to understand what's actually happening.

I also agree that we should remove the `main` key  from package json and instead use conditional `exports` to support CJS and ESM - that seems to be the more modern solution.

Using this structure, both of these imports work (although obviously not at the same time)

```
import { fn } from '@openfn/language-common';

import common from '@openfn/language-common';
const { fn } = common;
```

## Still To do

If we're happy with this pattern then we need to go through an apply it to all the existing packages and the migration utility. I suggest we do this in a different PR - I can raise it tomorrow, it won't take long.