### PR TITLE
Update package exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Then, from inside your new `packages/<name>`:
 - Commit your changes `git commit -am "cloned <name> into monorepo"`
 - Delete `package-lock.json`
 - Remove `bundledDependencies` from package.json
+- Fix index.js (see `index.js` below)
 - Run `pnpm install`
 - Remove the `docs` and `lib` dirs
 - Remove `.prettierrc`
@@ -159,6 +160,23 @@ Then, from inside your new `packages/<name>`:
   version bump for the package).
 - Commit your changes, including the changeset, and open a pull request against
   `main`.
+
+### index.js
+
+The index.js file should be exactly this:
+
+```
+import * as Adaptor from './Adaptor';
+export default Adaptor;
+
+export * from './Adaptor';
+```
+
+The first two lines export the Adaptor object as the default export from the
+module, so you can do `import common from '@openfn/common'`
+
+The second line exports every export of Adaptor from the main index, so you can
+do `import { fn } from '@openfn/common'`.
 
 ### Readme
 
@@ -182,35 +200,9 @@ In addition, you may need to replace any references to `npm` with `pnpm`
 
 ### Tests
 
-You'll need to update tests and get them passing. There are a few things to be
-aware of here.
-
-**Import paths**
+You'll need to update tests and get them passing.
 
 Instead of importing test files from `lib`, import directly from `src`.
 
 Ie, replace `import Adaptor from '../lib/Adaptor'` becomes
 `import Adaptor from '../src/Adaptor'`
-
-**Importing CJS modules**
-
-Packages in this repo should assume native support for esm modules (ie, `import`
-instead of `require`).
-
-Although adaptors use EJS syntax, many used to transpile through babel into CJS
-format.
-
-You will probably find that `chai` and `lodash` throw exceptions when you try
-and run the tests. To fix this, read closely the error message that is returned.
-You probably need to change the import from:
-
-```
-import { isEmpty } from 'lodash/fp';
-```
-
-to:
-
-```
-import _ from 'lodash/fp';
-const { isEmpty } = _;
-```

--- a/packages/_template/package.json
+++ b/packages/_template/package.json
@@ -3,7 +3,10 @@
   "version": "1.7.2",
   "description": "An adaptor template for OpenFn",
   "type": "module",
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "scripts": {
     "build": "pnpm clean && build-adaptor _template",
     "test": "mocha --experimental-specifier-resolution=node --no-warnings",

--- a/packages/_template/src/index.js
+++ b/packages/_template/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/_template/test/index.js
+++ b/packages/_template/test/index.js
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
 import nock from 'nock';
-import * as Adaptor from '../src/Adaptor.js';
-
-const { execute, create, dataValue } = Adaptor;
+import { execute, create, dataValue } from '../src/Adaptor.js';
 
 describe('execute', () => {
   it('executes each operation in sequence', done => {

--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -7,7 +7,10 @@
     "type": "git",
     "url": "https://github.com/openfn/adaptors.git"
   },
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "scripts": {
     "build": "pnpm clean && build-adaptor asana",
     "test": "mocha --experimental-specifier-resolution=node --no-warnings",

--- a/packages/asana/src/index.js
+++ b/packages/asana/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/asana/test/index.js
+++ b/packages/asana/test/index.js
@@ -1,8 +1,6 @@
-import chai from 'chai';
+import { expect } from 'chai';
 
-import Adaptor from '../src';
-const { execute } = Adaptor;
-const { expect } = chai;
+import { execute } from '../src';
 
 describe('execute', () => {
   it('executes each operation in sequence', done => {

--- a/packages/beyonic/package.json
+++ b/packages/beyonic/package.json
@@ -7,7 +7,10 @@
     "type": "git",
     "url": "https://github.com/openfn/adaptors.git"
   },
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "scripts": {
     "build": "pnpm clean && build-adaptor beyonic",
     "test": "mocha --experimental-specifier-resolution=node --no-warnings",

--- a/packages/beyonic/src/index.js
+++ b/packages/beyonic/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -3,13 +3,9 @@ const { curry, fromPairs } = _;
 
 import { JSONPath } from 'jsonpath-plus';
 
-import * as beta from './beta';
-import * as http from './http';
-import * as dateFns from './dateFns';
-
-export { beta };
-export { http };
-export { dateFns };
+export * as beta from './beta';
+export * as http from './http';
+export * as dateFns from './dateFns';
 
 /**
  * Execute a sequence of operations.

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -7,7 +7,10 @@
     "type": "git",
     "url": "https://github.com/openfn/adaptors.git"
   },
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "types": "types/index.d.ts",
   "scripts": {
     "build": "pnpm clean && build-adaptor dhis2",

--- a/packages/dhis2/src/index.js
+++ b/packages/dhis2/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -7,7 +7,10 @@
     "type": "git",
     "url": "https://github.com/openfn/adaptors.git"
   },
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "scripts": {
     "build": "pnpm clean && build-adaptor googlesheets",
     "test": "mocha --experimental-specifier-resolution=node --no-warnings",

--- a/packages/googlesheets/src/index.js
+++ b/packages/googlesheets/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/googlesheets/test/index.js
+++ b/packages/googlesheets/test/index.js
@@ -1,10 +1,6 @@
 import { expect } from 'chai';
 
-import nock from 'nock';
-import ClientFixtures, { fixtures } from './ClientFixtures';
-
-import Adaptor from '../src';
-const { execute, event, dataElement, get } = Adaptor;
+import { execute } from '../src';
 
 describe('execute', () => {
   it('executes each operation in sequence', (done) => {
@@ -31,8 +27,6 @@ describe('execute', () => {
 
   it('assigns references, data to the initialState', () => {
     let state = {};
-
-    let finalState = execute()(state);
 
     execute()(state).then((finalState) => {
       expect(finalState).to.eql({

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -7,7 +7,10 @@
     "type": "git",
     "url": "https://github.com/openfn/adaptors.git"
   },
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "type": "module",
   "types": "types/index.d.ts",
   "scripts": {

--- a/packages/http/src/index.js
+++ b/packages/http/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -1,10 +1,8 @@
-import * as Adaptor from '../src/Adaptor';
+import { execute, get, post, put, patch, del, alterState, request } from '../src';
 import { each } from '@openfn/language-common';
 import { expect } from 'chai';
 import nock from 'nock';
 import { setUrl } from '../src/Utils';
-
-const { execute, get, post, put, patch, del, alterState, request } = Adaptor;
 
 function stdGet(state) {
   return execute(get('https://www.example.com/api/fake', {}))(state).then(

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -2,7 +2,10 @@
   "name": "@openfn/language-mssql",
   "version": "3.1.0",
   "description": "A Microsoft SQL language pack for OpenFn",
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "homepage": "https://docs.openfn.org",
   "repository": {
     "type": "git",

--- a/packages/mssql/src/index.js
+++ b/packages/mssql/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/mssql/test/index.js
+++ b/packages/mssql/test/index.js
@@ -1,8 +1,5 @@
-import pkg from 'chai';
-const { expect } = pkg;
-
-import Adaptor from '../src';
-const { execute, event } = Adaptor;
+import { expect } from 'chai';
+import { execute, } from '../src';
 
 describe('execute', () => {
   // Mock this endpoint...
@@ -38,8 +35,6 @@ describe('execute', () => {
         server: 'testurl',
       },
     };
-
-    let finalState = execute()(state);
 
     execute()(state).then(finalState => {
       expect(finalState).to.eql({

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -3,7 +3,10 @@
   "version": "3.4.0",
   "description": "A PostgreSQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/openfn/adaptors.git"

--- a/packages/postgresql/src/index.js
+++ b/packages/postgresql/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/postgresql/test/index.js
+++ b/packages/postgresql/test/index.js
@@ -1,13 +1,9 @@
-import chai from 'chai';
-
-const { expect } = chai;
+import { expect } from 'chai';
 
 import nock from 'nock';
-import ClientFixtures from './ClientFixtures';
-const { fixtures } = ClientFixtures;
+import { fixtures } from './ClientFixtures';
 
-import Adaptor from '../src';
-const { execute, event, dataElement, get } = Adaptor;
+import { execute, event, dataElement, get } from '../src';
 
 describe.skip('execute', () => {
   // TODO: determine how to get travis to test against a local DB.

--- a/packages/postgresql/test/index.js
+++ b/packages/postgresql/test/index.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import nock from 'nock';
 import { fixtures } from './ClientFixtures';
 
-import { execute, event, dataElement, get } from '../src';
+import { execute/*, get*/ } from '../src';
 
 describe.skip('execute', () => {
   // TODO: determine how to get travis to test against a local DB.

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -2,7 +2,10 @@
   "name": "@openfn/language-primero",
   "version": "2.10.0",
   "description": "A UNICEF Primero language package for use with Open Function",
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "homepage": "https://docs.openfn.org",
   "repository": {
     "type": "git",

--- a/packages/primero/src/index.js
+++ b/packages/primero/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -3,7 +3,10 @@
   "version": "2.11.0",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
-  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "scripts": {
     "build": "pnpm clean && build-adaptor salesforce",
     "test": "mocha --experimental-specifier-resolution=node --no-warnings",

--- a/packages/salesforce/src/index.js
+++ b/packages/salesforce/src/index.js
@@ -1,5 +1,7 @@
 import * as Adaptor from './Adaptor';
-import * as FakeAdaptor from './FakeAdaptor';
-
 export default Adaptor;
-export { FakeAdaptor, Adaptor };
+
+import * as FakeAdaptor from './FakeAdaptor';
+export { FakeAdaptor };
+
+export * from './Adaptor';

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -7,7 +7,10 @@
     "type": "git",
     "url": "https://github.com/openfn/adaptors.git"
   },
-  "main": "dist/index.js",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "scripts": {
     "build": "pnpm clean && build-adaptor sftp",
     "test": "mocha --experimental-specifier-resolution=node --no-warnings",

--- a/packages/sftp/src/index.js
+++ b/packages/sftp/src/index.js
@@ -1,3 +1,4 @@
 import * as Adaptor from './Adaptor';
-export { Adaptor };
 export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/sftp/test/index.js
+++ b/packages/sftp/test/index.js
@@ -1,12 +1,6 @@
-import pkg from 'chai';
-const { expect } = pkg;
+import { expect } from 'chai';
 
-import nock from 'nock';
-
-import Adaptor from '../src';
-const { execute } = Adaptor;
-
-import { getJSON } from '../src/Adaptor';
+import { execute } from '../src';
 
 describe('The execute() function', () => {
   it('executes each operation in sequence', done => {

--- a/tools/migrate/src/update-package.ts
+++ b/tools/migrate/src/update-package.ts
@@ -35,7 +35,10 @@ export const updatePackage = (pkg: Record<string, any>, lang: string) => {
   };
 
   updated.type = 'module';
-  updated.main = 'dist/index.cjs';
+  updated.exports = {
+    import: './dist/index.js',
+    require: './dist/index.cjs',
+  };
   updated.types = 'types/index.d.ts';
 
   updated.files = ['dist/', 'types/', 'ast.json', 'configuration-schema.json'];


### PR DESCRIPTION
We've learned from #95 that the way adaptors are exporting is incorrect and doesn't work properly in ESM format.

This PR fixes the main exports for each adaptor, along with a few tweaks to test imports and some changes to the migration guide.

It also removes the `main` field in all package.jsons in favour of an `exports` field, which supports cjs and esm formats. This is now reflected in the migration utility.

It's targeted at the common branch for now because it includes the common adaptor.

I would merge and squash this down into `83_migrate_common`.