### PR TITLE
Update Dependencies

### DIFF
--- a/.changeset/fast-coins-jump.md
+++ b/.changeset/fast-coins-jump.md
@@ -1,0 +1,7 @@
+---
+'@openfn/language-dhis2': patch
+'@openfn/language-googlesheets': patch
+'@openfn/language-http': patch
+---
+
+Update dependency on language-common

--- a/.changeset/sharp-walls-sip.md
+++ b/.changeset/sharp-walls-sip.md
@@ -1,0 +1,21 @@
+---
+'@openfn/language-asana': patch
+'@openfn/language-common': patch
+'@openfn/language-dhis2': patch
+'@openfn/language-googlesheets': patch
+'@openfn/language-http': patch
+'@openfn/buildtools': patch
+'@openfn/language-beyonic': patch
+'@openfn/language-commcare': patch
+'@openfn/language-fhir': patch
+'@openfn/language-kobotoolbox': patch
+'@openfn/language-mssql': patch
+'@openfn/language-ocl': patch
+'@openfn/language-postgresql': patch
+'@openfn/language-primero': patch
+'@openfn/language-salesforce': patch
+'@openfn/language-sftp': patch
+'@openfn/language-template': patch
+---
+
+Fix typings

--- a/packages/dhis2/ast.json
+++ b/packages/dhis2/ast.json
@@ -947,6 +947,14 @@
               "name": "Function"
             },
             "name": "func"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -982,6 +990,14 @@
               "name": "String"
             },
             "name": "path"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -1060,6 +1076,14 @@
               "name": "String"
             },
             "name": "path"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -1095,6 +1119,14 @@
               "name": "String"
             },
             "name": "path"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -1140,6 +1172,14 @@
               "name": "Operation"
             },
             "name": "operation"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -1185,6 +1225,14 @@
               "name": "Value"
             },
             "name": "value"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Field"
+            }
           }
         ]
       },

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -30,12 +30,13 @@
   ],
   "dependencies": {
     "@openfn/buildtools": "workspace:^1.0.1",
-    "@openfn/language-common": "1.6.2",
+    "@openfn/language-common": "workspace:^1.7.3",
     "axios": "^0.24.0",
     "lodash": "^4.17.19",
     "qs": "^6.10.3"
   },
   "devDependencies": {
+    "@openfn/buildtools": "workspace:^1.0.1",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",
@@ -44,8 +45,7 @@
     "esno": "^0.16.3",
     "mocha": "7.2.0",
     "nock": "13.2.9",
-    "rimraf": "3.0.2",
-    "@openfn/buildtools": "workspace:^1.0.1"
+    "rimraf": "3.0.2"
   },
   "type": "module",
   "main": "dist/index.cjs"

--- a/packages/googlesheets/ast.json
+++ b/packages/googlesheets/ast.json
@@ -77,6 +77,14 @@
               "name": "Function"
             },
             "name": "func"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -112,6 +120,14 @@
               "name": "String"
             },
             "name": "path"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -190,6 +206,14 @@
               "name": "String"
             },
             "name": "path"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -225,6 +249,14 @@
               "name": "String"
             },
             "name": "path"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -270,6 +302,14 @@
               "name": "Operation"
             },
             "name": "operation"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -358,6 +398,14 @@
               "name": "Value"
             },
             "name": "value"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Field"
+            }
           }
         ]
       },

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -27,7 +27,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.7.1",
+    "@openfn/language-common": "workspace:^1.7.3",
     "googleapis": "100.0.0"
   },
   "devDependencies": {

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -461,6 +461,14 @@
               "name": "Function"
             },
             "name": "func"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -496,6 +504,14 @@
               "name": "String"
             },
             "name": "path"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -574,6 +590,14 @@
               "name": "String"
             },
             "name": "path"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -609,6 +633,14 @@
               "name": "String"
             },
             "name": "path"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -654,6 +686,14 @@
               "name": "Operation"
             },
             "name": "operation"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
           }
         ]
       },
@@ -742,6 +782,14 @@
               "name": "Value"
             },
             "name": "value"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Field"
+            }
           }
         ]
       },

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -29,8 +29,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:^1",
-    "axios": "1.1.3",
+    "@openfn/language-common": "workspace:1.7.3",
     "cheerio": "^1.0.0-rc.10",
     "cheerio-tableparser": "^1.0.1",
     "csv-parse": "^4.10.1",
@@ -38,18 +37,17 @@
     "form-data": "^3.0.0",
     "lodash": "^4.17.19",
     "request": "^2.88.2",
-    "rimraf": "^3.0.2",
     "tough-cookie": "^4.0.0"
   },
   "devDependencies": {
     "@openfn/buildtools": "workspace:^1.0.1",
     "@openfn/simple-ast": "0.4.1",
-    "@types/node": "18.11.7",
     "chai": "4.3.6",
     "deep-eql": "4.1.1",
     "esno": "^0.16.3",
     "mocha": "9.2.2",
-    "nock": "13.2.9"
+    "nock": "13.2.9",
+    "rimraf": "^3.0.2"
   },
   "main": "dist/index.cjs"
 }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -29,13 +29,13 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.7.1",
+    "@openfn/language-common": "workspace:^1",
+    "axios": "1.1.3",
     "cheerio": "^1.0.0-rc.10",
     "cheerio-tableparser": "^1.0.1",
     "csv-parse": "^4.10.1",
     "fast-safe-stringify": "^2.0.7",
     "form-data": "^3.0.0",
-    "import": "0.0.6",
     "lodash": "^4.17.19",
     "request": "^2.88.2",
     "rimraf": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,9 +222,10 @@ importers:
   packages/http:
     specifiers:
       '@openfn/buildtools': workspace:^1.0.1
-      '@openfn/language-common': 1.7.1
+      '@openfn/language-common': workspace:^1
       '@openfn/simple-ast': 0.4.1
       '@types/node': 18.11.7
+      axios: 1.1.3
       chai: 4.3.6
       cheerio: ^1.0.0-rc.10
       cheerio-tableparser: ^1.0.1
@@ -233,7 +234,6 @@ importers:
       esno: ^0.16.3
       fast-safe-stringify: ^2.0.7
       form-data: ^3.0.0
-      import: 0.0.6
       lodash: ^4.17.19
       mocha: 9.2.2
       nock: 13.2.9
@@ -241,13 +241,13 @@ importers:
       rimraf: ^3.0.2
       tough-cookie: ^4.0.0
     dependencies:
-      '@openfn/language-common': 1.7.1
+      '@openfn/language-common': link:../common
+      axios: 1.1.3
       cheerio: 1.0.0-rc.12
       cheerio-tableparser: 1.0.1
       csv-parse: 4.16.3
       fast-safe-stringify: 2.1.1
       form-data: 3.0.1
-      import: 0.0.6
       lodash: 4.17.21
       request: 2.88.2
       rimraf: 3.0.2
@@ -3779,14 +3779,6 @@ packages:
       resolve-from: 4.0.0
     dev: true
 
-  /import/0.0.6:
-    resolution: {integrity: sha512-QPhTdjy9J4wUzmWSG7APkSgMFuPGPw+iJTYUblcfc2AfpqaatbwgCldK1HoLYx+v/+lWvab63GWZtNkcnj9JcQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dependencies:
-      optimist: 0.3.7
-    dev: false
-
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -5010,12 +5002,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       is-wsl: 1.1.0
-    dev: false
-
-  /optimist/0.3.7:
-    resolution: {integrity: sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==}
-    dependencies:
-      wordwrap: 0.0.3
     dev: false
 
   /optionator/0.9.1:
@@ -6643,11 +6629,6 @@ packages:
   /word/0.3.0:
     resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
     engines: {node: '>=0.8'}
-    dev: false
-
-  /wordwrap/0.0.3:
-    resolution: {integrity: sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==}
-    engines: {node: '>=0.4.0'}
     dev: false
 
   /wordwrap/1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,10 +222,8 @@ importers:
   packages/http:
     specifiers:
       '@openfn/buildtools': workspace:^1.0.1
-      '@openfn/language-common': workspace:^1
+      '@openfn/language-common': workspace:1.7.3
       '@openfn/simple-ast': 0.4.1
-      '@types/node': 18.11.7
-      axios: 1.1.3
       chai: 4.3.6
       cheerio: ^1.0.0-rc.10
       cheerio-tableparser: ^1.0.1
@@ -242,7 +240,6 @@ importers:
       tough-cookie: ^4.0.0
     dependencies:
       '@openfn/language-common': link:../common
-      axios: 1.1.3
       cheerio: 1.0.0-rc.12
       cheerio-tableparser: 1.0.1
       csv-parse: 4.16.3
@@ -250,17 +247,16 @@ importers:
       form-data: 3.0.1
       lodash: 4.17.21
       request: 2.88.2
-      rimraf: 3.0.2
       tough-cookie: 4.1.2
     devDependencies:
       '@openfn/buildtools': link:../../tools/build
       '@openfn/simple-ast': 0.4.1
-      '@types/node': 18.11.7
       chai: 4.3.6
       deep-eql: 4.1.1
       esno: 0.16.3
       mocha: 9.2.2
       nock: 13.2.9
+      rimraf: 3.0.2
 
   packages/kobotoolbox:
     specifiers:
@@ -5605,6 +5601,7 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.0
+    dev: true
 
   /rollup/2.79.1:
     resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
   packages/dhis2:
     specifiers:
       '@openfn/buildtools': workspace:^1.0.1
-      '@openfn/language-common': 1.6.2
+      '@openfn/language-common': workspace:^1.7.3
       '@openfn/simple-ast': 0.4.1
       assertion-error: 2.0.0
       axios: ^0.24.0
@@ -150,7 +150,7 @@ importers:
       rimraf: 3.0.2
     dependencies:
       '@openfn/buildtools': link:../../tools/build
-      '@openfn/language-common': 1.6.2
+      '@openfn/language-common': link:../common
       axios: 0.24.0
       lodash: 4.17.21
       qs: 6.11.0
@@ -195,7 +195,7 @@ importers:
   packages/googlesheets:
     specifiers:
       '@openfn/buildtools': workspace:^1.0.1
-      '@openfn/language-common': 1.7.1
+      '@openfn/language-common': workspace:^1.7.3
       '@openfn/simple-ast': 0.4.1
       assertion-error: 1.1.0
       chai: 4.3.6
@@ -206,7 +206,7 @@ importers:
       nock: 13.2.9
       rimraf: 3.0.2
     dependencies:
-      '@openfn/language-common': 1.7.1
+      '@openfn/language-common': link:../common
       googleapis: 100.0.0
     devDependencies:
       '@openfn/buildtools': link:../../tools/build


### PR DESCRIPTION
This PR updates a few dependency versions across the adaptors, fixing #119

This is the reason why docs are changing when we run changeset version. The changes themselves are fine, they just need checking in.

I've also noticed a couple of eccentricities in `http`'s dependencies and fixed those.

At the time of writing, the dts build on http is broken.