### PR TITLE
Fail build if docs build fails (and finally fix kobotoolbox)

### DIFF
--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -24,7 +24,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:^1.7.4"
+    "@openfn/language-common": "1.7.5"
   },
   "devDependencies": {
     "@openfn/buildtools": "workspace:^1.0.2",

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -34,7 +34,8 @@
     "esno": "^0.16.3",
     "mocha": "^7.1.1",
     "nock": "^12.0.3",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "@openfn/simple-ast": "0.4.1"
   },
   "type": "module",
   "types": "types/index.d.ts",

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -24,7 +24,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.7.5"
+    "@openfn/language-common": "workspace:^1.7.4"
   },
   "devDependencies": {
     "@openfn/buildtools": "workspace:^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,7 @@ importers:
     specifiers:
       '@openfn/buildtools': workspace:^1.0.2
       '@openfn/language-common': workspace:^1.7.4
+      '@openfn/simple-ast': 0.4.1
       assertion-error: ^1.0.1
       chai: ^3.4.0
       deep-eql: ^0.1.3
@@ -273,6 +274,7 @@ importers:
       '@openfn/language-common': link:../common
     devDependencies:
       '@openfn/buildtools': link:../../tools/build
+      '@openfn/simple-ast': 0.4.1
       assertion-error: 1.1.0
       chai: 3.5.0
       deep-eql: 0.1.3

--- a/tools/build/src/commands/ast.ts
+++ b/tools/build/src/commands/ast.ts
@@ -7,7 +7,7 @@ export default (lang: string) => {
   console.log(`Building AST`);
   console.log();
 
-  return new Promise<void>(resolve => {
+  return new Promise<void>((resolve, reject) => {
     const dest = `${root}/ast.json`;
 
     // TODO adaptor.js is a problem
@@ -15,11 +15,12 @@ export default (lang: string) => {
     // and enable it to parse from index
     const cmd = `pnpm exec simple-ast  --adaptor ${root}/src/Adaptor.js --output ${dest}`;
     exec(cmd, (err, stdout, stderr) => {
+      if (err) {
+        console.error(err);
+        return reject();
+      }
       if (stdout) {
         console.log(stdout);
-      }
-      if (stderr) {
-        console.error(stderr);
       }
       console.log('... done!', dest);
       resolve();

--- a/tools/build/src/commands/ast.ts
+++ b/tools/build/src/commands/ast.ts
@@ -16,6 +16,7 @@ export default (lang: string) => {
     const cmd = `pnpm exec simple-ast  --adaptor ${root}/src/Adaptor.js --output ${dest}`;
     exec(cmd, (err, stdout, stderr) => {
       if (err) {
+        console.error('AST build failed!', dest);
         console.error(err);
         return reject();
       }

--- a/tools/build/src/commands/dts.ts
+++ b/tools/build/src/commands/dts.ts
@@ -27,7 +27,8 @@ export default (lang: string) => {
         cwd,
       },
       (err, stdout) => {
-        console.log(stdout);
+        // Hide error reports (for now)
+        // console.log(stdout);
         resolve();
       }
     );

--- a/tools/migrate/src/update-package.ts
+++ b/tools/migrate/src/update-package.ts
@@ -77,6 +77,7 @@ export const updatePackage = (pkg: Record<string, any>, lang: string) => {
   _.defaults(updated.devDependencies, {
     esno: '^0.16.3',
     '@openfn/buildtools': 'workspace:^1.0.1',
+    '@openfn/simple-ast': '0.4.1',
   });
 
   updated.scripts.clean = 'rimraf dist types docs';


### PR DESCRIPTION
This PR fixes two issues

1) kobotoolbox is failing to build docs because it doesn't declare a devDependency on simple-ast
2) The docs build will succeed in CI even if the actual build fails and errors are thrown #131

To prove that 2) is fixed, take a look at [this CI run](https://github.com/OpenFn/adaptors/actions/runs/3427846423/jobs/5711343050) for [4467ac6](https://github.com/OpenFn/adaptors/pull/132/commits/4467ac646588f353ecb4e535bfc89d29721be762). You'll see that the build has failed because of an error in kobotoolbox.

The fixes are:
1) Reject the docs promise if there's an error
2) Update the migration util to ensure simple-ast is declared as a dev dependency
3) Update the kobotoolbox dependencies
4) Suppress confusing output of the DTS build step (I'll probably regret this one day but it's fine for now - the real fix is in #121)

The latest commit should pass.