### PR TITLE
Trigger deploy on `openFn/docs`

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: "Build docs to docs branch"
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
 
     strategy:
       matrix:
@@ -35,3 +37,10 @@ jobs:
       - name: Build docs to docs branch
 
         run: pnpm exec .github/workflows/docs.sh
+      - name: Trigger deploy on openFn/docs
+        run: |
+          sleep 10s && curl -X POST \
+          -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/openFn/docs/actions/workflows/deploy.yml/dispatches \
+          -d '{"ref": "main"}'


### PR DESCRIPTION
## Summary

Add a dispatch that will trigger deploy on `openFn/docs`

## Details

Added a `write` permission since it's needed to perform a `POST` request to `openFn/docs` that will trigger the deploy workflow

