### PR TITLE
`Nov 25` adaptors releases

### DIFF
--- a/.changeset/bright-jeans-speak.md
+++ b/.changeset/bright-jeans-speak.md
@@ -1,5 +1,0 @@
----
-'language-facebook': minor
----
-
-migrate facebook

--- a/.changeset/bright-pigs-call.md
+++ b/.changeset/bright-pigs-call.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-openfn': minor
----
-
-Migrate OpenFn

--- a/.changeset/brown-geckos-speak.md
+++ b/.changeset/brown-geckos-speak.md
@@ -1,5 +1,0 @@
----
-'language-vtiger': minor
----
-
-migrate vtiger

--- a/.changeset/clean-toes-sit.md
+++ b/.changeset/clean-toes-sit.md
@@ -1,5 +1,0 @@
----
-'language-godata': minor
----
-
-Migrate Godata

--- a/.changeset/cyan-timers-float.md
+++ b/.changeset/cyan-timers-float.md
@@ -1,5 +1,0 @@
----
-'language-magpi': minor
----
-
-migrate magpi

--- a/.changeset/eleven-ads-taste.md
+++ b/.changeset/eleven-ads-taste.md
@@ -1,8 +1,0 @@
----
-'@openfn/language-cartodb': patch
-'@openfn/language-openhim': patch
-'@openfn/language-telerivet': patch
-'language-zoho': patch
----
-
-Fix Large gzip Denial of Service in superagent

--- a/.changeset/few-crews-try.md
+++ b/.changeset/few-crews-try.md
@@ -1,5 +1,0 @@
----
-'language-magpi': major
----
-
-Update xml2js parser

--- a/.changeset/fresh-eyes-wash.md
+++ b/.changeset/fresh-eyes-wash.md
@@ -1,5 +1,0 @@
----
-'language-zoho': minor
----
-
-migrate zoho

--- a/.changeset/heavy-emus-breathe.md
+++ b/.changeset/heavy-emus-breathe.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-openmrs': minor
----
-
-Migrate OpenMRS

--- a/.changeset/khaki-goats-retire.md
+++ b/.changeset/khaki-goats-retire.md
@@ -1,5 +1,0 @@
----
-'language-smpp': minor
----
-
-migrate smpp

--- a/.changeset/loud-fans-train.md
+++ b/.changeset/loud-fans-train.md
@@ -1,5 +1,0 @@
----
-'language-khanacademy': minor
----
-
-migrate khanacademy

--- a/.changeset/mean-chairs-wink.md
+++ b/.changeset/mean-chairs-wink.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-mailgun': minor
----
-
-Migrate Mailgun

--- a/.changeset/metal-berries-shop.md
+++ b/.changeset/metal-berries-shop.md
@@ -1,5 +1,0 @@
----
-'language-dynamics': minor
----
-
-Migrate Dynamics

--- a/.changeset/moody-grapes-peel.md
+++ b/.changeset/moody-grapes-peel.md
@@ -1,7 +1,0 @@
----
-'@openfn/language-godata': patch
-'@openfn/language-mailchimp': patch
-'@openfn/language-rapidpro': patch
----
-
-Fix axios Inefficient Regular Expression Complexity vulnerability

--- a/.changeset/ninety-years-lick.md
+++ b/.changeset/ninety-years-lick.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-mysql': minor
----
-
-Migrate MySQL

--- a/.changeset/popular-pandas-bake.md
+++ b/.changeset/popular-pandas-bake.md
@@ -1,5 +1,0 @@
----
-'language-maximo': minor
----
-
-migrate maximo

--- a/.changeset/proud-shrimps-lie.md
+++ b/.changeset/proud-shrimps-lie.md
@@ -1,5 +1,0 @@
----
-'language-cartodb': minor
----
-
-Migrate CartoDB

--- a/.changeset/selfish-insects-return.md
+++ b/.changeset/selfish-insects-return.md
@@ -1,5 +1,0 @@
----
-'language-resourcemap': minor
----
-
-migrate resourcemap

--- a/.changeset/strange-bears-visit.md
+++ b/.changeset/strange-bears-visit.md
@@ -1,5 +1,0 @@
----
-'language-nexmo': minor
----
-
-migrate nexmo

--- a/.changeset/swift-moles-knock.md
+++ b/.changeset/swift-moles-knock.md
@@ -1,5 +1,0 @@
----
-'language-openhim': minor
----
-
-Migrate OpenHIM

--- a/.changeset/thirty-forks-end.md
+++ b/.changeset/thirty-forks-end.md
@@ -1,8 +1,0 @@
----
-'@openfn/language-dynamics': patch
-'@openfn/language-godata': patch
-'@openfn/language-mailchimp': patch
-'@openfn/language-openhim': patch
----
-
-Updated ast and package.json

--- a/.changeset/tough-spiders-remember.md
+++ b/.changeset/tough-spiders-remember.md
@@ -1,5 +1,0 @@
----
-'language-mogli': minor
----
-
-migrate mogli

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @openfn/language-cartodb
+
+## 0.1.0
+
+### Minor Changes
+
+- 792d495: Migrate CartoDB
+
+### Patch Changes
+
+- e4ebcb6: Fix Large gzip Denial of Service in superagent

--- a/packages/cartodb/package.json
+++ b/packages/cartodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-cartodb",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "cartodb Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @openfn/language-dynamics
+
+## 0.3.0
+
+### Minor Changes
+
+- b032b9c: Migrate Dynamics
+
+### Patch Changes
+
+- e81561f: Updated ast and package.json

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dynamics",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A Microsoft Dynamics Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-facebook
+
+## 0.2.0
+
+### Minor Changes
+
+- f7669d2: migrate facebook

--- a/packages/facebook/package.json
+++ b/packages/facebook/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-facebook",
-  "version": "0.1.0",
+  "name": "@openfn/language-facebook",
+  "version": "0.2.0",
   "description": "An Language Package for Facebook Messenger API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/godata/CHANGELOG.md
+++ b/packages/godata/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @openfn/language-godata
+
+## 3.2.0
+
+### Minor Changes
+
+- 8e7a79e: Migrate Godata
+
+### Patch Changes
+
+- cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
+- e81561f: Updated ast and package.json

--- a/packages/godata/package.json
+++ b/packages/godata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-godata",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "An OpenFn adaptor for use with the WHO's GoData API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-khanacademy
+
+## 0.3.0
+
+### Minor Changes
+
+- 9137655: migrate khanacademy

--- a/packages/khanacademy/package.json
+++ b/packages/khanacademy/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-khanacademy",
-  "version": "0.2.0",
+  "name": "@openfn/language-khanacademy",
+  "version": "0.3.0",
   "description": "A Khan Academy Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/magpi/CHANGELOG.md
+++ b/packages/magpi/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @openfn/language-magpi
+
+## 1.0.0
+
+### Major Changes
+
+- e6c2b4a: Update xml2js parser
+
+### Minor Changes
+
+- df5dd2e: migrate magpi

--- a/packages/magpi/package.json
+++ b/packages/magpi/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-magpi",
-  "version": "0.3.2",
+  "name": "@openfn/language-magpi",
+  "version": "1.0.0",
   "description": "A Magpi Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailchimp
 
+## 0.3.1
+
+### Patch Changes
+
+- cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
+- e81561f: Updated ast and package.json
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mailchimp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An OpenFn adaptor for use with Mailchimp",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-mailgun
+
+## 0.3.0
+
+### Minor Changes
+
+- 9ded25e: Migrate Mailgun

--- a/packages/mailgun/package.json
+++ b/packages/mailgun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mailgun",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "mailgun Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-maximo
+
+## 0.3.0
+
+### Minor Changes
+
+- 4d4be56: migrate maximo

--- a/packages/maximo/package.json
+++ b/packages/maximo/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-maximo",
-  "version": "0.2.0",
+  "name": "@openfn/language-maximo",
+  "version": "0.3.0",
   "description": "An IBM Maximo EAM Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -1,15 +1,19 @@
 v0.1.6
-======
 
-* State gets cleaned up after the operations are finished.
-  This means that the final state is serializable.
+## 0.3.0
+
+### Minor Changes
+
+- # c6056e8: migrate mogli
+
+* State gets cleaned up after the operations are finished. This means that the
+  final state is serializable.
 
   The JSForce connection object is provided by `createConnection`, and in turn
   `execute` ensures it is run before the user's operations.
 
   The `cleanupState` reducer simply deletes the connection key from state.
 
-v0.1.3
-======
+# v0.1.3
 
-* Bumped language-common dependency to v0.0.4.
+- Bumped language-common dependency to v0.0.4.

--- a/packages/mogli/package.json
+++ b/packages/mogli/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-mogli",
-  "version": "0.2.1",
+  "name": "@openfn/language-mogli",
+  "version": "0.3.0",
   "description": "A Mogli SMS Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-mysql
+
+## 1.3.0
+
+### Minor Changes
+
+- 9d674c5: Migrate MySQL

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mysql",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A MySQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "main": "dist/index.cjs",

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-nexmo
+
+## 0.2.0
+
+### Minor Changes
+
+- f0f2495: migrate nexmo

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-nexmo",
-  "version": "0.1.1",
+  "name": "@openfn/language-nexmo",
+  "version": "0.2.0",
   "description": "An Language Package for Nexmo",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-openfn
+
+## 1.2.0
+
+### Minor Changes
+
+- be9d3c6: Migrate OpenFn

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openfn",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "An (experimental) adaptor for accessing the OpenFn web API",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @openfn/language-openhim
+
+## 0.1.0
+
+### Minor Changes
+
+- 1fd9b3b: Migrate OpenHIM
+
+### Patch Changes
+
+- e4ebcb6: Fix Large gzip Denial of Service in superagent
+- e81561f: Updated ast and package.json

--- a/packages/openhim/package.json
+++ b/packages/openhim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openhim",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "openhim Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-openmrs
+
+## 0.10.0
+
+### Minor Changes
+
+- 6786949: Migrate OpenMRS

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openmrs",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "OpenMRS Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-rapidpro
 
+## 0.5.1
+
+### Patch Changes
+
+- cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-rapidpro",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A RapidPro adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-resourcemap
+
+## 0.2.0
+
+### Minor Changes
+
+- 664dc7f: migrate resourcemap

--- a/packages/resourcemap/package.json
+++ b/packages/resourcemap/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-resourcemap",
-  "version": "0.1.0",
+  "name": "@openfn/language-resourcemap",
+  "version": "0.2.0",
   "description": "Resourcemap Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/smpp/CHANGELOG.md
+++ b/packages/smpp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-smpp
+
+## 1.2.0
+
+### Minor Changes
+
+- 3aedd05: migrate smpp

--- a/packages/smpp/package.json
+++ b/packages/smpp/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-smpp",
-  "version": "1.1.0",
+  "name": "@openfn/language-smpp",
+  "version": "1.2.0",
   "description": "An SMPP client API Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-telerivet
 
+## 0.1.1
+
+### Patch Changes
+
+- e4ebcb6: Fix Large gzip Denial of Service in superagent
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/telerivet/package.json
+++ b/packages/telerivet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-telerivet",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "telerivet Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openfn/language-vtiger
+
+## 1.1.0
+
+### Minor Changes
+
+- b4a13ff: migrate vtiger

--- a/packages/vtiger/package.json
+++ b/packages/vtiger/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-vtiger",
-  "version": "1.0.0",
+  "name": "@openfn/language-vtiger",
+  "version": "1.1.0",
   "description": "A Vtiger Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @openfn/language-zoho
+
+## 0.2.0
+
+### Minor Changes
+
+- f9ac74a: migrate zoho
+
+### Patch Changes
+
+- e4ebcb6: Fix Large gzip Denial of Service in superagent

--- a/packages/zoho/package.json
+++ b/packages/zoho/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "language-zoho",
-  "version": "0.1.0",
+  "name": "@openfn/language-zoho",
+  "version": "0.2.0",
   "description": "zoho Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {


### PR DESCRIPTION
## Summary

bump all changed packages and update their release notes.

## Details

- [x] 🦋  @openfn/language-cartodb@0.1.0
- [x] 🦋  @openfn/language-dynamics@0.3.0
- [x] 🦋  @openfn/language-facebook@0.2.0
- [x] 🦋  @openfn/language-godata@3.2.0
- [x] 🦋  @openfn/language-khanacademy@0.3.0
- [x] 🦋  @openfn/language-magpi@1.0.0
- [x] 🦋  @openfn/language-mailchimp@0.3.1
- [x] 🦋  @openfn/language-mailgun@0.3.0
- [x] 🦋  @openfn/language-maximo@0.3.0
- [x] 🦋  @openfn/language-mogli@0.3.0
- [x] 🦋  @openfn/language-mysql@1.3.0
- [x] 🦋  @openfn/language-nexmo@0.2.0
- [x] 🦋  @openfn/language-openfn@1.2.0
- [x] 🦋  @openfn/language-openhim@0.1.0
- [x] 🦋  @openfn/language-openmrs@0.10.0
- [x] 🦋  @openfn/language-rapidpro@0.5.1
- [x] 🦋  @openfn/language-resourcemap@0.2.0
- [x] 🦋  @openfn/language-smpp@1.2.0
- [x] 🦋  @openfn/language-telerivet@0.1.1
- [x] 🦋  @openfn/language-vtiger@1.1.0
- [x] 🦋  @openfn/language-zoho@0.2.0
