### PR TITLE
Salesforce: fix typings (?)

### DIFF
--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -36,7 +36,6 @@
     "jsforce": "^1.11.0",
     "lodash": "^4.17.21",
     "mustache": "^2.2.0",
-    "typescript": "4.8.4",
     "yargs": "^3.30.0"
   },
   "devDependencies": {

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -31,10 +31,11 @@
   ],
   "dependencies": {
     "@openfn/language-common": "1.7.5",
+    "@types/lodash": "^4.14.191",
     "JSONPath": "^0.10.0",
     "axios": "^0.21.1",
     "jsforce": "^1.11.0",
-    "lodash-fp": "^0.10.2",
+    "lodash": "^4.17.21",
     "mustache": "^2.2.0",
     "yargs": "^3.30.0"
   },

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -31,12 +31,12 @@
   ],
   "dependencies": {
     "@openfn/language-common": "1.7.5",
-    "@types/lodash": "^4.14.191",
     "JSONPath": "^0.10.0",
     "axios": "^0.21.1",
     "jsforce": "^1.11.0",
     "lodash": "^4.17.21",
     "mustache": "^2.2.0",
+    "typescript": "4.8.4",
     "yargs": "^3.30.0"
   },
   "devDependencies": {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -1,3 +1,4 @@
+/// <reference path="./lodash-overrides.d.ts" />
 /** @module Adaptor */
 
 /**
@@ -31,7 +32,6 @@ const { curry, flatten } = lodash;
  *  relationship("relationship_name__r", "externalID on related object", dataSource("path"))
  * Fixed Value:
  *  relationship("relationship_name__r", "externalID on related object", "hello world")
- * @constructor
  * @param {string} relationshipName - `__r` relationship field on the record.
  * @param {string} externalId - Salesforce ExternalID field.
  * @param {string} dataSource - resolvable source.
@@ -51,11 +51,10 @@ export function relationship(relationshipName, externalId, dataSource) {
  * @public
  * @example
  * describeAll()
- * @constructor
  * @param {State} state - Runtime state.
  * @returns {State}
  */
-export const describeAll = curry(function (state) {
+const _describeAll = function (state) {
   let { connection } = state;
 
   return connection.describeGlobal().then(result => {
@@ -67,19 +66,19 @@ export const describeAll = curry(function (state) {
       references: [sobjects, ...state.references],
     };
   });
-});
+};
+export const describeAll = curry(_describeAll);
 
 /**
  * Outputs basic information about an sObject to `STDOUT`.
  * @public
  * @example
  * describe('obj_name')
- * @constructor
  * @param {String} sObject - API name of the sObject.
  * @param {State} state - Runtime state.
  * @returns {State}
  */
-export const describe = curry(function (sObject, state) {
+const _describe = function (sObject, state) {
   let { connection } = state;
 
   const objectName = expandReferences(sObject)(state);
@@ -96,21 +95,21 @@ export const describe = curry(function (sObject, state) {
         references: [result, ...state.references],
       };
     });
-});
+};
+export const describe = curry(_describe);
 
 /**
  * Retrieves a Salesforce sObject(s).
  * @public
  * @example
  * retrieve('ContentVersion', '0684K0000020Au7QAE/VersionData');
- * @constructor
  * @param {String} sObject - The sObject to retrieve
  * @param {String} id - The id of the record
  * @param {Function} callback - A callback to execute once the record is retrieved
  * @param {State} state - Runtime state
  * @returns {State}
  */
-export const retrieve = curry(function (sObject, id, callback, state) {
+const _retrieve = function (sObject, id, callback, state) {
   let { connection } = state;
 
   const finalId = expandReferences(id)(state);
@@ -130,7 +129,8 @@ export const retrieve = curry(function (sObject, id, callback, state) {
       }
       return state;
     });
-});
+};
+export const retrieve = curry(_retrieve);
 
 /**
  * Execute an SOQL query.
@@ -139,12 +139,11 @@ export const retrieve = curry(function (sObject, id, callback, state) {
  * @public
  * @example
  * query(`SELECT Id FROM Patient__c WHERE Health_ID__c = '${state.data.field1}'`);
- * @constructor
  * @param {String} qs - A query string.
  * @param {State} state - Runtime state.
  * @returns {Operation}
  */
-export const query = curry(function (qs, state) {
+const _query = function (qs, state) {
   let { connection } = state;
   qs = expandReferences(qs)(state);
   console.log(`Executing query: ${qs}`);
@@ -163,7 +162,8 @@ export const query = curry(function (qs, state) {
       references: [result, ...state.references],
     };
   });
-});
+};
+export const query = curry(_query);
 
 /**
  * Create and execute a bulk job.
@@ -174,7 +174,6 @@ export const query = curry(function (qs, state) {
  *     return { 'Age__c': x.age, 'Name': x.name }
  *   })
  * });
- * @constructor
  * @param {String} sObject - API name of the sObject.
  * @param {String} operation - The bulk operation to be performed
  * @param {Object} options - Options passed to the bulk api.
@@ -182,7 +181,7 @@ export const query = curry(function (qs, state) {
  * @param {State} state - Runtime state.
  * @returns {Operation}
  */
-export const bulk = curry(function (sObject, operation, options, fun, state) {
+const _bulk = function (sObject, operation, options, fun, state) {
   const { connection } = state;
   const { failOnError, allowNoOp, pollTimeout, pollInterval } = options;
   const finalAttrs = fun(state);
@@ -262,7 +261,8 @@ export const bulk = curry(function (sObject, operation, options, fun, state) {
     const merged = [].concat.apply([], arrayOfResults);
     return { ...state, references: [merged, ...state.references] };
   });
-});
+};
+export const bulk = curry(_bulk);
 
 /**
  * Delete records of an object.
@@ -272,14 +272,13 @@ export const bulk = curry(function (sObject, operation, options, fun, state) {
  *  '0060n00000JQWHYAA5',
  *  '0090n00000JQEWHYAA5
  * ], { failOnError: true })
- * @constructor
  * @param {String} sObject - API name of the sObject.
  * @param {Object} attrs - Array of IDs of records to delete.
  * @param {Object} options - Options for the destroy delete operation.
  * @param {State} state - Runtime state.
  * @returns {Operation}
  */
-export const destroy = curry(function (sObject, attrs, options, state) {
+const _destroy = function (sObject, attrs, options, state) {
   let { connection } = state;
   const finalAttrs = expandReferences(attrs)(state);
   const { failOnError } = options;
@@ -303,7 +302,8 @@ export const destroy = curry(function (sObject, attrs, options, state) {
         references: [result, ...state.references],
       };
     });
-});
+};
+export const destroy = curry(_destroy);
 
 /**
  * Create a new object.
@@ -313,13 +313,12 @@ export const destroy = curry(function (sObject, attrs, options, state) {
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
  * @param {String} sObject - API name of the sObject.
  * @param {Object} attrs - Field attributes for the new object.
  * @param {State} state - Runtime state.
  * @returns {Operation}
  */
-export const create = curry(function (sObject, attrs, state) {
+const _create = function (sObject, attrs, state) {
   let { connection } = state;
   const finalAttrs = expandReferences(attrs)(state);
   console.info(`Creating ${sObject}`, finalAttrs);
@@ -331,7 +330,8 @@ export const create = curry(function (sObject, attrs, state) {
       references: [recordResult, ...state.references],
     };
   });
-});
+};
+export const create = curry(_create);
 
 /**
  * Create a new object if conditions are met.
@@ -341,14 +341,13 @@ export const create = curry(function (sObject, attrs, state) {
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
  * @param {boolean} logical - a logical statement that will be evaluated.
  * @param {String} sObject - API name of the sObject.
  * @param {Object} attrs - Field attributes for the new object.
  * @param {State} state - Runtime state.
  * @returns {Operation}
  */
-export const createIf = curry(function (logical, sObject, attrs, state) {
+const _createIf = function (logical, sObject, attrs, state) {
   let { connection } = state;
   logical = expandReferences(logical)(state);
 
@@ -368,7 +367,8 @@ export const createIf = curry(function (logical, sObject, attrs, state) {
       ...state,
     };
   }
-});
+};
+export const createIf = curry(_createIf);
 
 /**
  * Upsert an object.
@@ -378,14 +378,13 @@ export const createIf = curry(function (logical, sObject, attrs, state) {
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
  * @param {String} sObject - API name of the sObject.
  * @param {String} externalId - ID.
  * @param {Object} attrs - Field attributes for the new object.
  * @param {State} state - Runtime state.
  * @returns {Operation}
  */
-export const upsert = curry(function (sObject, externalId, attrs, state) {
+const _upsert = function (sObject, externalId, attrs, state) {
   let { connection } = state;
   const finalAttrs = expandReferences(attrs)(state);
   console.info(
@@ -404,7 +403,8 @@ export const upsert = curry(function (sObject, externalId, attrs, state) {
         references: [recordResult, ...state.references],
       };
     });
-});
+};
+export const upsert = curry(_upsert);
 
 /**
  * Upsert if conditions are met.
@@ -414,7 +414,6 @@ export const upsert = curry(function (sObject, externalId, attrs, state) {
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
  * @param {boolean} logical - a logical statement that will be evaluated.
  * @param {String} sObject - API name of the sObject.
  * @param {String} externalId - ID.
@@ -422,13 +421,7 @@ export const upsert = curry(function (sObject, externalId, attrs, state) {
  * @param {State} state - Runtime state.
  * @returns {Operation}
  */
-export const upsertIf = curry(function (
-  logical,
-  sObject,
-  externalId,
-  attrs,
-  state
-) {
+const _upsertIf = function (logical, sObject, externalId, attrs, state) {
   let { connection } = state;
   logical = expandReferences(logical)(state);
 
@@ -456,7 +449,8 @@ export const upsertIf = curry(function (
       ...state,
     };
   }
-});
+};
+export const upsertIf = curry(_upsertIf);
 
 /**
  * Update an object.
@@ -466,13 +460,12 @@ export const upsertIf = curry(function (
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
  * @param {String} sObject - API name of the sObject.
  * @param {Object} attrs - Field attributes for the new object.
  * @param {State} state - Runtime state.
  * @returns {Operation}
  */
-export const update = curry(function (sObject, attrs, state) {
+const _update = function (sObject, attrs, state) {
   let { connection } = state;
   const finalAttrs = expandReferences(attrs)(state);
   console.info(`Updating ${sObject}`, finalAttrs);
@@ -484,22 +477,23 @@ export const update = curry(function (sObject, attrs, state) {
       references: [recordResult, ...state.references],
     };
   });
-});
+};
+export const update = curry(_update);
 
 /**
  * Get a reference ID by an index.
  * @public
  * @example
  * reference(0)
- * @constructor
  * @param {number} position - Position for references array.
  * @param {State} state - Array of references.
  * @returns {State}
  */
-export const reference = curry(function (position, state) {
+const _reference = function (position, state) {
   const { references } = state;
   return references[position].id;
-});
+};
+export const reference = curry(_reference);
 
 /**
  * Creates a connection.

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -19,9 +19,9 @@ import {
   chunk,
 } from '@openfn/language-common';
 import jsforce from 'jsforce';
-import loadash from 'lodash-fp';
+import lodash from 'lodash/fp';
 
-const { curry, flatten } = loadash;
+const { curry, flatten } = lodash;
 
 /**
  * Adds a lookup relation or 'dome insert' to a record.

--- a/packages/salesforce/src/FakeAdaptor.js
+++ b/packages/salesforce/src/FakeAdaptor.js
@@ -1,7 +1,7 @@
 import { execute as commonExecute } from '@openfn/language-common';
-import loadash from 'lodash-fp';
+import lodash from 'lodash/fp';
 
-const { curry, mapValues, flatten } = loadash;
+const { curry, mapValues, flatten } = lodash;
 
 /** @module FakeAdaptor */
 

--- a/packages/salesforce/src/FakeAdaptor.js
+++ b/packages/salesforce/src/FakeAdaptor.js
@@ -1,6 +1,5 @@
 import { execute as commonExecute } from '@openfn/language-common';
 import lodash from 'lodash/fp';
-
 const { curry, mapValues, flatten } = lodash;
 
 /** @module FakeAdaptor */

--- a/packages/salesforce/src/index.js
+++ b/packages/salesforce/src/index.js
@@ -1,7 +1,4 @@
 import * as Adaptor from './Adaptor';
 export default Adaptor;
 
-import * as FakeAdaptor from './FakeAdaptor';
-export { FakeAdaptor };
-
 export * from './Adaptor';

--- a/packages/salesforce/src/lodash-overrides.d.ts
+++ b/packages/salesforce/src/lodash-overrides.d.ts
@@ -1,0 +1,10 @@
+// This file overrides curry to make it into a sort of proxy function
+// This should export the correct signature to the DTS file
+declare module 'lodash/fp' {
+  export const curry: <F>(fn: F) => F;
+
+  // @ts-ignore
+  export default {
+    curry,
+  };
+}

--- a/packages/salesforce/test/Adaptor.test.js
+++ b/packages/salesforce/test/Adaptor.test.js
@@ -190,7 +190,6 @@ describe('Adaptor', () => {
 
       afterExecutionOf(operations)
         .then(state => {
-          console.log(state);
           let references = state.references.reverse();
 
           expect(references.length).to.eql(4);

--- a/packages/salesforce/test/CompositionExamples.test.js
+++ b/packages/salesforce/test/CompositionExamples.test.js
@@ -15,10 +15,9 @@ import {
 } from '../src/FakeAdaptor';
 
 import lodash from 'lodash/fp';
+const { filter } = lodash;
 
 import testData from './nestedTestData' assert { type: 'json' };
-
-const { filter, last } = lodash;
 
 describe('Composition Examples', () => {
   let initialState;

--- a/packages/salesforce/test/CompositionExamples.test.js
+++ b/packages/salesforce/test/CompositionExamples.test.js
@@ -14,11 +14,11 @@ import {
   steps,
 } from '../src/FakeAdaptor';
 
-import loadash from 'lodash-fp';
+import lodash from 'lodash/fp';
 
 import testData from './nestedTestData' assert { type: 'json' };
 
-const { filter, last } = loadash;
+const { filter, last } = lodash;
 
 describe('Composition Examples', () => {
   let initialState;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1101,7 +1101,6 @@ importers:
       rimraf: 3.0.2
       sinon: ^14.0.1
       type-detect: 1.0.0
-      typescript: 4.8.4
       yargs: ^3.30.0
     dependencies:
       '@openfn/language-common': link:../common
@@ -1110,7 +1109,6 @@ importers:
       jsforce: 1.11.0
       lodash: 4.17.21
       mustache: 2.3.2
-      typescript: 4.8.4
       yargs: 3.32.0
     devDependencies:
       '@openfn/buildtools': link:../../tools/build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1087,6 +1087,7 @@ importers:
       '@openfn/buildtools': workspace:^1.0.2
       '@openfn/language-common': 1.7.5
       '@openfn/simple-ast': 0.4.1
+      '@types/lodash': ^4.14.191
       JSONPath: ^0.10.0
       assertion-error: 1.1.0
       axios: ^0.21.1
@@ -1094,7 +1095,7 @@ importers:
       deep-eql: 4.1.1
       esno: ^0.16.3
       jsforce: ^1.11.0
-      lodash-fp: ^0.10.2
+      lodash: ^4.17.21
       mocha: 7.2.0
       mustache: ^2.2.0
       nock: 13.2.9
@@ -1104,10 +1105,11 @@ importers:
       yargs: ^3.30.0
     dependencies:
       '@openfn/language-common': link:../common
+      '@types/lodash': 4.14.191
       JSONPath: 0.10.0
       axios: 0.21.4
       jsforce: 1.11.0
-      lodash-fp: 0.10.4
+      lodash: 4.17.21
       mustache: 2.3.2
       yargs: 3.32.0
     devDependencies:
@@ -2342,6 +2344,10 @@ packages:
 
   /@types/linkify-it/3.0.2:
     resolution: {integrity: sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==}
+    dev: false
+
+  /@types/lodash/4.14.191:
+    resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
     dev: false
 
   /@types/markdown-it/12.2.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1087,7 +1087,6 @@ importers:
       '@openfn/buildtools': workspace:^1.0.2
       '@openfn/language-common': 1.7.5
       '@openfn/simple-ast': 0.4.1
-      '@types/lodash': ^4.14.191
       JSONPath: ^0.10.0
       assertion-error: 1.1.0
       axios: ^0.21.1
@@ -1102,15 +1101,16 @@ importers:
       rimraf: 3.0.2
       sinon: ^14.0.1
       type-detect: 1.0.0
+      typescript: 4.8.4
       yargs: ^3.30.0
     dependencies:
       '@openfn/language-common': link:../common
-      '@types/lodash': 4.14.191
       JSONPath: 0.10.0
       axios: 0.21.4
       jsforce: 1.11.0
       lodash: 4.17.21
       mustache: 2.3.2
+      typescript: 4.8.4
       yargs: 3.32.0
     devDependencies:
       '@openfn/buildtools': link:../../tools/build
@@ -2344,10 +2344,6 @@ packages:
 
   /@types/linkify-it/3.0.2:
     resolution: {integrity: sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==}
-    dev: false
-
-  /@types/lodash/4.14.191:
-    resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
     dev: false
 
   /@types/markdown-it/12.2.3:

--- a/tools/build/src/commands/dts.ts
+++ b/tools/build/src/commands/dts.ts
@@ -16,6 +16,7 @@ export default (lang: string) => {
     '--emitDeclarationOnly',
     '--lib es2020',
     `--declarationDir ${root}/types`,
+    '--skipLibCheck',
     `${root}/src/index.js`,
   ];
   // Need to run the command out of the build tool dir


### PR DESCRIPTION
## Summary

This PR makes a few adjustments to Salesforce to fix its d.ts type definitions.

## Details

At the moment, Salesforce exports basically all its functions as type `any`, with all type semantics lost.

This is really hurting my experimental magic-functions stuff  - and it's going to give us trouble further down the line.

The basic problem is that salesforce wraps its exports with `curry`, and that sort of breaks the type tracking when generating the d.ts. files.

I've overridden lodash's d.ts with a sort of proxy function around `curry`. For this to actually, the comments need to be associated with the actual function, not the assigned variable. Otherwise the proxied generic doesn't map properly. Hence the `_describe` etc indirections.

Additional fixes:
* I'm using modern `lodash/fp` instead of the archived `lodash-fp`

## Issues

This fixes #184 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
