### PR TITLE
`kobotoolbox` Add `getDeploymentInfo` helper function

### DIFF
--- a/.changeset/bright-panthers-attack.md
+++ b/.changeset/bright-panthers-attack.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-kobotoolbox': minor
+---
+
+add getDeploymentInfo function

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -112,6 +112,46 @@ export function getSubmissions(params, callback) {
   };
 }
 
+/**
+ * Get deployment information for a specific form
+ * @example
+ * getDeploymentInfo({formId: 'aXecHjmbATuF6iGFmvBLBX'}, state => {
+ *   console.log(state.data);
+ *   return state;
+ * });
+ * @function
+ * @param {object} params - Form Id and data to make the fetch or filter
+ * @param {function} callback - (Optional) Callback function to execute after fetching form deployment information
+ * @returns {Operation}
+ */
+export function getDeploymentInfo(params, callback) {
+  return state => {
+    params = expandReferences(params)(state);
+
+    const { baseURL, apiVersion, username, password } = state.configuration;
+    const { formId } = params;
+
+    const url = `${baseURL}/api/${apiVersion}/assets/${formId}/deployment/?format=json`;
+    const auth = { username, password };
+
+    const config = {
+      url,
+      params: params.query,
+      auth,
+    };
+
+    return http
+      .get(config)(state)
+      .then(response => {
+        console.log('✓', 'deployment information fetched.');
+
+        const nextState = composeNextState(state, response.data);
+        if (callback) return callback(nextState);
+        return nextState;
+      });
+  };
+}
+
 export {
   fn,
   alterState,


### PR DESCRIPTION
## Summary

I added a `getDeploymentInfo` function which is available on version 2 of [kobotoolbox API](https://kf.kobotoolbox.org/api/v2/assets/)

## Details

The function retrieves information about the existing deployment if any.

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [x] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.