### PR TITLE
Update `@constructor` to `@function`

### DIFF
--- a/.changeset/cool-feet-bathe.md
+++ b/.changeset/cool-feet-bathe.md
@@ -1,0 +1,37 @@
+---
+'@openfn/language-asana': patch
+'@openfn/language-beyonic': patch
+'@openfn/language-bigquery': patch
+'@openfn/language-cartodb': patch
+'@openfn/language-commcare': patch
+'@openfn/language-dhis2': patch
+'@openfn/language-dynamics': patch
+'@openfn/language-facebook': patch
+'@openfn/language-fhir': patch
+'@openfn/language-godata': patch
+'@openfn/language-googlesheets': patch
+'@openfn/language-http': patch
+'@openfn/language-khanacademy': patch
+'@openfn/language-kobotoolbox': patch
+'@openfn/language-magpi': patch
+'@openfn/language-mailchimp': patch
+'@openfn/language-mailgun': patch
+'@openfn/language-maximo': patch
+'@openfn/language-mogli': patch
+'@openfn/language-mssql': patch
+'@openfn/language-mysql': patch
+'@openfn/language-ocl': patch
+'@openfn/language-openfn': patch
+'@openfn/language-openhim': patch
+'@openfn/language-openmrs': patch
+'@openfn/language-postgresql': patch
+'@openfn/language-primero': patch
+'@openfn/language-progres': patch
+'@openfn/language-rapidpro': patch
+'@openfn/language-salesforce': patch
+'@openfn/language-sftp': patch
+'@openfn/language-surveycto': patch
+'@openfn/language-template': patch
+---
+
+change @constructor to @function and remove /\*_ @module Adaptor _/

--- a/packages/asana/src/Adaptor.js
+++ b/packages/asana/src/Adaptor.js
@@ -1,4 +1,3 @@
-/** @module Adaptor */
 import {
   execute as commonExecute,
   composeNextState,

--- a/packages/beyonic/src/Adaptor.js
+++ b/packages/beyonic/src/Adaptor.js
@@ -5,8 +5,6 @@ import {
 import { post } from './Client';
 import { resolve as resolveUrl } from 'url';
 
-/** @module Adaptor */
-
 /**
  * Execute a sequence of operations.
  * Wraps `language-common/execute`, and prepends initial state for beyonic.
@@ -15,7 +13,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -36,7 +34,7 @@ export function execute(...operations) {
  * execute(
  *   createPayment(data)
  * )(state)
- * @constructor
+ * @function
  * @param {object} data - Payload data for the payment
  * @returns {Operation}
  */
@@ -64,7 +62,7 @@ export function createPayment(data) {
  * execute(
  *   createContact(data)
  * )(state)
- * @constructor
+ * @function
  * @param {object} data - Payload data for the contact
  * @returns {Operation}
  */
@@ -92,7 +90,7 @@ export function createContact(data) {
  * execute(
  *   createCollectionRequest(data)
  * )(state)
- * @constructor
+ * @function
  * @param {object} data - Payload data for the collection request
  * @returns {Operation}
  */

--- a/packages/bigquery/src/Adaptor.js
+++ b/packages/bigquery/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import 'regenerator-runtime/runtime.js';
 import {
   execute as commonExecute,

--- a/packages/cartodb/src/Adaptor.js
+++ b/packages/cartodb/src/Adaptor.js
@@ -7,7 +7,7 @@ import jsonSqlPkg from 'json-sql';
 
 const jsonSql = jsonSqlPkg();
 
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.
@@ -38,7 +38,7 @@ export function execute(...operations) {
  * execute(
  *   sql(sqlQuery)
  * )(state)
- * @constructor
+ * @function
  * @param {object} sqlQuery - Payload data for the message
  * @returns {Operation}
  */

--- a/packages/commcare/ast.json
+++ b/packages/commcare/ast.json
@@ -19,9 +19,8 @@
             "description": "submitXls(\n   [\n     {name: 'Mamadou', phone: '000000'},\n   ],\n   {\n     case_type: 'student',\n     search_field: 'external_id',\n     create_new_cases: 'on',\n   }\n)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -72,9 +71,8 @@
             "description": "submit(\n   fields(\n     field(\"@\", function(state) {\n       return {\n         \"xmlns\": \"http://openrosa.org/formdesigner/form-id-here\"\n       };\n     }),\n     field(\"question1\", dataValue(\"answer1\")),\n     field(\"question2\", \"Some answer here.\")\n   )\n )"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -118,9 +116,8 @@
             "description": "fetchReportData(reportId, params, postUrl)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 
 import {
   execute as commonExecute,
@@ -20,7 +20,7 @@ import xlsx from 'xlsx';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -43,7 +43,7 @@ export function execute(...operations) {
  * Performs a post request
  * @example
  *  clientPost(formData)
- * @constructor
+ * @function
  * @param {Object} formData - Form Data with auth params and body
  * @returns {State}
  */
@@ -77,7 +77,7 @@ function clientPost({ url, body, username, password }) {
  *      create_new_cases: 'on',
  *    }
  * )
- * @constructor
+ * @function
  * @param {Object} formData - Object including form data.
  * @param {Object} params - Request params including case type and external id.
  * @returns {Operation}
@@ -146,7 +146,7 @@ export function submitXls(formData, params) {
  *      field("question2", "Some answer here.")
  *    )
  *  )
- * @constructor
+ * @function
  * @param {Object} formData - Object including form data.
  * @returns {Operation}
  */
@@ -196,7 +196,7 @@ export function submit(formData) {
  * @public
  * @example
  * fetchReportData(reportId, params, postUrl)
- * @constructor
+ * @function
  * @param {String} reportId - API name of the report.
  * @param {Object} params - Query params, incl: limit, offset, and custom report filters.
  * @param {String} postUrl - Url to which the response object will be posted.

--- a/packages/dhis2/ast.json
+++ b/packages/dhis2/ast.json
@@ -17,9 +17,8 @@
             "type": null
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -149,9 +148,8 @@
             "type": null
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -289,9 +287,8 @@
             "type": null
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -381,9 +378,8 @@
             "type": null
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -502,9 +498,8 @@
             "type": null
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -560,9 +555,8 @@
             "type": null
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -651,9 +645,8 @@
             "type": null
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -771,9 +764,8 @@
             "description": "findAttributeValue(state.data.trackedEntityInstances[0], 'first name')"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -825,9 +817,8 @@
             "description": "attr('w75KJ2mc4zz', 'Elias')"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -879,9 +870,8 @@
             "description": "dv('f7n9E0hX8qk', 12)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import axios from 'axios';
 import _ from 'lodash';
 import {
@@ -26,7 +26,7 @@ const { indexOf } = _;
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -49,7 +49,7 @@ export function execute(...operations) {
  * For `OpenFn.org` users with the `old-style configuration`.
  * @example
  * configMigrationHelper(state)
- * @constructor
+ * @function
  * @param {object} state - the runtime state
  * @returns {object}
  */
@@ -122,7 +122,7 @@ axios.interceptors.response.use(
 /**
  * Create a record
  * @public
- * @constructor
+ * @function
  * @param {string} resourceType - Type of resource to create. E.g. `trackedEntityInstances`, `programs`, `events`, ...
  * @param {Object} data - Data that will be used to create a given instance of resource. To create a single instance of a resource, `data` must be a javascript object, and to create multiple instances of a resources, `data` must be an array of javascript objects.
  * @param {Object} [options] - Optional `options` to define URL parameters via params (E.g. `filter`, `dimension` and other import parameters), request config (E.g. `auth`) and the DHIS2 apiVersion.
@@ -252,7 +252,7 @@ export function create(resourceType, data, options = {}, callback = false) {
  * Update data. A generic helper function to update a resource object of any type.
  * Updating an object requires to send `all required fields` or the `full body`
  * @public
- * @constructor
+ * @function
  * @param {string} resourceType - The type of resource to be updated. E.g. `dataElements`, `organisationUnits`, etc.
  * @param {string} path - The `id` or `path` to the `object` to be updated. E.g. `FTRrcoaog83` or `FTRrcoaog83/{collection-name}/{object-id}`
  * @param {Object} data - Data to update. It requires to send `all required fields` or the `full body`. If you want `partial updates`, use `patch` operation.
@@ -416,7 +416,7 @@ export function update(
  * Get data. Generic helper method for getting data of any kind from DHIS2.
  * - This can be used to get `DataValueSets`,`events`,`trackedEntityInstances`,`etc.`
  * @public
- * @constructor
+ * @function
  * @param {string} resourceType - The type of resource to get(use its `plural` name). E.g. `dataElements`, `trackedEntityInstances`,`organisationUnits`, etc.
  * @param {Object} query - A query object that will limit what resources are retrieved when converted into request params.
  * @param {Object} [options] - Optional `options` to define URL parameters via params beyond filters, request configuration (e.g. `auth`) and DHIS2 api version to use.
@@ -464,7 +464,7 @@ export function get(resourceType, query, options = {}, callback = false) {
 /**
  * Upsert a record. A generic helper function used to atomically either insert a row, or on the basis of the row already existing, UPDATE that existing row instead.
  * @public
- * @constructor
+ * @function
  * @param {string} resourceType - The type of a resource to `upsert`. E.g. `trackedEntityInstances`
  * @param {Object} query - A query object that allows to uniquely identify the resource to update. If no matches found, then the resource will be created.
  * @param {Object} data - The data to use for update or create depending on the result of the query.
@@ -528,7 +528,7 @@ export function upsert(
 /**
  * Discover `DHIS2` `api` `endpoint` `query parameters` and allowed `operators` for a given resource's endpoint.
  * @public
- * @constructor
+ * @function
  * @param {string} httpMethod - The HTTP to inspect parameter usage for a given endpoint, e.g., `get`, `post`,`put`,`patch`,`delete`
  * @param {string} endpoint - The path for a given endpoint. E.g. `/trackedEntityInstances` or `/dataValueSets`
  * @returns {Operation}
@@ -625,7 +625,7 @@ export function discover(httpMethod, endpoint) {
  * - You are not required to send the full body of object properties.
  * - This is useful for cases where you don't want or need to update all properties on a object.
  * @public
- * @constructor
+ * @function
  * @param {string} resourceType - The type of resource to be updated. E.g. `dataElements`, `organisationUnits`, etc.
  * @param {string} path - The `id` or `path` to the `object` to be updated. E.g. `FTRrcoaog83` or `FTRrcoaog83/{collection-name}/{object-id}`
  * @param {Object} data - Data to update. Include only the fields you want to update. E.g. `{name: "New Name"}`
@@ -671,7 +671,7 @@ export function patch(
 /**
  * Delete a record. A generic helper function to delete an object
  * @public
- * @constructor
+ * @function
  * @param {string} resourceType - The type of resource to be deleted. E.g. `trackedEntityInstances`, `organisationUnits`, etc.
  * @param {string} path - Can be an `id` of an `object` or `path` to the `nested object` to `delete`.
  * @param {Object} [data] - Optional. This is useful when you want to remove multiple objects from a collection in one request. You can send `data` as, for example, `{"identifiableObjects": [{"id": "IDA"}, {"id": "IDB"}, {"id": "IDC"}]}`. See more {@link https://docs.dhis2.org/2.34/en/dhis2_developer_manual/web-api.html#deleting-objects on DHIS2 API docs}
@@ -717,7 +717,7 @@ export function destroy(
  * @public
  * @example
  * findAttributeValue(state.data.trackedEntityInstances[0], 'first name')
- * @constructor
+ * @function
  * @param {Object} trackedEntityInstance - A tracked entity instance (TEI) object
  * @param {string} attributeDisplayName - The 'displayName' to search for in the TEI's attributes
  * @returns {string}
@@ -736,7 +736,7 @@ export function findAttributeValue(
  * @public
  * @example
  * attr('w75KJ2mc4zz', 'Elias')
- * @constructor
+ * @function
  * @param {string} attribute - A tracked entity instance (TEI) attribute ID.
  * @param {string} value - The value for that attribute.
  * @returns {object}
@@ -750,7 +750,7 @@ export function attr(attribute, value) {
  * @public
  * @example
  * dv('f7n9E0hX8qk', 12)
- * @constructor
+ * @function
  * @param {string} dataElement - A data element ID.
  * @param {string} value - The value for that data element.
  * @returns {object}

--- a/packages/dynamics/src/Adaptor.js
+++ b/packages/dynamics/src/Adaptor.js
@@ -5,7 +5,7 @@ import {
 import request from 'request';
 import { resolve as resolveUrl } from 'url';
 
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.
@@ -15,7 +15,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/facebook/src/Adaptor.js
+++ b/packages/facebook/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   expandReferences,

--- a/packages/fhir/src/Adaptor.js
+++ b/packages/fhir/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   composeNextState,

--- a/packages/godata/src/Adaptor.js
+++ b/packages/godata/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   composeNextState,
@@ -14,7 +14,7 @@ import axios from 'axios';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/googlesheets/ast.json
+++ b/packages/googlesheets/ast.json
@@ -18,9 +18,8 @@
             "description": "appendValues({\n  spreadsheetId: '1O-a4_RgPF_p8W3I6b5M9wobA3-CBW8hLClZfUik5sos',\n  range: 'Sheet1!A1:E1',\n  values: [\n    ['From expression', '$15', '2', '3/15/2016'],\n    ['Really now!', '$100', '1', '3/20/2016'],\n  ],\n})"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -4,7 +4,7 @@ import {
 } from "@openfn/language-common";
 import { google } from "googleapis";
 
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.
@@ -14,7 +14,7 @@ import { google } from "googleapis";
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -46,7 +46,7 @@ export function execute(...operations) {
  *     ['Really now!', '$100', '1', '3/20/2016'],
  *   ],
  * })
- * @constructor
+ * @function
  * @param {Object} params - Data object to add to the spreadsheet.
  * @returns {Operation}
  */

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -20,9 +20,8 @@
             "description": "get('/myEndpoint', {\n   query: {foo: 'bar', a: 1},\n   headers: {'content-type': 'application/json'},\n   authentication: {username: 'user', password: 'pass'}\n })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -84,9 +83,8 @@
             "description": "post('/myEndpoint', {\n   body: {'foo': 'bar'},\n   headers: {'content-type': 'application/json'},\n   authentication: {username: 'user', password: 'pass'}\n })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -148,9 +146,8 @@
             "description": "put('/myEndpoint', {\n   body: {'foo': 'bar'},\n   headers: {'content-type': 'application/json'},\n   authentication: {username: 'user', password: 'pass'}\n })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -212,9 +209,8 @@
             "description": "patch('/myEndpoint', {\n   body: {'foo': 'bar'},\n   headers: {'content-type': 'application/json'},\n   authentication: {username: 'user', password: 'pass'}\n })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -276,9 +272,8 @@
             "description": "del(`/myendpoint/${state => state.data.id}`, {\n   headers: {'content-type': 'application/json'}\n })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -339,9 +334,8 @@
             "description": "parseXML(body, function($){\n   return $(\"table[class=your_table]\").parsetable(true, true, true);\n })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -393,9 +387,8 @@
             "description": "parseCSV(\"/home/user/someData.csv\", {\n\t  quoteChar: '\"',\n\t  header: false,\n\t});"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   setAuth,
   setUrl,
@@ -31,7 +31,7 @@ const { axios } = http;
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -128,7 +128,7 @@ function handleCallback(state, callback) {
  *    headers: {'content-type': 'application/json'},
  *    authentication: {username: 'user', password: 'pass'}
  *  })
- * @constructor
+ * @function
  * @param {string} path - Path to resource
  * @param {object} params - Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
@@ -164,7 +164,7 @@ export function get(path, params, callback) {
  *    headers: {'content-type': 'application/json'},
  *    authentication: {username: 'user', password: 'pass'}
  *  })
- * @constructor
+ * @function
  * @param {string} path - Path to resource
  * @param {object} params - Body, Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
@@ -200,7 +200,7 @@ export function post(path, params, callback) {
  *    headers: {'content-type': 'application/json'},
  *    authentication: {username: 'user', password: 'pass'}
  *  })
- * @constructor
+ * @function
  * @param {string} path - Path to resource
  * @param {object} params - Body, Query, Headers and Auth parameters
  * @param {function} callback - (Optional) Callback function
@@ -236,7 +236,7 @@ export function put(path, params, callback) {
  *    headers: {'content-type': 'application/json'},
  *    authentication: {username: 'user', password: 'pass'}
  *  })
- * @constructor
+ * @function
  * @param {string} path - Path to resource
  * @param {object} params - Body, Query, Headers and Auth parameters
  * @param {function} callback - (Optional) Callback function
@@ -270,7 +270,7 @@ export function patch(path, params, callback) {
  *  del(`/myendpoint/${state => state.data.id}`, {
  *    headers: {'content-type': 'application/json'}
  *  })
- * @constructor
+ * @function
  * @param {string} path - Path to resource
  * @param {object} params - Body, Query, Headers and Auth parameters
  * @param {function} callback - (Optional) Callback function
@@ -304,7 +304,7 @@ export function del(path, params, callback) {
  *  parseXML(body, function($){
  *    return $("table[class=your_table]").parsetable(true, true, true);
  *  })
- * @constructor
+ * @function
  * @param {String} body - data string to be parsed
  * @param {function} script - script for extracting data
  * @returns {Operation}
@@ -336,7 +336,7 @@ export function parseXML(body, script) {
  * 	  quoteChar: '"',
  * 	  header: false,
  * 	});
- * @constructor
+ * @function
  * @param {String} target - string or local file with CSV data
  * @param {Object} config - csv-parse config object
  * @returns {Operation}
@@ -378,7 +378,7 @@ export function parseCSV(target, config) {
  * Make a request using the 'request' node module. This module is deprecated.
  * @example
  *  request(params);
- * @constructor
+ * @function
  * @param {object} params - Query, Headers and Authentication parameters
  * @returns {Operation}
  */

--- a/packages/khanacademy/src/Adaptor.js
+++ b/packages/khanacademy/src/Adaptor.js
@@ -6,7 +6,7 @@ import { resolve as resolveUrl } from 'url';
 import request from 'request';
 import qs from 'qs';
 
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.
@@ -16,7 +16,7 @@ import qs from 'qs';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -37,7 +37,7 @@ export function execute(...operations) {
  * execute(
  *   fetch(params)
  * )(state)
- * @constructor
+ * @function
  * @param {object} params - data to make the query
  * @returns {Operation}
  */

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 
 import {
   execute as commonExecute,

--- a/packages/magpi/src/Adaptor.js
+++ b/packages/magpi/src/Adaptor.js
@@ -6,7 +6,7 @@ import { resolve as resolveUrl } from 'url';
 import js2xmlparser from 'js2xmlparser';
 import request from 'request';
 import xml2js from 'xml2js';
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.

--- a/packages/mailchimp/src/Adaptor.js
+++ b/packages/mailchimp/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   composeNextState,
@@ -17,7 +17,7 @@ import { resolve } from 'path';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -39,7 +39,7 @@ export function execute(...operations) {
  * Add members to a particular audience
  * @example
  * upsertMembers(params)
- * @constructor
+ * @function
  * @param {object} params - a listId, users, and options
  * @returns {Operation}
  */
@@ -72,7 +72,7 @@ export function upsertMembers(params) {
  * Tag members with a particular tag
  * @example
  * tagMembers(params)
- * @constructor
+ * @function
  * @param {object} params - a tagId, members, and a list
  * @returns {Operation}
  */
@@ -96,7 +96,7 @@ export function tagMembers(params) {
  * Start a batch with a list of operations.
  * @example
  * startBatch(params)
- * @constructor
+ * @function
  * @param {object} params - operations batch job
  * @returns {Operation}
  */

--- a/packages/mailgun/src/Adaptor.js
+++ b/packages/mailgun/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   expandReferences,
@@ -17,7 +17,7 @@ import request from "sync-request";
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/maximo/src/Adaptor.js
+++ b/packages/maximo/src/Adaptor.js
@@ -7,7 +7,7 @@ import { resolve as resolveUrl } from 'url';
 import base64 from 'base-64';
 import utf8 from 'utf8';
 
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.

--- a/packages/mogli/src/Adaptor.js
+++ b/packages/mogli/src/Adaptor.js
@@ -4,7 +4,7 @@ import request from 'request';
 // import { curry, mapValues, flatten } from 'lodash-fp';
 import pkg from 'lodash-fp';
 const { curry, mapValues, flatten } = pkg;
-/** @module Adaptor */
+
 
 /**
  * @typedef {Object} State
@@ -176,7 +176,7 @@ export function execute(...operations) {
 
 /**
  * Removes unserializable keys from the state.
- * @constructor
+ * @function
  * @param {State} state
  * @returns {State}
  */

--- a/packages/mssql/ast.json
+++ b/packages/mssql/ast.json
@@ -18,9 +18,8 @@
             "description": "sql({ query, options })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -62,9 +61,8 @@
             "description": "findValue({\n   uuid: 'id',\n   relation: 'users',\n   where: { first_name: 'Mama%', last_name: 'Cisse'},\n   operator: { first_name: 'like', last_name: '='}\n })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -108,9 +106,8 @@
             "description": "insert(table, record, {setNull: [\"'undefined'\", \"''\"], logValues: false})"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -172,9 +169,8 @@
             "description": "insertMany(table, records, { setNull: false, writeSql: true, logValues: false })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -237,9 +233,8 @@
             "description": "upsert(table, uuid, record, { setNull: \"'undefined'\", logValues: false})\nupsert(table, [uuid1, uuid2], record, { setNull: \"'undefined'\", logValues: false})"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -312,9 +307,8 @@
             "description": "upsertIf(\n  dataValue('name'),\n  'users', // the DB table\n  'uuid', // a DB column with a unique constraint\n  { name: 'Elodie', id: 7 },\n  { writeSql:true, execute: true, logValues: false }\n)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -395,9 +389,8 @@
             "description": "upsertMany(\n 'users', 'email', records, { logValues: false }\n)\nupsertMany(\n 'users', ['email', 'phone'], records, { logValues: false }\n)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -467,9 +460,8 @@
             "description": "describeTable('clinic_visits')"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -522,9 +514,8 @@
             "description": "insertTable('table_name', state => state.data.map(\n  column => ({\n    name: column.name,\n    type: column.type,\n    required: true, // optional\n    unique: false, // optional - to be set to true for unique constraint\n  })\n));"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -586,9 +577,8 @@
             "description": "modifyTable('table_name', state => state.data.map(\n  newColumn => ({\n    name: newColumn.name,\n    type: newColumn.type,\n    required: true, // optional\n    unique: false, // optional - to be set to true for unique constraint\n  })\n));"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -58,7 +58,7 @@ function createConnection(state) {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -176,7 +176,7 @@ function queryHandler(state, query, callback, options) {
  * @public
  * @example
  * sql({ query, options })
- * @constructor
+ * @function
  * @param {object} params - Payload data for the message
  * @returns {Operation}
  */
@@ -244,7 +244,7 @@ function escapeQuote(stringExp) {
  *    where: { first_name: 'Mama%', last_name: 'Cisse'},
  *    operator: { first_name: 'like', last_name: '='}
  *  })
- * @constructor
+ * @function
  * @param {object} filter - A filter object with the lookup table, a uuid and the condition
  * @returns {Operation}
  */
@@ -302,7 +302,7 @@ export function findValue(filter) {
  * @public
  * @example
  * insert(table, record, {setNull: ["'undefined'", "''"], logValues: false})
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {object} record - Payload data for the record as a JS object
  * @param {object} options - Optional options argument
@@ -347,7 +347,7 @@ export function insert(table, record, options) {
  * @public
  * @example
  * insertMany(table, records, { setNull: false, writeSql: true, logValues: false })
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {function} records - A function that takes state and returns an array of records
  * @param {object} options - Optional options argument
@@ -396,7 +396,7 @@ export function insertMany(table, records, options) {
  * @example
  * upsert(table, uuid, record, { setNull: "'undefined'", logValues: false})
  * upsert(table, [uuid1, uuid2], record, { setNull: "'undefined'", logValues: false})
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {string} uuid - The uuid column to determine a matching/existing record
  * @param {object} record - Payload data for the record as a JS object
@@ -474,7 +474,7 @@ export function upsert(table, uuid, record, options) {
  *   { name: 'Elodie', id: 7 },
  *   { writeSql:true, execute: true, logValues: false }
  * )
- * @constructor
+ * @function
  * @param {string} logical - a data to check existing value for.
  * @param {string} table - The target table
  * @param {string} uuid - The uuid column to determine a matching/existing record
@@ -558,7 +558,7 @@ export function upsertIf(logical, table, uuid, record, options) {
  * upsertMany(
  *  'users', ['email', 'phone'], records, { logValues: false }
  * )
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {string} uuid - The uuid column to determine a matching/existing record
  * @param {function} records - A function that takes state and returns an array of records
@@ -636,7 +636,7 @@ export function upsertMany(table, uuid, records, options) {
  * @public
  * @example
  * describeTable('clinic_visits')
- * @constructor
+ * @function
  * @param {string} tableName - The name of the table to describe
  * @param {object} options - Optional options argument
  * @returns {Operation}
@@ -673,7 +673,7 @@ export function describeTable(tableName, options) {
  *     unique: false, // optional - to be set to true for unique constraint
  *   })
  * ));
- * @constructor
+ * @function
  * @param {string} tableName - The name of the table to create
  * @param {array} columns - An array of form columns
  * @param {object} options - Optional options argument
@@ -732,7 +732,7 @@ export function insertTable(tableName, columns, options) {
  *     unique: false, // optional - to be set to true for unique constraint
  *   })
  * ));
- * @constructor
+ * @function
  * @param {string} tableName - The name of the table to alter
  * @param {array} columns - An array of form columns
  * @param {object} options - Optional options argument

--- a/packages/mysql/ast.json
+++ b/packages/mysql/ast.json
@@ -19,9 +19,8 @@
             "description": "upsertMany(\n  'users', // the DB table\n  [\n    { name: 'one', email: 'one@openfn.org' },\n    { name: 'two', email: 'two@openfn.org' },\n  ]\n)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/mysql/src/Adaptor.js
+++ b/packages/mysql/src/Adaptor.js
@@ -6,7 +6,7 @@ import { resolve as resolveUrl } from 'url';
 import mysql from 'mysql';
 import squel from 'squel';
 
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.
@@ -16,7 +16,7 @@ import squel from 'squel';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -70,7 +70,7 @@ function cleanupState(state) {
  *      field('name', dataValue('name'))
  *   ))
  * )(state)
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {object} fields - A fields object
  * @returns {Operation}
@@ -130,7 +130,7 @@ export function insert(table, fields) {
  *      field('name', dataValue('name'))
  *   ))
  * )(state)
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {object} fields - A fields object
  * @returns {Operation}
@@ -208,7 +208,7 @@ export function upsert(table, fields) {
  *     { name: 'two', email: 'two@openfn.org' },
  *   ]
  * )
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {array} data - An array of objects or a function that returns an array
  * @returns {Operation}
@@ -262,7 +262,7 @@ export function upsertMany(table, data) {
  * execute(
  *   query({ sql: 'select * from users;' })
  * )(state)
- * @constructor
+ * @function
  * @param {object} options - Payload data for the message
  * @returns {Operation}
  */
@@ -303,7 +303,7 @@ export function query(options) {
  * execute(
  *   sqlString(state => "select * from items;")
  * )(state)
- * @constructor
+ * @function
  * @param {String} queryString - A query string (or function which takes state and returns a string)
  * @returns {Operation}
  */

--- a/packages/ocl/src/Adaptor.js
+++ b/packages/ocl/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   composeNextState,

--- a/packages/openfn/ast.json
+++ b/packages/openfn/ast.json
@@ -19,9 +19,8 @@
             "description": "request({method: 'get', path: '/jobs/});"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/openfn/src/Adaptor.js
+++ b/packages/openfn/src/Adaptor.js
@@ -22,7 +22,7 @@ const defaultHeaders = { 'User-Agent': `language-openfn-v${version}` };
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -88,7 +88,7 @@ function logout(state) {
  * @public
  * @example
  *  request({method: 'get', path: '/jobs/});
- * @constructor
+ * @function
  * @param {object} options - Body, Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
  * @returns {Operation}

--- a/packages/openhim/src/Adaptor.js
+++ b/packages/openhim/src/Adaptor.js
@@ -5,7 +5,7 @@ import {
 import { post } from './Client';
 import { resolve as resolveUrl } from 'url';
 
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.
@@ -15,7 +15,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -36,7 +36,7 @@ export function execute(...operations) {
  * execute(
  *   encounter(data)
  * )(state)
- * @constructor
+ * @function
  * @param {object} encounterData - Payload data for the encounter
  * @returns {Operation}
  */

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -7,7 +7,7 @@ import request from 'request';
 import { assembleError, tryJson } from './Utils';
 import { resolve as resolveUrl } from 'url';
 
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.
@@ -86,7 +86,7 @@ function cleanupState(state) {
  * execute(
  *   getPatient({ uuid: 123 })
  * )(state)
- * @constructor
+ * @function
  * @param {object} params - object with uuid for the patient
  * @returns {Operation}
  */
@@ -179,7 +179,7 @@ export function getPatients(criteria, options) {
  *   { identifier: '007' },
  *   { exactlyOne: true }
  * )(state)
- * @constructor
+ * @function
  * @param {object} criteria - Criteria object for the people
  * @param {object} options - Options object for the handling of responses
  * @returns {Operation}
@@ -226,7 +226,7 @@ export function getPeople(criteria, options) {
  * @example
  * execute(
  *   createEncounter(params)(state)
- * @constructor
+ * @function
  * @param {object} params - parameters of the encounter
  * @returns {Operation}
  */
@@ -263,7 +263,7 @@ export function createEncounter(params) {
  *   method: 'GET'
  *   url: 'encounterType'
  * })(state)
- * @constructor
+ * @function
  * @param {object} params - parameters for the request
  * @param {function} callback - a callback to execute on the next state
  * @returns {Operation}

--- a/packages/postgresql/ast.json
+++ b/packages/postgresql/ast.json
@@ -19,9 +19,8 @@
             "description": "sql(state => `select(*) from ${state.data.tableName};`, { writeSql: true })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -72,9 +71,8 @@
             "description": "findValue({\n   uuid: 'id',\n   relation: 'users',\n   where: { first_name: 'Mamadou' },\n   operator: { first_name: 'like' }\n })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -118,9 +116,8 @@
             "description": "insert('users', { name: 'Elodie', id: 7 }, { setNull: \"'NaN'\", logValues: true });"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -182,9 +179,8 @@
             "description": "insertMany('users', state => state.data.recordArray, { setNull: \"'undefined'\", logValues: true });"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -247,9 +243,8 @@
             "description": "upsert(\n  'users', // the DB table\n  'ON CONSTRAINT users_pkey', // a DB column with a unique constraint OR a CONSTRAINT NAME\n  { name: 'Elodie', id: 7 },\n  { setNull: [\"''\", \"'undefined'\"], writeSql:true, execute: true, logValues: true }\n)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -322,9 +317,8 @@
             "description": "upsertIf(\n  dataValue('name'),\n  'users', // the DB table\n  'ON CONSTRAINT users_pkey', // a DB column with a unique constraint OR a CONSTRAINT NAME\n  { name: 'Elodie', id: 7 },\n  { writeSql:true, execute: true }\n)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -405,9 +399,8 @@
             "description": "upsertMany(\n  'users', // the DB table\n  'email', // a DB column with a unique constraint OR a CONSTRAINT NAME\n  [\n    { name: 'one', email: 'one@openfn.org },\n    { name: 'two', email: 'two@openfn.org },\n  ]\n { logValues: true }\n)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -477,9 +470,8 @@
             "description": "describeTable('clinic_visits')"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -532,9 +524,8 @@
             "description": "insertTable('table_name', state => state.data.map(\n  column => ({\n    name: column.name,\n    type: column.type,\n    required: true, // optional\n    unique: false, // optional - to be set to true for unique constraint\n  })\n));"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -596,9 +587,8 @@
             "description": "modifyTable('table_name', state => state.data.map(\n  newColumn => ({\n    name: newColumn.name,\n    type: newColumn.type,\n    required: true, // optional\n    unique: false, // optional - to be set to true for unique constraint\n  })\n));"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/postgresql/src/Adaptor.js
+++ b/packages/postgresql/src/Adaptor.js
@@ -5,7 +5,7 @@ import {
 import pg from 'pg';
 import format from 'pg-format';
 
-/** @module Adaptor */
+
 
 /**
  * Execute a sequence of operations.
@@ -15,7 +15,7 @@ import format from 'pg-format';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */
@@ -152,7 +152,7 @@ function queryHandler(state, query, options) {
  * @public
  * @example
  * sql(state => `select(*) from ${state.data.tableName};`, { writeSql: true })
- * @constructor
+ * @function
  * @param {function} sqlQuery - a function which takes state and returns a
  * string of SQL.
  * @param {object} options - Optional options argument
@@ -184,7 +184,7 @@ export function sql(sqlQuery, options) {
  *    where: { first_name: 'Mamadou' },
  *    operator: { first_name: 'like' }
  *  })
- * @constructor
+ * @function
  * @param {object} filter - A filter object with the lookup table, a uuid and the condition
  * @returns {Operation}
  */
@@ -239,7 +239,7 @@ export function findValue(filter) {
  * @public
  * @example
  * insert('users', { name: 'Elodie', id: 7 }, { setNull: "'NaN'", logValues: true });
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {object} record - Payload data for the record as a JS object or function
  * @param {object} options - Optional options argument
@@ -277,7 +277,7 @@ export function insert(table, record, options) {
  * @public
  * @example
  * insertMany('users', state => state.data.recordArray, { setNull: "'undefined'", logValues: true });
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {array} records - An array or a function that takes state and returns an array
  * @param {object} options - Optional options argument
@@ -328,7 +328,7 @@ export function insertMany(table, records, options) {
  *   { name: 'Elodie', id: 7 },
  *   { setNull: ["''", "'undefined'"], writeSql:true, execute: true, logValues: true }
  * )
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {string} uuid - The uuid column to determine a matching/existing record
  * @param {object} record - Payload data for the record as a JS object or function
@@ -389,7 +389,7 @@ export function upsert(table, uuid, record, options) {
  *   { name: 'Elodie', id: 7 },
  *   { writeSql:true, execute: true }
  * )
- * @constructor
+ * @function
  * @param {string} logical - a data to check existing value for.
  * @param {string} table - The target table
  * @param {string} uuid - The uuid column to determine a matching/existing record
@@ -462,7 +462,7 @@ export function upsertIf(logical, table, uuid, record, options) {
  *   ]
  *  { logValues: true }
  * )
- * @constructor
+ * @function
  * @param {string} table - The target table
  * @param {string} uuid - The uuid column to determine a matching/existing record
  * @param {array} data - An array of objects or a function that returns an array
@@ -525,7 +525,7 @@ export function upsertMany(table, uuid, data, options) {
  * @public
  * @example
  * describeTable('clinic_visits')
- * @constructor
+ * @function
  * @param {string} tableName - The name of the table to describe
  * @param {object} options - Optional options argument
  * @returns {Operation}
@@ -561,7 +561,7 @@ export function describeTable(tableName, options) {
  *     unique: false, // optional - to be set to true for unique constraint
  *   })
  * ));
- * @constructor
+ * @function
  * @param {string} tableName - The name of the table to create
  * @param {array} columns - An array of form columns
  * @param {object} options - Optional options argument
@@ -621,7 +621,7 @@ export function insertTable(tableName, columns, options) {
  *     unique: false, // optional - to be set to true for unique constraint
  *   })
  * ));
- * @constructor
+ * @function
  * @param {string} tableName - The name of the table to alter
  * @param {array} columns - An array of form columns
  * @param {object} options - Optional options argument

--- a/packages/primero/ast.json
+++ b/packages/primero/ast.json
@@ -8,7 +8,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Get cases from Primero",
+        "description": "Get cases from Primero\n\nUse this function to get cases from Primero based on a set of query parameters.\nNote that in many implementations, the `remote` attribute should be set to `true` to ensure that only cases marked for remote access will be retrieved.\nYou can specify a `case_id` value to fetch a unique case and a query string to filter result.",
         "tags": [
           {
             "title": "public",
@@ -17,7 +17,13 @@
           },
           {
             "title": "example",
-            "description": "getCases({\n  remote: true,\n  case_id: '6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz'\n  query: 'sex=male' // optional\n}, { withReferrals: true }, callback)"
+            "description": "getCases({\n  remote: true,\n  query: \"sex=male\",\n});",
+            "caption": "Get cases from Primero with query parameters"
+          },
+          {
+            "title": "example",
+            "description": "getCases({\n  remote: true,\n  case_id: \"6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz\",\n});",
+            "caption": "Get case from Primero for a specific case id"
           },
           {
             "title": "function",
@@ -70,7 +76,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Create case in Primero",
+        "description": "Create a new case in Primero\n\nUse this function to create a new case in Primero based on a set of Data.",
         "tags": [
           {
             "title": "public",
@@ -79,7 +85,8 @@
           },
           {
             "title": "example",
-            "description": "createCase({\n  data: state => data {\n    \"enabled\": true,\n    \"age\": 15,\n    \"sex\": \"male\",\n    \"name\": \"Alex\",\n    \"status\": \"open\",\n    \"case_id\": \"6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz\",\n    \"owned_by\": \"primero_cp\"\n  }}, callback)"
+            "description": "createCase({\n  data: {\n    age: 16,\n    sex: \"female\",\n    name: \"Edwine Edgemont\",\n  },\n});",
+            "caption": "Create a new case in Primero based on a set of Data"
           },
           {
             "title": "function",
@@ -124,7 +131,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Update case in Primero",
+        "description": "Update an existing case in Primero\n\nUse this function to update an existing case from Primero.\nIn this implementation, the function uses a case ID to check for the case to update,\nThen merge the values submitted in this call into an existing case.\nFields not specified in this request will not be modified.\nFor nested subform fields, the subform arrays will be recursively merged,\nkeeping both the existing values and appending the new",
         "tags": [
           {
             "title": "public",
@@ -133,7 +140,8 @@
           },
           {
             "title": "example",
-            "description": "updateCase(\"7ed1d49f-14c7-4181-8d83-dc8ed1699f08\", {\n  data: state => data {\n    \"age\": 20,\n    \"sex\": \"male\",\n    \"name\": \"Alex\",\n    \"status\": \"open\",\n    \"case_id\": \"6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz\",\n  }}, callback)"
+            "description": "updateCase(\"6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz\", {\n  data: {\n    age: 16,\n    sex: \"female\",\n    name: \"Fiona Edgemont\",\n  },\n});",
+            "caption": "Update case for a specific case id"
           },
           {
             "title": "function",
@@ -142,7 +150,7 @@
           },
           {
             "title": "param",
-            "description": "an ID to use for the update.",
+            "description": "A case ID to use for the update.",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -186,7 +194,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Upsert case to Primero",
+        "description": "Upsert case to Primero\n\nUse this function to update an existing case from Primero or to create it otherwise.\nIn this implementation, we first fetch the list of cases,\nthen we check if the case exist before choosing the right operation to do.",
         "tags": [
           {
             "title": "public",
@@ -195,7 +203,8 @@
           },
           {
             "title": "example",
-            "description": "upsertCase({\n  externalIds: ['case_id'],\n  data: state => ({\n    \"age\": 20,\n    \"sex\": \"male\",\n    \"name\": \"Alex\",\n    \"status\": \"open\",\n    \"case_id\": \"6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz\",\n  })\n});"
+            "description": "upsertCase({\n  externalIds: [\"case_id\"],\n  data: state => ({\n    age: 20,\n    sex: \"male\",\n    name: \"Alex\",\n    status: \"open\",\n    case_id: \"6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz\",\n  }),\n});",
+            "caption": "Upsert case for a specific case id"
           },
           {
             "title": "function",
@@ -204,7 +213,7 @@
           },
           {
             "title": "param",
-            "description": "an object with an externalId and some case data.",
+            "description": "an object with an externalIds and some case data.",
             "type": {
               "type": "NameExpression",
               "name": "object"
@@ -239,7 +248,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Get referrals for a specific case in Primero",
+        "description": "Get referrals for a specific case in Primero\n\nUse this function to get the list of referrals of one case from Primero.\nThe search can be done using either `record id` or `case id`.",
         "tags": [
           {
             "title": "public",
@@ -248,7 +257,13 @@
           },
           {
             "title": "example",
-            "description": "getReferrals({\n  externalId: \"record_id\",\n  id: \"7ed1d49f-14c7-4181-8d83-dc8ed1699f08\",\n}, callback)"
+            "description": "getReferrals({\n  externalId: \"record_id\",\n  id: \"6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz\",\n});",
+            "caption": "Get referrals for a case in Primero by record id"
+          },
+          {
+            "title": "example",
+            "description": "getReferrals({\n  id: \"6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz\",\n});",
+            "caption": "Get referrals for a case in Primero by case id"
           },
           {
             "title": "function",
@@ -292,7 +307,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Create referrals in Primero",
+        "description": "Create referrals in Primero\n\nUse this function to bulk refer to one or multiple cases from Primero to a single user",
         "tags": [
           {
             "title": "public",
@@ -301,7 +316,8 @@
           },
           {
             "title": "example",
-            "description": "createReferrals({\n  data: {\n    \"ids\": ['case_id'],\n     \"transitioned_to\": \"primero_cp\",\n     \"notes\": \"Creating a referral\"\n  }\n}, callback)"
+            "description": "createReferrals({\n  data: {\n    ids: [\n      \"749e9c6e-60db-45ec-8f5a-69da7c223a79\",\n      \"dcea6052-07d9-4cfa-9abf-9a36987cdd25\",\n    ],\n    transitioned_to: \"primero_cp\",\n    notes: \"This is a bulk referral\",\n  },\n});",
+            "caption": "Create referrals for multiple cases in Primero"
           },
           {
             "title": "function",
@@ -354,7 +370,8 @@
           },
           {
             "title": "example",
-            "description": "updateReferral({\n  caseExternalId: \"record_id\",\n  caseId: \"7ed1d49f-14c7-4181-8d83-dc8ed1699f08\"\n  id: \"37612f65-3bda-48eb-b526-d31383f94166\",\n  data: state => state.data\n}, callback)"
+            "description": "updateReferral({\n  caseExternalId: \"record_id\",\n  id: \"749e9c6e-60db-45ec-8f5a-69da7c223a79\",\n  caseId: \"dcea6052-07d9-4cfa-9abf-9a36987cdd25\",\n  data: (state) => state.data,\n});",
+            "caption": "Update referral by record id"
           },
           {
             "title": "function",
@@ -363,7 +380,7 @@
           },
           {
             "title": "param",
-            "description": "an object with an externalId value to use, the id and the referral id to update.",
+            "description": "an object with an caseExternalId value to use, the id and the referral id to update.",
             "type": {
               "type": "NameExpression",
               "name": "object"
@@ -398,7 +415,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Get forms from Primero",
+        "description": "Get forms from Primero\n\nUse this function to get forms from Primero that are accessible to this user based on a set of query parameters.\nThe user can filter the form list by record type and module.",
         "tags": [
           {
             "title": "public",
@@ -407,7 +424,13 @@
           },
           {
             "title": "example",
-            "description": "getForms({\n  record_type: '' // Optional. Filters by the record type of the form,\n  module_id: 'id' //Optional. Filter forms by module,\n}, callback)"
+            "description": "getForms();",
+            "caption": "Get the list of all forms"
+          },
+          {
+            "title": "example",
+            "description": "getForms({\n  module_id: \"6aeaa66a-5a92-4ff5-bf7a-e59cde07eaaz\",\n});",
+            "caption": "Get the list of all forms for a specific module"
           },
           {
             "title": "function",
@@ -451,7 +474,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Get lookups from Primero",
+        "description": "Get lookups from Primero\n\nUse this function to get a paginated list of all lookups that are accessible to this user from Primero.\nNote: You can specify a `per` value to fetch records per page(Defaults to 20).\nAlso you can specify `page` value to fetch pagination (Defaults to 1)",
         "tags": [
           {
             "title": "public",
@@ -460,7 +483,8 @@
           },
           {
             "title": "example",
-            "description": "getLookups({\n  page: 1 // Optional. Pagination. Defaults to 1,\n  per: 20 // Optional. Records per page. Defaults to 20,\n}, callback)"
+            "description": "getLookups({\n  per: 10000,\n  page: 5\n});",
+            "caption": "Get lookups from Primero with query parameters"
           },
           {
             "title": "function",
@@ -504,7 +528,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Get locations from Primero",
+        "description": "Get locations from Primero\n\nUse this function to get a paginated list of all locations that are accessible to this user from Primero.\nNote: You can specify a `per` value to fetch records per page(Defaults to 20).\nAlso you can specify `page` value to fetch pagination (Defaults to 1).\nAnother parameter is `hierarchy: true` (Defaults to false)",
         "tags": [
           {
             "title": "public",
@@ -513,7 +537,8 @@
           },
           {
             "title": "example",
-            "description": "getLocations({\n  page: 1 // Optional.\n  per: 20 // Optional. Records per page,\n  hierarchy: // Defaults to false,\n}, callback)"
+            "description": "getLocations({\n  page: 1,\n  per: 20\n})",
+            "caption": "Get loocations from Primero with query parameters"
           },
           {
             "title": "function",

--- a/packages/primero/src/Adaptor.js
+++ b/packages/primero/src/Adaptor.js
@@ -1,4 +1,3 @@
-// /** @module Adaptor */
 import {
   execute as commonExecute,
   expandReferences,

--- a/packages/progres/src/Adaptor.js
+++ b/packages/progres/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   composeNextState,
@@ -14,7 +14,7 @@ import {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/rapidpro/src/Adaptor.js
+++ b/packages/rapidpro/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   composeNextState,

--- a/packages/salesforce/ast.json
+++ b/packages/salesforce/ast.json
@@ -20,9 +20,8 @@
             "description": "Data Sourced Value:\n relationship(\"relationship_name__r\", \"externalID on related object\", dataSource(\"path\"))\nFixed Value:\n relationship(\"relationship_name__r\", \"externalID on related object\", \"hello world\")"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -82,9 +81,8 @@
             "description": "describeAll()"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -127,9 +125,8 @@
             "description": "describe('obj_name')"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -183,9 +180,8 @@
             "description": "retrieve('ContentVersion', '0684K0000020Au7QAE/VersionData');"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -255,9 +251,8 @@
             "description": "query(`SELECT Id FROM Patient__c WHERE Health_ID__c = '${state.data.field1}'`);"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -312,9 +307,8 @@
             "description": "bulk('Patient__c', 'insert', { failOnError: true, pollInterval: 3000, pollTimeout: 240000 }, state => {\n  return state.data.someArray.map(x => {\n    return { 'Age__c': x.age, 'Name': x.name }\n  })\n});"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -395,9 +389,8 @@
             "description": "destroy('obj_name', [\n '0060n00000JQWHYAA5',\n '0090n00000JQEWHYAA5\n], { failOnError: true })"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -468,9 +461,8 @@
             "description": "create('obj_name', {\n  attr1: \"foo\",\n  attr2: \"bar\"\n})"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -533,9 +525,8 @@
             "description": "createIf(true, 'obj_name', {\n  attr1: \"foo\",\n  attr2: \"bar\"\n})"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -607,9 +598,8 @@
             "description": "upsert('obj_name', 'ext_id', {\n  attr1: \"foo\",\n  attr2: \"bar\"\n})"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -682,9 +672,8 @@
             "description": "upsertIf(true, 'obj_name', 'ext_id', {\n  attr1: \"foo\",\n  attr2: \"bar\"\n})"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -764,9 +753,8 @@
             "description": "update('obj_name', {\n  attr1: \"foo\",\n  attr2: \"bar\"\n})"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -827,9 +815,8 @@
             "description": "reference(0)"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 
 /**
  * @typedef {Object} State
@@ -31,7 +31,7 @@ const { curry, flatten } = loadash;
  *  relationship("relationship_name__r", "externalID on related object", dataSource("path"))
  * Fixed Value:
  *  relationship("relationship_name__r", "externalID on related object", "hello world")
- * @constructor
+ * @function
  * @param {string} relationshipName - `__r` relationship field on the record.
  * @param {string} externalId - Salesforce ExternalID field.
  * @param {string} dataSource - resolvable source.
@@ -51,7 +51,7 @@ export function relationship(relationshipName, externalId, dataSource) {
  * @public
  * @example
  * describeAll()
- * @constructor
+ * @function
  * @param {State} state - Runtime state.
  * @returns {State}
  */
@@ -74,7 +74,7 @@ export const describeAll = curry(function (state) {
  * @public
  * @example
  * describe('obj_name')
- * @constructor
+ * @function
  * @param {String} sObject - API name of the sObject.
  * @param {State} state - Runtime state.
  * @returns {State}
@@ -103,7 +103,7 @@ export const describe = curry(function (sObject, state) {
  * @public
  * @example
  * retrieve('ContentVersion', '0684K0000020Au7QAE/VersionData');
- * @constructor
+ * @function
  * @param {String} sObject - The sObject to retrieve
  * @param {String} id - The id of the record
  * @param {Function} callback - A callback to execute once the record is retrieved
@@ -139,7 +139,7 @@ export const retrieve = curry(function (sObject, id, callback, state) {
  * @public
  * @example
  * query(`SELECT Id FROM Patient__c WHERE Health_ID__c = '${state.data.field1}'`);
- * @constructor
+ * @function
  * @param {String} qs - A query string.
  * @param {State} state - Runtime state.
  * @returns {Operation}
@@ -174,7 +174,7 @@ export const query = curry(function (qs, state) {
  *     return { 'Age__c': x.age, 'Name': x.name }
  *   })
  * });
- * @constructor
+ * @function
  * @param {String} sObject - API name of the sObject.
  * @param {String} operation - The bulk operation to be performed
  * @param {Object} options - Options passed to the bulk api.
@@ -272,7 +272,7 @@ export const bulk = curry(function (sObject, operation, options, fun, state) {
  *  '0060n00000JQWHYAA5',
  *  '0090n00000JQEWHYAA5
  * ], { failOnError: true })
- * @constructor
+ * @function
  * @param {String} sObject - API name of the sObject.
  * @param {Object} attrs - Array of IDs of records to delete.
  * @param {Object} options - Options for the destroy delete operation.
@@ -313,7 +313,7 @@ export const destroy = curry(function (sObject, attrs, options, state) {
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
+ * @function
  * @param {String} sObject - API name of the sObject.
  * @param {Object} attrs - Field attributes for the new object.
  * @param {State} state - Runtime state.
@@ -341,7 +341,7 @@ export const create = curry(function (sObject, attrs, state) {
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
+ * @function
  * @param {boolean} logical - a logical statement that will be evaluated.
  * @param {String} sObject - API name of the sObject.
  * @param {Object} attrs - Field attributes for the new object.
@@ -378,7 +378,7 @@ export const createIf = curry(function (logical, sObject, attrs, state) {
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
+ * @function
  * @param {String} sObject - API name of the sObject.
  * @param {String} externalId - ID.
  * @param {Object} attrs - Field attributes for the new object.
@@ -414,7 +414,7 @@ export const upsert = curry(function (sObject, externalId, attrs, state) {
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
+ * @function
  * @param {boolean} logical - a logical statement that will be evaluated.
  * @param {String} sObject - API name of the sObject.
  * @param {String} externalId - ID.
@@ -466,7 +466,7 @@ export const upsertIf = curry(function (
  *   attr1: "foo",
  *   attr2: "bar"
  * })
- * @constructor
+ * @function
  * @param {String} sObject - API name of the sObject.
  * @param {Object} attrs - Field attributes for the new object.
  * @param {State} state - Runtime state.
@@ -491,7 +491,7 @@ export const update = curry(function (sObject, attrs, state) {
  * @public
  * @example
  * reference(0)
- * @constructor
+ * @function
  * @param {number} position - Position for references array.
  * @param {State} state - Array of references.
  * @returns {State}

--- a/packages/sftp/ast.json
+++ b/packages/sftp/ast.json
@@ -18,9 +18,8 @@
             "description": "list('/some/path/')"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -62,9 +61,8 @@
             "description": "getCSV(\n  '/some/path/to_file.csv'\n);"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -108,9 +106,8 @@
             "description": "putCSV(\n  '/some/path/to_local_file.csv',\n  '/some/path/to_remove_file.csv',\n  { delimiter: ';', noheader: true }\n);"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -171,9 +168,8 @@
             "description": "getJSON(\n  '/path/To/File',\n  'utf8',\n);"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {
@@ -225,9 +221,8 @@
             "description": "normalizeCSVarray({ delimiter: ';', noheader: true });"
           },
           {
-            "title": "constructor",
+            "title": "function",
             "description": null,
-            "type": null,
             "name": null
           },
           {

--- a/packages/sftp/src/Adaptor.js
+++ b/packages/sftp/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   composeNextState,
@@ -37,7 +37,7 @@ export function execute(...operations) {
  * @public
  * @example
  * list('/some/path/')
- * @constructor
+ * @function
  * @param {string} dirPath - Path to resource
  * @returns {Operation}
  */
@@ -72,7 +72,7 @@ export function list(dirPath) {
  * getCSV(
  *   '/some/path/to_file.csv'
  * );
- * @constructor
+ * @function
  * @param {string} filePath - Path to resource
  * @returns {Operation}
  */
@@ -140,7 +140,7 @@ export function getCSV(filePath) {
  *   '/some/path/to_remove_file.csv',
  *   { delimiter: ';', noheader: true }
  * );
- * @constructor
+ * @function
  * @param {string} localFilePath -  Data source for data to copy to the remote server.
  * @param {string} remoteFilePath - Path to the remote file to be created on the server.
  * @param {object} parsingOptions - Options which can be passed to adjust the read and write stream used in sending the data to the remote server
@@ -177,7 +177,7 @@ export function putCSV(localFilePath, remoteFilePath, parsingOptions) {
  *   '/path/To/File',
  *   'utf8',
  * );
- * @constructor
+ * @function
  * @param {string} filePath - Path to resource
  * @param {string} encoding - Character encoding for the json
  * @returns {Operation}
@@ -225,7 +225,7 @@ export function getJSON(filePath, encoding) {
  * @public
  * @example
  * normalizeCSVarray({ delimiter: ';', noheader: true });
- * @constructor
+ * @function
  * @param {options} options - Options passed to csvtojson parser
  * @param {callback} callback - Options passed to csvtojson parser
  * @returns {Operation}

--- a/packages/surveycto/src/Adaptor.js
+++ b/packages/surveycto/src/Adaptor.js
@@ -13,7 +13,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @constructor
+ * @function
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/template/lib/Adaptor.js
+++ b/packages/template/lib/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import { execute as commonExecute, composeNextState, expandReferences, http } from '@openfn/language-common';
 const {
   axios

--- a/packages/template/src/Adaptor.js
+++ b/packages/template/src/Adaptor.js
@@ -1,4 +1,4 @@
-/** @module Adaptor */
+
 import {
   execute as commonExecute,
   composeNextState,


### PR DESCRIPTION
## Summary

Updated `@constructor` to `@function` for all adaptors functions that we're using @`constructor`. And also removed `/** @module Adaptor */` which was causing the documentation for the adaptor function to have `Adaptor.{function}`


## Issues #190 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
