### PR TITLE
Use typedoc for magic lookup unit tests

### DIFF
--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -20,8 +20,8 @@
     "clean": "rimraf dist types docs",
     "integration-test": "mocha --experimental-specifier-resolution=node --no-warnings test/integration.cjs",
     "pack": "pnpm pack --pack-destination ../../dist",
-    "test:watch": "mocha -w --experimental-specifier-resolution=node --no-warnings \"**/*.test.js\"",
-    "test": "mocha --experimental-specifier-resolution=node --no-warnings \"test/**/*.test.js\""
+    "test:watch": "mocha -w --experimental-specifier-resolution=node --no-warnings --exclude test/integration.cjs",
+    "test": "mocha --experimental-specifier-resolution=node --no-warnings --exclude test/integration.cjs"
   },
   "author": "Open Function Group",
   "license": "LGPLv3",

--- a/packages/dhis2/src/index.js
+++ b/packages/dhis2/src/index.js
@@ -1,4 +1,3 @@
 import * as Adaptor from './Adaptor';
 export default Adaptor;
-
 export * from './Adaptor';

--- a/packages/dhis2/src/index.ts
+++ b/packages/dhis2/src/index.ts
@@ -1,48 +1,8 @@
-// TODO need complete typings to stop typedocs exploding
-declare global {
-  type Operation = any;
-  type Operations = Operation[];
-  type DataSource = any;
-  type Integer = any;
-  type State = any;
-  type Field = any;
-  type Fields = any;
-  type Value = any;
-}
-
-export type Dhis2Attribute = {
-  /**
-   * The attribute id
-   * @lookup $.children.attributes[*]
-   */
-  attribute: string;
-
-  value: any;
-};
-
-export type Dhis2Data = {
-  /**
-   * The id of an organisation unit
-   * @lookup $.children.orgUnits[*]
-   */
-  orgUnit?: string;
-
-  /**
-   * Tracked instance id
-   */
-  trackedEntityInstance?: string;
-
-  /**
-   * Tracked instance type
-   * @lookup $.children.trackedEntityTypes[*]
-   */
-  trackedEntityType?: string;
-
-  /**
-   * List of attributes
-   */
-  attributes?: Dhis2Attribute[];
-};
+// Note that if we define types inline here, we get noise and warnings from
+// typedoc in our unit tests (because of spurious "errors" in our jsdocs, including
+// from imported files)
+// Splitting the typedefs out into their own file makes testing a bit cleaner
+import './types';
 
 import * as Adaptor from './Adaptor';
 export default Adaptor;

--- a/packages/dhis2/src/index.ts
+++ b/packages/dhis2/src/index.ts
@@ -1,3 +1,15 @@
+// TODO need complete typings to stop typedocs exploding
+declare global {
+  type Operation = any;
+  type Operations = Operation[];
+  type DataSource = any;
+  type Integer = any;
+  type State = any;
+  type Field = any;
+  type Fields = any;
+  type Value = any;
+}
+
 export type Dhis2Attribute = {
   /**
    * The attribute id

--- a/packages/dhis2/src/types.ts
+++ b/packages/dhis2/src/types.ts
@@ -1,0 +1,45 @@
+// TODO need complete typings to stop typedocs exploding
+declare global {
+  type Operation = any;
+  type Operations = Operation[];
+  type DataSource = any;
+  type Integer = any;
+  type State = any;
+  type Field = any;
+  type Fields = any;
+  type Value = any;
+}
+
+export type Dhis2Attribute = {
+  /**
+   * The attribute id
+   * @lookup $.children.attributes[*]
+   */
+  attribute: string;
+
+  value: any;
+};
+
+export type Dhis2Data = {
+  /**
+   * The id of an organisation unit
+   * @lookup $.children.orgUnits[*]
+   */
+  orgUnit?: string;
+
+  /**
+   * Tracked instance id
+   */
+  trackedEntityInstance?: string;
+
+  /**
+   * Tracked instance type
+   * @lookup $.children.trackedEntityTypes[*]
+   */
+  trackedEntityType?: string;
+
+  /**
+   * List of attributes
+   */
+  attributes?: Dhis2Attribute[];
+};

--- a/packages/dhis2/src/types.ts
+++ b/packages/dhis2/src/types.ts
@@ -1,15 +1,3 @@
-// TODO need complete typings to stop typedocs exploding
-declare global {
-  type Operation = any;
-  type Operations = Operation[];
-  type DataSource = any;
-  type Integer = any;
-  type State = any;
-  type Field = any;
-  type Fields = any;
-  type Value = any;
-}
-
 export type Dhis2Attribute = {
   /**
    * The attribute id

--- a/packages/dhis2/test/metadata/lookup.test.js
+++ b/packages/dhis2/test/metadata/lookup.test.js
@@ -9,7 +9,7 @@ let queries;
 before(async () => {
   // Parse Adaptor.js and pull out all of its lookup queries
   queries = await extractLookups(
-    path.resolve('src/index.ts'),
+    path.resolve('src/types.ts'),
     path.resolve('src/Adaptor.js')
   );
 });

--- a/packages/dhis2/test/metadata/lookup.test.js
+++ b/packages/dhis2/test/metadata/lookup.test.js
@@ -8,18 +8,35 @@ let queries;
 
 before(async () => {
   // Parse Adaptor.js and pull out all of its lookup queries
-  queries = await extractLookups(path.resolve('src/Adaptor.js'));
+  queries = await extractLookups(
+    path.resolve('src/index.ts'),
+    path.resolve('src/Adaptor.js')
+  );
 });
 
 describe('DHIS2 lookup tests', async () => {
   // Unit tests of each query against a sample model
   describe('create', () => {
-    it('should list resourceTypes', () => {
+    it('resourceType: should list resourceTypes', () => {
       const results = jp.query(data, queries.create.resourceType);
+      // TODO the cached model is actually out of dae
       expect(results).to.have.lengthOf(4);
-      expect(results[0]).to.equal('trackedEntityInstances');
+      expect(results).to.include('trackedEntityInstances');
+      expect(results).to.include('events');
+      expect(results).to.include('programs');
     });
+  });
 
-    // TODO what about testing the lookups on the typescript though?
+  // Query against a type interface
+  // This sort of works but there's a lot of problems in the set up
+  describe('Dhis2Data', () => {
+    it('should list orgUnits', () => {
+      const results = jp.query(data, queries.Dhis2Data.orgUnit);
+      expect(results).to.have.lengthOf(1334);
+
+      const [first] = results;
+      expect(first.name).to.equal('y4kDUliaw7e');
+      expect(first.type).to.equal('orgUnit');
+    });
   });
 });

--- a/packages/dhis2/tsconfig.json
+++ b/packages/dhis2/tsconfig.json
@@ -1,21 +1,13 @@
 {
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "*.d.ts"],
   "compilerOptions": {
+    "outDir": "dist-tmp",
     "allowJs": true,
     "esModuleInterop": true,
     "isolatedModules": true,
     "moduleResolution": "node",
-    "noImplicitAny": false,
-    "preserveConstEnums": true,
-    "removeComments": false,
-    "resolveJsonModule": true,
-    "sourceMap": false,
-    "strictNullChecks": false,
     "target": "ES2020",
     "module": "es2020"
-    // "declaration": true,
-    // "declarationDir": "types",
-    // "emitDeclarationOnly": true
   }
 }

--- a/packages/dhis2/tsconfig.json
+++ b/packages/dhis2/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "preserveConstEnums": true,
+    "removeComments": false,
+    "resolveJsonModule": true,
+    "sourceMap": false,
+    "strictNullChecks": false,
+    "target": "ES2020",
+    "module": "es2020"
+    // "declaration": true,
+    // "declarationDir": "types",
+    // "emitDeclarationOnly": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1439,6 +1439,7 @@ importers:
       esno: 0.16.3
       jsdoc-to-markdown: ^7.1.1
       ts-node: 10.9.1
+      typedoc: ^0.23.26
       typescript: 4.8.4
     dependencies:
       '@types/jsdoc-to-markdown': 7.0.3
@@ -1447,6 +1448,7 @@ importers:
       esno: 0.16.3
       jsdoc-to-markdown: 7.1.1
       ts-node: 10.9.1_evej5wzm4hojmu6uzxwpspdmsu
+      typedoc: 0.23.26_typescript@4.8.4
       typescript: 4.8.4
 
 packages:
@@ -2551,6 +2553,10 @@ packages:
   /ansi-regex/6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
+    dev: false
+
+  /ansi-sequence-parser/1.1.0:
+    resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
     dev: false
 
   /ansi-styles/2.2.1:
@@ -7410,6 +7416,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  /jsonc-parser/3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+    dev: false
+
   /jsonfile/4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
@@ -7781,6 +7791,10 @@ packages:
     dependencies:
       yallist: 4.0.0
 
+  /lunr/2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+    dev: false
+
   /mailgun-js/0.22.0:
     resolution: {integrity: sha512-a2alg5nuTZA9Psa1pSEIEsbxr1Zrmqx4VkgGCQ30xVh0kIH7Bu57AYILo+0v8QLSdXtCyLaS+KVmdCrQo0uWFA==}
     engines: {node: '>=6.0.0'}
@@ -7857,6 +7871,12 @@ packages:
 
   /marked/4.1.1:
     resolution: {integrity: sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==}
+    engines: {node: '>= 12'}
+    hasBin: true
+    dev: false
+
+  /marked/4.2.12:
+    resolution: {integrity: sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==}
     engines: {node: '>= 12'}
     hasBin: true
     dev: false
@@ -8058,6 +8078,13 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
+
+  /minimatch/7.4.1:
+    resolution: {integrity: sha512-Oz1iPEP+MGl7KS3SciLsLLcuZ7VsBfb7Qrz/jYt/s/sYAv272P26HSLz2f77Y6hzTKXiBi6g765fqpEDNc5fJw==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimist-options/4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -9885,6 +9912,15 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  /shiki/0.14.1:
+    resolution: {integrity: sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==}
+    dependencies:
+      ansi-sequence-parser: 1.1.0
+      jsonc-parser: 3.2.0
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 8.0.0
+    dev: false
+
   /side-channel/1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
@@ -11070,6 +11106,20 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
 
+  /typedoc/0.23.26_typescript@4.8.4:
+    resolution: {integrity: sha512-5m4KwR5tOLnk0OtMaRn9IdbeRM32uPemN9kur7YK9wFqx8U0CYrvO9aVq6ysdZSV1c824BTm+BuQl2Ze/k1HtA==}
+    engines: {node: '>= 14.14'}
+    hasBin: true
+    peerDependencies:
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x
+    dependencies:
+      lunr: 2.3.9
+      marked: 4.2.12
+      minimatch: 7.4.1
+      shiki: 0.14.1
+      typescript: 4.8.4
+    dev: false
+
   /typescript/4.8.4:
     resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
     engines: {node: '>=4.2.0'}
@@ -11273,6 +11323,14 @@ packages:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
+    dev: false
+
+  /vscode-oniguruma/1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
+    dev: false
+
+  /vscode-textmate/8.0.0:
+    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
     dev: false
 
   /walk-back/2.0.1:

--- a/tools/parse-jsdoc/package.json
+++ b/tools/parse-jsdoc/package.json
@@ -19,6 +19,7 @@
     "esno": "0.16.3",
     "jsdoc-to-markdown": "^7.1.1",
     "ts-node": "10.9.1",
+    "typedoc": "^0.23.26",
     "typescript": "4.8.4"
   }
 }

--- a/tools/parse-jsdoc/src/extract-lookups.ts
+++ b/tools/parse-jsdoc/src/extract-lookups.ts
@@ -9,7 +9,6 @@ type LookupMap = {
 
 const extractJsLookups = async (path: string) => {
   const operations = await parseOperations(path);
-
   return operations?.reduce((result: LookupMap, fn) => {
     if (fn.params) {
       result[fn.name] = fn.params.reduce((params, p) => {

--- a/tools/parse-jsdoc/src/extract-lookups.ts
+++ b/tools/parse-jsdoc/src/extract-lookups.ts
@@ -1,4 +1,5 @@
 import parseOperations from './parse-operations';
+import parseTs from './parse-ts';
 
 type LookupMap = {
   [operation: string]: {
@@ -6,24 +7,60 @@ type LookupMap = {
   };
 };
 
-// Get a map of lookup queries for the parameters of each operation in a file.
-// This function will parse the jsdoc of the file at the provided path
-// It will return a map of operations, and for each operation,
-// a key/value pair of the parameter name and its lookup query
-const extractLookups = async (path: string) => {
+const extractJsLookups = async (path: string) => {
   const operations = await parseOperations(path);
 
-  const result: LookupMap = operations.reduce((acc, fn) => {
+  return operations?.reduce((result: LookupMap, fn) => {
     if (fn.params) {
-      acc[fn.name] = fn.params.reduce((params, p) => {
+      result[fn.name] = fn.params.reduce((params, p) => {
         if (p.lookup) {
           params[p.name] = p.lookup;
         }
         return params;
       }, {} as { [paramName: string]: string });
     }
-    return acc;
-  }, {} as LookupMap);
+    return result;
+  }, {});
+};
+
+const extractTsLookups = async (path: string) => {
+  const types = await parseTs(path);
+
+  return types?.reduce((result: LookupMap, iface) => {
+    // TODO come back and look at typings
+    // @ts-ignore
+    const lookups = iface.type?.declaration?.children
+      .filter((dec: any) => dec.kindString === 'Property')
+      .reduce((acc: any, prop: any) => {
+        if (prop.comment?.blockTags?.length) {
+          const lookup = prop.comment?.blockTags?.find(
+            ({ tag }: any) => tag === '@lookup'
+          );
+          if (lookup) {
+            acc[prop.name] = lookup.content[0].text;
+          }
+        }
+        return acc;
+      }, {} as { [propName: string]: string });
+    if (Object.keys(lookups).length) {
+      result[iface.name] = lookups;
+    }
+    return result;
+  }, {});
+};
+
+// Get a map of lookup queries for the parameters of each operation in a file.
+// This function will parse the jsdoc of the file at the provided path
+// It will return a map of operations, and for each operation,
+// a key/value pair of the parameter name and its lookup query
+const extractLookups = async (...paths: string[]) => {
+  const result: LookupMap = {};
+
+  for (const p of paths) {
+    const fn = p.endsWith('.ts') ? extractTsLookups : extractJsLookups;
+    Object.assign(result, await fn(p));
+  }
+
   return result;
 };
 

--- a/tools/parse-jsdoc/src/parse-operations.ts
+++ b/tools/parse-jsdoc/src/parse-operations.ts
@@ -33,7 +33,6 @@ type JSDocReturn = {
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// TODO can I just use typedoc for this so that I only have to have one interface?
 const parseOperations = async (pathToSource: string) => {
   const parsed = (await jsdoc2md.getJsdocData({
     files: [pathToSource],

--- a/tools/parse-jsdoc/src/parse-operations.ts
+++ b/tools/parse-jsdoc/src/parse-operations.ts
@@ -33,6 +33,7 @@ type JSDocReturn = {
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// TODO can I just use typedoc for this so that I only have to have one interface?
 const parseOperations = async (pathToSource: string) => {
   const parsed = (await jsdoc2md.getJsdocData({
     files: [pathToSource],

--- a/tools/parse-jsdoc/src/parse-ts.ts
+++ b/tools/parse-jsdoc/src/parse-ts.ts
@@ -9,6 +9,8 @@ export default async (pathToSource: string, pathToTsConfig?: string) => {
 
   const options = {
     entryPoints: [pathToSource],
+    // Ignore errors (our adaptors have a lot of undefined types, like Operation)
+    skipErrorChecking: true,
   } as Partial<TypeDocOptions>;
 
   // If not defined, this will look in the working dir (usually the adaptor dir) for a tsconfig

--- a/tools/parse-jsdoc/src/parse-ts.ts
+++ b/tools/parse-jsdoc/src/parse-ts.ts
@@ -2,51 +2,23 @@ import TypeDoc from 'typedoc';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
 
-const dirname = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-
-export default async (pathToSource: string) => {
-  const dir = path.dirname(pathToSource);
+export default async (pathToSource: string, pathToTsConfig?: string) => {
   const app = new TypeDoc.Application();
 
   const s = new TypeDoc.Serializer();
 
   app.options.addReader(new TypeDoc.TSConfigReader());
+
   app.bootstrap({
     entryPoints: [pathToSource],
     showConfig: true,
 
-    // TODO lots of wierd warnings come from common... wat can we do about externals?
-    // this doesn't seem to help..
+    // TODO lots of weird warnings come from common... what can we do about externals?
+    // this doesn't seem to help...
     excludeExternals: true,
 
-    // dodgy pathing
-    // having to pass a path here is a real pain - can't I just pass all the options I need?
-    // Or an inline object?
-    basePath: dir, // doesn't do what I think it does
-
-    // Ideally this would use the tsconfig in the "hosting" pckage
-    // ie, if running from dhis2 tests, it should use dhis2's config
-    // But the config for the doc build and the config for tests is kinda different
-    // This package's tests actually fail if we use its tsconfig (because includes is wrong)
-    // tsconfig: `${dirname}/tsconfig.parser.json`,
-    // tsconfig: path.resolve('../../tools/parse-jsdoc/tsconfig.parser.json'),
-
-    // includes: ['../../**/*.ts'],
-    // tsconfig: {
-    //   // dodgy include pathing
-    //   "include": ["../../**/*.ts"],
-    //   "compilerOptions": {
-    //     "strict": false,
-    //     "module": "es2020",
-    //     "moduleResolution": "node",
-    //     "allowSyntheticDefaultImports": true,
-    //     "skipLibCheck": true
-    //   }
-    // }
-
-    compilerOptions: {
-      strict: false,
-    },
+    // If not defined, this will look in the working dir (usually the adaptor dir) for a tsconfig
+    tsconfig: pathToTsConfig,
   });
 
   const project = app.convert();

--- a/tools/parse-jsdoc/src/parse-ts.ts
+++ b/tools/parse-jsdoc/src/parse-ts.ts
@@ -1,6 +1,4 @@
 import TypeDoc from 'typedoc';
-import path from 'node:path';
-import { fileURLToPath } from 'url';
 
 export default async (pathToSource: string, pathToTsConfig?: string) => {
   const app = new TypeDoc.Application();

--- a/tools/parse-jsdoc/src/parse-ts.ts
+++ b/tools/parse-jsdoc/src/parse-ts.ts
@@ -1,0 +1,59 @@
+import TypeDoc from 'typedoc';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+
+const dirname = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+export default async (pathToSource: string) => {
+  const dir = path.dirname(pathToSource);
+  const app = new TypeDoc.Application();
+
+  const s = new TypeDoc.Serializer();
+
+  app.options.addReader(new TypeDoc.TSConfigReader());
+  app.bootstrap({
+    entryPoints: [pathToSource],
+    showConfig: true,
+
+    // TODO lots of wierd warnings come from common... wat can we do about externals?
+    // this doesn't seem to help..
+    excludeExternals: true,
+
+    // dodgy pathing
+    // having to pass a path here is a real pain - can't I just pass all the options I need?
+    // Or an inline object?
+    basePath: dir, // doesn't do what I think it does
+
+    // Ideally this would use the tsconfig in the "hosting" pckage
+    // ie, if running from dhis2 tests, it should use dhis2's config
+    // But the config for the doc build and the config for tests is kinda different
+    // This package's tests actually fail if we use its tsconfig (because includes is wrong)
+    // tsconfig: `${dirname}/tsconfig.parser.json`,
+    // tsconfig: path.resolve('../../tools/parse-jsdoc/tsconfig.parser.json'),
+
+    // includes: ['../../**/*.ts'],
+    // tsconfig: {
+    //   // dodgy include pathing
+    //   "include": ["../../**/*.ts"],
+    //   "compilerOptions": {
+    //     "strict": false,
+    //     "module": "es2020",
+    //     "moduleResolution": "node",
+    //     "allowSyntheticDefaultImports": true,
+    //     "skipLibCheck": true
+    //   }
+    // }
+
+    compilerOptions: {
+      strict: false,
+    },
+  });
+
+  const project = app.convert();
+  const json = s.projectToObject(project!);
+
+  // Return all type aliases in the file
+  return (
+    json.children?.filter(thing => thing.kindString === 'Type alias') ?? []
+  );
+};

--- a/tools/parse-jsdoc/src/parse-ts.ts
+++ b/tools/parse-jsdoc/src/parse-ts.ts
@@ -1,4 +1,4 @@
-import TypeDoc from 'typedoc';
+import TypeDoc, { TypeDocOptions } from 'typedoc';
 
 export default async (pathToSource: string, pathToTsConfig?: string) => {
   const app = new TypeDoc.Application();
@@ -7,17 +7,16 @@ export default async (pathToSource: string, pathToTsConfig?: string) => {
 
   app.options.addReader(new TypeDoc.TSConfigReader());
 
-  app.bootstrap({
+  const options = {
     entryPoints: [pathToSource],
-    showConfig: true,
+  } as Partial<TypeDocOptions>;
 
-    // TODO lots of weird warnings come from common... what can we do about externals?
-    // this doesn't seem to help...
-    excludeExternals: true,
+  // If not defined, this will look in the working dir (usually the adaptor dir) for a tsconfig
+  if (pathToTsConfig) {
+    options.tsconfig = pathToTsConfig;
+  }
 
-    // If not defined, this will look in the working dir (usually the adaptor dir) for a tsconfig
-    tsconfig: pathToTsConfig,
-  });
+  app.bootstrap(options);
 
   const project = app.convert();
   const json = s.projectToObject(project!);

--- a/tools/parse-jsdoc/test/extract-lookups.test.ts
+++ b/tools/parse-jsdoc/test/extract-lookups.test.ts
@@ -7,6 +7,6 @@ test('should extract lookups for function parameters', async t => {
     path.resolve('test/fixtures/operation-const.js')
   );
 
-  t.false(result.operation.x);
+  t.falsy(result.operation.x);
   t.is(result.operation.y, '$[*]');
 });

--- a/tools/parse-jsdoc/test/extract-lookups.test.ts
+++ b/tools/parse-jsdoc/test/extract-lookups.test.ts
@@ -1,9 +1,9 @@
 import test from 'ava';
 import path from 'node:path';
-import extractQueries from '../src/extract-lookups';
+import extractLookups from '../src/extract-lookups';
 
-test('should extract queries', async t => {
-  const result = await extractQueries(
+test('should extract lookups for function parameters', async t => {
+  const result = await extractLookups(
     path.resolve('test/fixtures/operation-const.js')
   );
 

--- a/tools/parse-jsdoc/test/fixtures/types.ts
+++ b/tools/parse-jsdoc/test/fixtures/types.ts
@@ -1,0 +1,9 @@
+export type Dhis2Attribute = {
+  /**
+   * The attribute id
+   * @lookup $.children.attributes[*]
+   */
+  attribute: string;
+
+  value: any;
+};

--- a/tools/parse-jsdoc/test/parse-operations.test.ts
+++ b/tools/parse-jsdoc/test/parse-operations.test.ts
@@ -20,7 +20,6 @@ test('should parse a single operation (as a const)', async t => {
   const result = await parseOperations(
     path.resolve('test/fixtures/operation-const.js')
   );
-  console.log(result);
 
   t.assert(result.length === 1);
 

--- a/tools/parse-jsdoc/test/parse-operations.test.ts
+++ b/tools/parse-jsdoc/test/parse-operations.test.ts
@@ -16,7 +16,7 @@ test('should parse a single operation (as a function)', async t => {
   t.assert(fn.returns.length === 1);
 });
 
-test.only('should parse a single operation (as a const)', async t => {
+test('should parse a single operation (as a const)', async t => {
   const result = await parseOperations(
     path.resolve('test/fixtures/operation-const.js')
   );

--- a/tools/parse-jsdoc/test/parse-ts.test.ts
+++ b/tools/parse-jsdoc/test/parse-ts.test.ts
@@ -3,7 +3,10 @@ import path from 'node:path';
 import parseTs from '../src/parse-ts';
 
 test('should parse a single interface', async t => {
-  const result = await parseTs(path.resolve('test/fixtures/types.ts'));
+  const result = await parseTs(
+    path.resolve('test/fixtures/types.ts'),
+    path.resolve('tsconfig.test.json')
+  );
 
   t.assert(result.length === 1);
 

--- a/tools/parse-jsdoc/test/parse-ts.test.ts
+++ b/tools/parse-jsdoc/test/parse-ts.test.ts
@@ -1,0 +1,19 @@
+import test from 'ava';
+import path from 'node:path';
+import parseTs from '../src/parse-ts';
+
+test('should parse a single interface', async t => {
+  const result = await parseTs(path.resolve('test/fixtures/types.ts'));
+
+  t.assert(result.length === 1);
+
+  const [iface] = result;
+  t.is(iface.name, 'Dhis2Attribute');
+  // @ts-ignore
+  const props = iface.type?.declaration?.children;
+  t.is(props.length, 2);
+
+  const [attr] = props;
+  t.is(attr.kindString, 'Property');
+  t.is(attr.comment.summary[0].text, 'The attribute id');
+});

--- a/tools/parse-jsdoc/test/parse-ts.test.ts
+++ b/tools/parse-jsdoc/test/parse-ts.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import path from 'node:path';
-import { ReflectionType } from 'typedoc';
+import { DeclarationReflection, ReflectionType } from 'typedoc';
 
 import parseTs from '../src/parse-ts';
 
@@ -15,7 +15,8 @@ test('should parse a single interface', async t => {
   const [iface] = result;
   t.is(iface.name, 'Dhis2Attribute');
 
-  const props = (iface.type as ReflectionType).declaration.children ?? [];
+  const props =
+    (iface.type as unknown as ReflectionType).declaration.children ?? [];
   t.is(props.length, 2);
 
   const [attr] = props;

--- a/tools/parse-jsdoc/test/parse-ts.test.ts
+++ b/tools/parse-jsdoc/test/parse-ts.test.ts
@@ -1,5 +1,7 @@
 import test from 'ava';
 import path from 'node:path';
+import { ReflectionType } from 'typedoc';
+
 import parseTs from '../src/parse-ts';
 
 test('should parse a single interface', async t => {
@@ -12,11 +14,11 @@ test('should parse a single interface', async t => {
 
   const [iface] = result;
   t.is(iface.name, 'Dhis2Attribute');
-  // @ts-ignore
-  const props = iface.type?.declaration?.children;
+
+  const props = (iface.type as ReflectionType).declaration.children ?? [];
   t.is(props.length, 2);
 
   const [attr] = props;
   t.is(attr.kindString, 'Property');
-  t.is(attr.comment.summary[0].text, 'The attribute id');
+  t.is(attr.comment?.summary[0].text, 'The attribute id');
 });

--- a/tools/parse-jsdoc/tsconfig.parser.json
+++ b/tools/parse-jsdoc/tsconfig.parser.json
@@ -1,0 +1,11 @@
+{
+  // dodgy include pathing
+  "include": ["**/*.ts"],
+  "compilerOptions": {
+    "strict": false,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
+  }
+}

--- a/tools/parse-jsdoc/tsconfig.test.json
+++ b/tools/parse-jsdoc/tsconfig.test.json
@@ -1,6 +1,5 @@
 {
-  // dodgy include pathing
-  "include": ["**/*.ts"],
+  "include": ["test/**/*.ts"],
   "compilerOptions": {
     "strict": false,
     "module": "es2020",


### PR DESCRIPTION
So we have a problem in #196 that we can't unit test magic lookups define in typescript files (ie, all the interesting stuff in dhis2).

This is pretty bad for devx because the model of being able to unit test directly against the jsdoc is gonna be really improtant.

This PR uses `typedoc` to parse `index.ts` and pull out any jsdoc annotations on object interfaces.

It basically works - there's a working unit test! - but I'm having some major drama in finding a config that works across all packages (including tools). Not going to document this in much detail just yet.

Basically when I call typedoc I want to pass in a tsconfig directly. But it stubbornly only accept a path to a tsconfig, which makes it hard to dynamically alter a config to suit a different package. There will be a solution but I need to hammer it around some more.

Still to do:

* [x] Sort out the the tsconfig thing (which is killing me)
*  [x] ~~Replace jsdoc2md  with typedoc ~~
* [x] Clear up the error/warning spam coming out of typedoc