### PR TITLE
Release - magic functions

### DIFF
--- a/.changeset/wicked-lemons-punch.md
+++ b/.changeset/wicked-lemons-punch.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-dhis2': patch
+'@openfn/language-salesforce': patch
+---
+
+Add @magic annotations

--- a/.changeset/wicked-lemons-punch.md
+++ b/.changeset/wicked-lemons-punch.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-dhis2': patch
-'@openfn/language-salesforce': patch
----
-
-Add @magic annotations

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-dhis2
 
+## 3.2.7
+
+### Patch Changes
+
+- c09b821: Add @magic annotations
+
 ## 3.2.6
 
 ### Patch Changes

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dhis2",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "DHIS2 Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-salesforce
 
+## 3.0.1
+
+### Patch Changes
+
+- c09b821: Add @magic annotations
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {


### PR DESCRIPTION
This PR bumps versions in `dhis2` and `salesforce` to include jsdoc annotations,

PR #196 did not include changesets as there aren't really any public changes (only a custom jsdoc annotation).

What I didn't really think about was that this means no release candidates were build when running `pnpm publish`, which I guess on reflection makes sense!

So I've bumped the versions here which should trigger a proper release.

To release, you'll need to:
* Install
* Build
* Publish