### PR TITLE
Fix dhis2  `apiVersion` url build

### DIFF
--- a/.changeset/kind-candles-arrive.md
+++ b/.changeset/kind-candles-arrive.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-dhis2': patch
+---
+
+update buildUrl to handle api version

--- a/packages/dhis2/src/Utils.js
+++ b/packages/dhis2/src/Utils.js
@@ -23,8 +23,10 @@ export class Log {
 }
 
 export function buildUrl(urlString, hostUrl, apiVersion) {
-  const pathSuffix = apiVersion ? `/${apiVersion}${urlString}` : `${urlString}`;
-  return hostUrl + '/api' + pathSuffix;
+  const pathSuffix = apiVersion
+    ? `/${apiVersion}/api${urlString}`
+    : `/api${urlString}`;
+  return hostUrl + pathSuffix;
 }
 
 /**


### PR DESCRIPTION
## Summary

`apiVersion` configuration was not properly built using in `DHIS2` adaptor, i updated the `buildUlr` utility function to properly build a valid DHIS2 API endpoint   

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
