### PR TITLE
Fix salesforce 3

### DIFF
--- a/.changeset/lovely-doors-joke.md
+++ b/.changeset/lovely-doors-joke.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-salesforce': patch
+---
+
+Fix dependencies

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -31,7 +31,6 @@
   ],
   "dependencies": {
     "@openfn/language-common": "1.7.5",
-    "@openfn/parse-jsdoc": "workspace:^1.0.0",
     "JSONPath": "^0.10.0",
     "axios": "^0.21.1",
     "jsforce": "^1.11.0",
@@ -41,6 +40,7 @@
     "yargs": "^3.30.0"
   },
   "devDependencies": {
+    "@openfn/parse-jsdoc": "workspace:^1.0.0",
     "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/metadata": "workspace:^1.0.0",
     "@openfn/simple-ast": "0.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1113,7 +1113,6 @@ importers:
       yargs: ^3.30.0
     dependencies:
       '@openfn/language-common': link:../common
-      '@openfn/parse-jsdoc': link:../../tools/parse-jsdoc
       JSONPath: 0.10.0
       axios: 0.21.4
       jsforce: 1.11.0
@@ -1124,6 +1123,7 @@ importers:
     devDependencies:
       '@openfn/buildtools': link:../../tools/build
       '@openfn/metadata': link:../../tools/metadata
+      '@openfn/parse-jsdoc': link:../../tools/parse-jsdoc
       '@openfn/simple-ast': 0.4.1
       assertion-error: 1.1.0
       chai: 4.3.6


### PR DESCRIPTION
Salesforce 3 incorrectly has a dependency on internal tooling `parse-jsdoc`. This is a magic function thing.

This PR reduces it to a dev dependency which means it should work in prod.

I've checked dhis2, which also has magic, and that appears to be fine.

Suggest we release straight from this branch, then merge.