### PR TITLE
update adaptors docs build command

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -8,7 +8,7 @@ rm -rf tmp/*
 pnpm install --frozen-lockfile
 
 # build new docs
-pnpm -r run build docs
+pnpm build:adaptors docs
 
 # copy new packages docs files to the root docs directory
 # rsync -pr packages/*/docs/ docs/


### PR DESCRIPTION
## Summary

The docs build command `pnpm -r build docs` was broken due to introduced changes. I have updated the command to `pnpm build:adaptors docs` which will build docs for all adaptors 

closes #219 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
