### PR TITLE
Mark `execute` as `@private`

### DIFF
--- a/.changeset/fuzzy-deers-obey.md
+++ b/.changeset/fuzzy-deers-obey.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': patch
+---
+
+mark execute private and ast build

--- a/.changeset/silly-hairs-matter.md
+++ b/.changeset/silly-hairs-matter.md
@@ -1,0 +1,43 @@
+---
+'@openfn/language-asana': patch
+'@openfn/language-beyonic': patch
+'@openfn/language-bigquery': patch
+'@openfn/language-cartodb': patch
+'@openfn/language-commcare': patch
+'@openfn/language-dhis2': patch
+'@openfn/language-dynamics': patch
+'@openfn/language-facebook': patch
+'@openfn/language-fhir': patch
+'@openfn/language-godata': patch
+'@openfn/language-googlesheets': patch
+'@openfn/language-http': patch
+'@openfn/language-khanacademy': patch
+'@openfn/language-kobotoolbox': patch
+'@openfn/language-magpi': patch
+'@openfn/language-mailchimp': patch
+'@openfn/language-mailgun': patch
+'@openfn/language-maximo': patch
+'@openfn/language-medicmobile': patch
+'@openfn/language-mssql': patch
+'@openfn/language-mysql': patch
+'@openfn/language-nexmo': patch
+'@openfn/language-ocl': patch
+'@openfn/language-openfn': patch
+'@openfn/language-openhim': patch
+'@openfn/language-openmrs': patch
+'@openfn/language-postgresql': patch
+'@openfn/language-primero': patch
+'@openfn/language-progres': patch
+'@openfn/language-rapidpro': patch
+'@openfn/language-resourcemap': patch
+'@openfn/language-sftp': patch
+'@openfn/language-smpp': patch
+'@openfn/language-surveycto': patch
+'@openfn/language-telerivet': patch
+'@openfn/language-template': patch
+'@openfn/language-twilio': patch
+'@openfn/language-vtiger': patch
+'@openfn/language-zoho': patch
+---
+
+mark execute as private

--- a/packages/asana/src/Adaptor.js
+++ b/packages/asana/src/Adaptor.js
@@ -13,7 +13,7 @@ import {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/beyonic/src/Adaptor.js
+++ b/packages/beyonic/src/Adaptor.js
@@ -13,7 +13,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/bigquery/src/Adaptor.js
+++ b/packages/bigquery/src/Adaptor.js
@@ -18,7 +18,7 @@ import { resolve } from 'path';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/cartodb/src/Adaptor.js
+++ b/packages/cartodb/src/Adaptor.js
@@ -17,7 +17,7 @@ const jsonSql = jsonSqlPkg();
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Array} ...operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -20,7 +20,7 @@ import xlsx from 'xlsx';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -18,9 +18,9 @@
             "description": "execute(\n   create('foo'),\n   delete('bar')\n )"
           },
           {
-            "title": "function",
+            "title": "private",
             "description": null,
-            "name": null
+            "type": null
           },
           {
             "title": "param",

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -16,7 +16,7 @@ export * as dateFns from './dateFns';
  *    create('foo'),
  *    delete('bar')
  *  )
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Promise}
  */

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -25,7 +25,7 @@ const { indexOf } = _;
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/dynamics/src/Adaptor.js
+++ b/packages/dynamics/src/Adaptor.js
@@ -15,7 +15,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/facebook/src/Adaptor.js
+++ b/packages/facebook/src/Adaptor.js
@@ -15,7 +15,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/fhir/src/Adaptor.js
+++ b/packages/fhir/src/Adaptor.js
@@ -17,7 +17,7 @@ export { axios };
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/godata/src/Adaptor.js
+++ b/packages/godata/src/Adaptor.js
@@ -14,7 +14,7 @@ import axios from 'axios';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -14,7 +14,7 @@ import { google } from "googleapis";
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -31,7 +31,7 @@ const { axios } = http;
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/khanacademy/src/Adaptor.js
+++ b/packages/khanacademy/src/Adaptor.js
@@ -16,7 +16,7 @@ import qs from 'qs';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -15,7 +15,7 @@ import {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/magpi/src/Adaptor.js
+++ b/packages/magpi/src/Adaptor.js
@@ -16,7 +16,7 @@ import xml2js from 'xml2js';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/mailchimp/src/Adaptor.js
+++ b/packages/mailchimp/src/Adaptor.js
@@ -17,7 +17,7 @@ import { resolve } from 'path';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/mailgun/src/Adaptor.js
+++ b/packages/mailgun/src/Adaptor.js
@@ -17,7 +17,7 @@ import request from "sync-request";
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/maximo/src/Adaptor.js
+++ b/packages/maximo/src/Adaptor.js
@@ -17,7 +17,7 @@ import utf8 from 'utf8';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/medicmobile/src/Adaptor.js
+++ b/packages/medicmobile/src/Adaptor.js
@@ -15,7 +15,7 @@ import _ from 'lodash';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -58,7 +58,7 @@ function createConnection(state) {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/mysql/src/Adaptor.js
+++ b/packages/mysql/src/Adaptor.js
@@ -16,7 +16,7 @@ import squel from 'squel';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/nexmo/src/Adaptor.js
+++ b/packages/nexmo/src/Adaptor.js
@@ -13,7 +13,7 @@ import Nexmo from 'nexmo';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/ocl/src/Adaptor.js
+++ b/packages/ocl/src/Adaptor.js
@@ -17,7 +17,7 @@ export { axios };
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/openfn/src/Adaptor.js
+++ b/packages/openfn/src/Adaptor.js
@@ -22,7 +22,7 @@ const defaultHeaders = { 'User-Agent': `language-openfn-v${version}` };
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/openhim/src/Adaptor.js
+++ b/packages/openhim/src/Adaptor.js
@@ -15,7 +15,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -17,7 +17,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Array} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/postgresql/src/Adaptor.js
+++ b/packages/postgresql/src/Adaptor.js
@@ -15,7 +15,7 @@ import format from 'pg-format';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/primero/src/Adaptor.js
+++ b/packages/primero/src/Adaptor.js
@@ -26,7 +26,7 @@ const composeNextState = (state, data, meta) => {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/progres/src/Adaptor.js
+++ b/packages/progres/src/Adaptor.js
@@ -14,7 +14,7 @@ import {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/rapidpro/src/Adaptor.js
+++ b/packages/rapidpro/src/Adaptor.js
@@ -17,7 +17,7 @@ export { axios };
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/resourcemap/src/Adaptor.js
+++ b/packages/resourcemap/src/Adaptor.js
@@ -12,7 +12,7 @@ import request from 'request';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/sftp/src/Adaptor.js
+++ b/packages/sftp/src/Adaptor.js
@@ -19,7 +19,7 @@ import { stat } from 'fs';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/smpp/src/Adaptor.js
+++ b/packages/smpp/src/Adaptor.js
@@ -12,7 +12,7 @@ import request from 'request';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/surveycto/src/Adaptor.js
+++ b/packages/surveycto/src/Adaptor.js
@@ -13,7 +13,7 @@ import { resolve as resolveUrl } from 'url';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/telerivet/src/Adaptor.js
+++ b/packages/telerivet/src/Adaptor.js
@@ -12,7 +12,7 @@ import { post } from './Client';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/template/lib/Adaptor.js
+++ b/packages/template/lib/Adaptor.js
@@ -11,7 +11,7 @@ const {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/template/src/Adaptor.js
+++ b/packages/template/src/Adaptor.js
@@ -16,7 +16,7 @@ const { axios } = http;
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/twilio/src/Adaptor.js
+++ b/packages/twilio/src/Adaptor.js
@@ -12,7 +12,7 @@ import {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/vtiger/src/Adaptor.js
+++ b/packages/vtiger/src/Adaptor.js
@@ -23,7 +23,7 @@ function assembleError({ response, error }) {
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */

--- a/packages/zoho/src/Adaptor.js
+++ b/packages/zoho/src/Adaptor.js
@@ -12,7 +12,7 @@ import { post } from './Client';
  *   create('foo'),
  *   delete('bar')
  * )(state)
- * @function
+ * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}
  */


### PR DESCRIPTION
## Summary

Mark the `execute()` function as `@private` in all adaptos except `common`


## Issues

In docs [#332](https://github.com/OpenFn/docs/issues/332)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
