### PR TITLE
Better dev dependencies

### DIFF
--- a/.changeset/great-islands-prove.md
+++ b/.changeset/great-islands-prove.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-dhis2': patch
+'@openfn/language-salesforce': patch
+---
+
+Remove tools as devdependencies

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "author": "Open Function Group",
   "license": "ISC",
   "devDependencies": {
-    "@changesets/cli": "2.25.0"
+    "@changesets/cli": "2.25.0",
+    "@openfn/buildtools": "workspace:^1.0.2",
+    "@openfn/metadata": "workspace:^1.0.1",
+    "@openfn/parse-jsdoc": "workspace:^1.0.0",
+    "@openfn/simple-ast": "0.4.1"
   }
 }

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -32,17 +32,12 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/language-common": "workspace:^1.7.7",
     "axios": "^0.24.0",
     "lodash": "^4.17.19",
     "qs": "^6.11.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
-    "@openfn/metadata": "workspace:^1.0.1",
-    "@openfn/parse-jsdoc": "workspace:^1.0.0",
-    "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",
     "chai-http": "4.3.0",

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -40,10 +40,6 @@
     "yargs": "^3.30.0"
   },
   "devDependencies": {
-    "@openfn/parse-jsdoc": "workspace:^1.0.0",
-    "@openfn/buildtools": "workspace:^1.0.2",
-    "@openfn/metadata": "workspace:^1.0.1",
-    "@openfn/simple-ast": "0.4.1",
     "assertion-error": "1.1.0",
     "chai": "4.3.6",
     "deep-eql": "4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,16 @@ importers:
   .:
     specifiers:
       '@changesets/cli': 2.25.0
+      '@openfn/buildtools': workspace:^1.0.2
+      '@openfn/metadata': workspace:^1.0.1
+      '@openfn/parse-jsdoc': workspace:^1.0.0
+      '@openfn/simple-ast': 0.4.1
     devDependencies:
       '@changesets/cli': 2.25.0
+      '@openfn/buildtools': link:tools/build
+      '@openfn/metadata': link:tools/metadata
+      '@openfn/parse-jsdoc': link:tools/parse-jsdoc
+      '@openfn/simple-ast': 0.4.1
 
   packages/asana:
     specifiers:
@@ -210,11 +218,7 @@ importers:
 
   packages/dhis2:
     specifiers:
-      '@openfn/buildtools': workspace:^1.0.2
       '@openfn/language-common': workspace:^1.7.7
-      '@openfn/metadata': workspace:^1.0.1
-      '@openfn/parse-jsdoc': workspace:^1.0.0
-      '@openfn/simple-ast': 0.4.1
       assertion-error: 2.0.0
       axios: ^0.24.0
       chai: 4.3.6
@@ -228,15 +232,11 @@ importers:
       qs: ^6.11.0
       rimraf: 3.0.2
     dependencies:
-      '@openfn/buildtools': link:../../tools/build
       '@openfn/language-common': link:../common
       axios: 0.24.0
       lodash: 4.17.21
       qs: 6.11.0
     devDependencies:
-      '@openfn/metadata': link:../../tools/metadata
-      '@openfn/parse-jsdoc': link:../../tools/parse-jsdoc
-      '@openfn/simple-ast': 0.4.1
       assertion-error: 2.0.0
       chai: 4.3.6
       chai-http: 4.3.0
@@ -1090,11 +1090,7 @@ importers:
 
   packages/salesforce:
     specifiers:
-      '@openfn/buildtools': workspace:^1.0.2
       '@openfn/language-common': 1.7.7
-      '@openfn/metadata': workspace:^1.0.1
-      '@openfn/parse-jsdoc': workspace:^1.0.0
-      '@openfn/simple-ast': 0.4.1
       JSONPath: ^0.10.0
       assertion-error: 1.1.0
       axios: ^0.21.1
@@ -1121,10 +1117,6 @@ importers:
       mustache: 2.3.2
       yargs: 3.32.0
     devDependencies:
-      '@openfn/buildtools': link:../../tools/build
-      '@openfn/metadata': link:../../tools/metadata
-      '@openfn/parse-jsdoc': link:../../tools/parse-jsdoc
-      '@openfn/simple-ast': 0.4.1
       assertion-error: 1.1.0
       chai: 4.3.6
       deep-eql: 4.1.1
@@ -2228,7 +2220,7 @@ packages:
       '@babel/core': 7.19.6
       doctrine: 2.1.0
       lodash.isequal: 4.5.0
-      yargs: 17.6.0
+      yargs: 17.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -11717,7 +11709,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: false
 
   /yargs/3.32.0:
     resolution: {integrity: sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==}


### PR DESCRIPTION
The previous fix to #226 did not work.

## The Problem

`salesforce` and `dhis2` have dependencies on two new internal tools for magic functions: `parse-jsdoc` and `metadata`. These are unpublished packages.

Even though they are declared as devDependencies, npm will throw an error during `install omit=dev` because these packages are not published to npmjs.org.

This is annoying.

## The Solution

But, this is actually really cool.

Instead of declaring internal dev dependencies on the package, we can declare them on the monorepo root.

Now all packages will have visibility over the internal tooling packages without having to add them as an explicit dependency.

Big fan.

## Further work

We should do this for all adaptors going forward. I don't know whether we should do it all in one go or do it per-package when we need to.

It's not critical for other packages, because they  don't depend on unpublished stuff.