### PR TITLE
Salesforce: stabilise metadata tests

### DIFF
--- a/packages/salesforce/test/metadata/metadata.test.js
+++ b/packages/salesforce/test/metadata/metadata.test.js
@@ -26,7 +26,7 @@ describe('metadata function', () => {
       mockHelper
     );
 
-    const [asset] = model.children;
+    const asset = model.children.find(({ name }) => name === 'Asset');
     expect(asset.name).to.eql('Asset');
     expect(asset.type).to.eql('sobject');
     expect(asset.meta?.system).to.be.true;
@@ -40,7 +40,9 @@ describe('metadata function', () => {
       mockHelper
     );
 
-    const [_asset, vera] = model.children;
+    const vera = model.children.find(
+      ({ name }) => name === 'vera__Attendance__c'
+    );
     expect(vera.name).to.eql('vera__Attendance__c');
     expect(vera.type).to.eql('sobject');
     expect(vera.meta?.system).to.not.be.ok;
@@ -54,7 +56,7 @@ describe('metadata function', () => {
       mockHelper
     );
 
-    const [asset] = model.children;
+    const asset = model.children.find(({ name }) => name === 'Asset');
     const fields = asset.children;
     expect(fields).to.be.ok;
     expect(fields.length).to.eql(2);
@@ -68,7 +70,7 @@ describe('metadata function', () => {
       mockHelper
     );
 
-    const [asset] = model.children;
+    const asset = model.children.find(({ name }) => name === 'Asset');
     const sn = asset.children.find(({ name }) => name === 'SerialNumber');
     expect(sn).to.be.ok;
     expect(sn.type, 'field');


### PR DESCRIPTION
Some salesforce metadata tests are failing intermittently.

Since the tests run on the same fixture data, I can only think that the fails occur because the array ordering comes out differently.

So I've made the tests more robust by not relying on array order - which can only be an improvement, even if the actual issue isn't resolved.

@mtuchi this doesn't address the fails in your loom video, but I still think that's an install issue(the `jsonpath` module is not installed).

It looks OK on my machine :tm:  but I'd appreciate some more QA. I'll re-run CI a few times.

## Issues

#237


## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
