### PR TITLE
`sftp` error handling 

### DIFF
--- a/.changeset/silent-pugs-raise.md
+++ b/.changeset/silent-pugs-raise.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-sftp': patch
+---
+
+error handling

--- a/packages/sftp/src/Adaptor.js
+++ b/packages/sftp/src/Adaptor.js
@@ -110,8 +110,8 @@ export function getCSV(filePath, parsingOptions = {}) {
           return state;
         })
         .catch(e => {
+          console.log(e);
           sftp.end();
-          throw e;
         });
     } else {
       return sftp
@@ -139,8 +139,8 @@ export function getCSV(filePath, parsingOptions = {}) {
           return state;
         })
         .catch(e => {
+          console.log(e);
           sftp.end();
-          throw e;
         });
     }
   };


### PR DESCRIPTION
## Summary

Incase of error, `console.log` instead of throw so that the workflow doesn't stop and we get to see the error which makes debugging easy 

## Details

Change `throw e` to `console.log(e)`


## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
