### PR TITLE
`OpenMRS` add support for `upsert`, `update` & `create`

### DIFF
--- a/.changeset/fuzzy-bobcats-invite.md
+++ b/.changeset/fuzzy-bobcats-invite.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-openmrs': minor
+---
+
+Add create, update and upsert function

--- a/.changeset/fuzzy-bobcats-invite.md
+++ b/.changeset/fuzzy-bobcats-invite.md
@@ -2,4 +2,14 @@
 '@openfn/language-openmrs': minor
 ---
 
-Add create, update and upsert function
+- Add create, update and upsert function
+- Add callback support and improve examples for
+  - get()
+  - post()
+  - getPatient()
+  - searchPerson()
+  - getEncounter()
+  - searchPatient()
+  - createPatient()
+  - getEncounters()
+  - createEncounter()

--- a/packages/openmrs/ast.json
+++ b/packages/openmrs/ast.json
@@ -137,7 +137,7 @@
           },
           {
             "title": "example",
-            "description": "update(\"person\", {\"gender\":\"M\",\"birthdate\":\"1997-01-13\"})",
+            "description": "update(\"person\", '3cad37ad-984d-4c65-a019-3eb120c9c373',{\"gender\":\"M\",\"birthdate\":\"1997-01-13\"})",
             "caption": "a person"
           }
         ]
@@ -222,8 +222,13 @@
           },
           {
             "title": "example",
-            "description": "upsert('trackedEntityInstances', {\n ou: 'TSyzvBiovKh',\n filter: ['w75KJ2mc4zz:Eq:Qassim'],\n}, {\n orgUnit: 'TSyzvBiovKh',\n trackedEntityType: 'nEenWmSyUEp',\n attributes: [\n   {\n     attribute: 'w75KJ2mc4zz',\n     value: 'Qassim',\n   },\n ],\n});",
-            "caption": "Example `expression.js` of upsert"
+            "description": "upsert('patient', { q: '10007JJ' }, { person: { age: 50 } });",
+            "caption": "For an existing patient using upsert"
+          },
+          {
+            "title": "example",
+            "description": "upsert(\n  \"patient\",\n  { q: \"1000EHE\" },\n  {\n    identifiers: [\n      {\n        identifier: \"1000EHE\",\n        identifierType: \"05a29f94-c0ed-11e2-94be-8c13b969e334\",\n        location: \"44c3efb0-2583-4c80-a79e-1f756a03c0a1\",\n        preferred: true,\n      },\n    ],\n    person: {\n      gender: \"M\",\n      age: 42,\n    },\n  }\n);",
+            "caption": "For non existing patient creating a patient record using upsert"
           }
         ]
       },

--- a/packages/openmrs/ast.json
+++ b/packages/openmrs/ast.json
@@ -1,5 +1,235 @@
 {
-  "operations": [],
+  "operations": [
+    {
+      "name": "create",
+      "params": [
+        "resourceType",
+        "data",
+        "callback"
+      ],
+      "docs": {
+        "description": "Create a record",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Type of resource to create. E.g. `person`, `patient`, `encounter`, ...",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "resourceType"
+          },
+          {
+            "title": "param",
+            "description": "Object which defines data that will be used to create a given instance of resource. To create a single instance of a resource, `data` must be a javascript object, and to create multiple instances of a resources, `data` must be an array of javascript objects.",
+            "type": {
+              "type": "NameExpression",
+              "name": "OpenMRSData"
+            },
+            "name": "data"
+          },
+          {
+            "title": "param",
+            "description": "Optional callback to handle the response",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "function"
+              }
+            },
+            "name": "callback"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          },
+          {
+            "title": "example",
+            "description": "create(\"person\", {\n  names: [\n    {\n      givenName: \"Mohit\",\n      familyName: \"Kumar\",\n    },\n  ],\n  gender: \"M\",\n  birthdate: \"1997-09-02\",\n  addresses: [\n    {\n      address1: \"30, Vivekananda Layout, Munnekolal,Marathahalli\",\n      cityVillage: \"Bengaluru\",\n      country: \"India\",\n      postalCode: \"560037\",\n    },\n  ],\n});",
+            "caption": "a person"
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
+      "name": "update",
+      "params": [
+        "resourceType",
+        "path",
+        "data",
+        "callback"
+      ],
+      "docs": {
+        "description": "Update data. A generic helper function to update a resource object of any type.\nUpdating an object requires to send `all required fields` or the `full body`",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "The type of resource to be updated. E.g. `person`, `patient`, etc.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "resourceType"
+          },
+          {
+            "title": "param",
+            "description": "The `id` or `path` to the `object` to be updated. E.g. `e739808f-f166-42ae-aaf3-8b3e8fa13fda` or `e739808f-f166-42ae-aaf3-8b3e8fa13fda/{collection-name}/{object-id}`",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "path"
+          },
+          {
+            "title": "param",
+            "description": "Data to update. It requires to send `all required fields` or the `full body`. If you want `partial updates`, use `patch` operation.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "data"
+          },
+          {
+            "title": "param",
+            "description": "Optional callback to handle the response",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "function"
+              }
+            },
+            "name": "callback"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          },
+          {
+            "title": "example",
+            "description": "update(\"person\", {\"gender\":\"M\",\"birthdate\":\"1997-01-13\"})",
+            "caption": "a person"
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
+      "name": "upsert",
+      "params": [
+        "resourceType",
+        "query",
+        "data",
+        "callback"
+      ],
+      "docs": {
+        "description": "Upsert a record. A generic helper function used to atomically either insert a row, or on the basis of the row already existing, UPDATE that existing row instead.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "The type of a resource to `upsert`. E.g. `trackedEntityInstances`",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "resourceType"
+          },
+          {
+            "title": "param",
+            "description": "A query object that allows to uniquely identify the resource to update. If no matches found, then the resource will be created.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "query"
+          },
+          {
+            "title": "param",
+            "description": "The data to use for update or create depending on the result of the query.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "data"
+          },
+          {
+            "title": "param",
+            "description": "Optional callback to handle the response",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "function"
+              }
+            },
+            "name": "callback"
+          },
+          {
+            "title": "throws",
+            "description": "Throws range error",
+            "type": {
+              "type": "NameExpression",
+              "name": "RangeError"
+            }
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          },
+          {
+            "title": "example",
+            "description": "upsert('trackedEntityInstances', {\n ou: 'TSyzvBiovKh',\n filter: ['w75KJ2mc4zz:Eq:Qassim'],\n}, {\n orgUnit: 'TSyzvBiovKh',\n trackedEntityType: 'nEenWmSyUEp',\n attributes: [\n   {\n     attribute: 'w75KJ2mc4zz',\n     value: 'Qassim',\n   },\n ],\n});",
+            "caption": "Example `expression.js` of upsert"
+          }
+        ]
+      },
+      "valid": true
+    }
+  ],
   "exports": [],
   "common": [
     {

--- a/packages/openmrs/ast.json
+++ b/packages/openmrs/ast.json
@@ -61,7 +61,7 @@
           {
             "title": "example",
             "description": "create(\"person\", {\n  names: [\n    {\n      givenName: \"Mohit\",\n      familyName: \"Kumar\",\n    },\n  ],\n  gender: \"M\",\n  birthdate: \"1997-09-02\",\n  addresses: [\n    {\n      address1: \"30, Vivekananda Layout, Munnekolal,Marathahalli\",\n      cityVillage: \"Bengaluru\",\n      country: \"India\",\n      postalCode: \"560037\",\n    },\n  ],\n});",
-            "caption": "a person"
+            "caption": "Create a person"
           }
         ]
       },

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -53,24 +53,27 @@ async function login(state) {
  * @example
  * getPatient("123")
  * @function
- * @param {object} params - object with uuid for the patient
+ * @param {string} uuid - A uuid for the patient
+ * @param {function} [callback] - Optional callback to handle the response
+ * @example <caption>Get a patient by uuid</caption>
+ * getPatient('681f8785-c9ca-4dc8-a091-7b869316ff93')
  * @returns {Operation}
  */
-export function getPatient(uuid) {
+export function getPatient(uuid, callback = false) {
   return state => {
     Log.info(`Searching for patient with uuid: ${uuid}`);
     const { instanceUrl } = state.configuration;
-
+    const defaultQuery = { v: 'full', limit: 1 };
     const url = `${instanceUrl}/ws/rest/v1/patient/${uuid}`;
 
     return agent
       .get(url)
       .accept('json')
-      .query({ v: 'full' })
+      .query(defaultQuery)
       .then(response => {
         Log.success(`Found patient.`);
 
-        return handleResponse(response, state);
+        return handleResponse(response, state, callback);
       })
       .catch(handleError);
   };
@@ -78,7 +81,7 @@ export function getPatient(uuid) {
 
 /**
  * Creates an encounter
- * @example
+ * @example <caption>Create an encounter</caption>
  * createEncounter({
  *   encounterDatetime: '2023-05-25T06:08:25.000+0000',
  *   patient: '1fdaa696-e759-4a7d-a066-f1ae557c151b',
@@ -93,14 +96,14 @@ export function getPatient(uuid) {
  *   },
  * })
  * @function
- * @param {object} params - parameters of the encounter
+ * @param {object} data - Data parameters of the encounter
+ * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
-export function createEncounter(params) {
+export function createEncounter(data, callback = false) {
   return state => {
-    const body = JSON.stringify(expandReferences(params)(state));
-
     const { instanceUrl } = state.configuration;
+    const body = expandReferences(data)(state);
     const url = `${instanceUrl}/ws/rest/v1/encounter`;
 
     Log.info(`Creating an encounter.`);
@@ -112,7 +115,7 @@ export function createEncounter(params) {
       .then(response => {
         Log.success(`Created an encounter.`);
 
-        return handleResponse(response, state);
+        return handleResponse(response, state, callback);
       })
       .catch(handleError);
   };
@@ -121,13 +124,14 @@ export function createEncounter(params) {
 /**
  * Make a get request to any OpenMRS endpoint
  * @example
- * get("encounterType", {
- *   v: "default",
+ * get("patient", {
+ *   q: "Patient",
  *   limit: 1,
  * });
  * @function
  * @param {string} path - Path to resource
  * @param {object} query - parameters for the request
+ * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
 export function get(path, query, callback = false) {
@@ -148,13 +152,14 @@ export function get(path, query, callback = false) {
 /**
  * Make a post request to any OpenMRS endpoint
  * @example
- * post("encounterType", {
- *   v: "default",
- *   limit: 1,
- * });
+ * post(
+ *   "idgen/identifiersource/8549f706-7e85-4c1d-9424-217d50a2988b/identifier",
+ *   {}
+ * );
  * @function
  * @param {string} path - Path to resource
  * @param {object} data - Object which defines data that will be used to create a given instance of resource
+ * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
 export function post(path, data, callback = false) {
@@ -179,12 +184,13 @@ export function post(path, data, callback = false) {
  * @example
  * searchPatient({ q: Sarah })
  * @function
- * @param {object} params - object with query for the patient
+ * @param {object} query - Object with query for the patient
+ * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
-export function searchPatient(params) {
+export function searchPatient(query, callback = false) {
   return state => {
-    const qs = expandReferences(params)(state);
+    const qs = expandReferences(query)(state);
     Log.info(`Searching for patient with name: ${qs.q}`);
     const { instanceUrl } = state.configuration;
 
@@ -204,7 +210,7 @@ export function searchPatient(params) {
               count > 1 ? 's' : ''
             }.`
           );
-          return handleResponse(response, state);
+          return handleResponse(response, state, callback);
         } else {
           throw new Error(
             `Raising an error because ${count} records were found.`
@@ -220,12 +226,13 @@ export function searchPatient(params) {
  * @example
  * searchPerson({ q: Sarah })
  * @function
- * @param {object} params - object with query for the person
+ * @param {object} query - object with query for the person
+ * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
-export function searchPerson(params) {
+export function searchPerson(query, callback = false) {
   return state => {
-    const qs = expandReferences(params)(state);
+    const qs = expandReferences(query)(state);
     Log.info(`Searching for person with name: ${qs.q}`);
 
     const { instanceUrl } = state.configuration;
@@ -246,7 +253,7 @@ export function searchPerson(params) {
               count > 1 ? 's' : ''
             }.`
           );
-          return handleResponse(response, state);
+          return handleResponse(response, state, callback);
         } else {
           throw new Error(
             `Raising an error because ${count} records were found.`
@@ -282,12 +289,13 @@ export function searchPerson(params) {
  *   },
  * })
  * @function
- * @param {object} params - parameters of the patient
+ * @param {object} data - Object parameters of the patient
+ * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
-export function createPatient(params) {
+export function createPatient(data, callback = false) {
   return state => {
-    const body = JSON.stringify(expandReferences(params)(state));
+    const body = expandReferences(data)(state);
     const { instanceUrl } = state.configuration;
     const url = `${instanceUrl}/ws/rest/v1/patient`;
 
@@ -300,7 +308,7 @@ export function createPatient(params) {
       .then(response => {
         Log.success(`Created a new patient.`);
 
-        return handleResponse(response, state);
+        return handleResponse(response, state, callback);
       })
       .catch(handleError);
   };
@@ -311,10 +319,11 @@ export function createPatient(params) {
  * @example
  * getEncounter("123")
  * @function
- * @param {object} uuid - object with uuid for the encounter
+ * @param {object} uuid - A uuid for the encounter
+ * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
-export function getEncounter(uuid) {
+export function getEncounter(uuid, callback = false) {
   return state => {
     Log.info(`Searching for encounter with uuid: ${uuid}`);
     const { instanceUrl } = state.configuration;
@@ -327,7 +336,7 @@ export function getEncounter(uuid) {
       .then(response => {
         Log.success(`Found an encounter.`);
 
-        return handleResponse(response, state);
+        return handleResponse(response, state, callback);
       })
       .catch(handleError);
   };
@@ -338,12 +347,13 @@ export function getEncounter(uuid) {
  * @example
  * getEncounters({patient: "123", fromdate: "2023-05-18"})
  * @function
- * @param {object} params - Criteria object for the patient
+ * @param {object} query - Object for the patient
+ * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
-export function getEncounters(params) {
+export function getEncounters(query, callback = false) {
   return state => {
-    const qs = expandReferences(params)(state);
+    const qs = expandReferences(query)(state);
     const { instanceUrl } = state.configuration;
     const url = `${instanceUrl}/ws/rest/v1/encounter`;
 
@@ -356,7 +366,7 @@ export function getEncounters(params) {
       .then(response => {
         Log.success(`Found an encounter.`);
 
-        return handleResponse(response, state);
+        return handleResponse(response, state, callback);
       })
       .catch(handleError);
   };
@@ -370,7 +380,7 @@ export function getEncounters(params) {
  * @param {OpenMRSData} data - Object which defines data that will be used to create a given instance of resource. To create a single instance of a resource, `data` must be a javascript object, and to create multiple instances of a resources, `data` must be an array of javascript objects.
  * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
- * @example <caption>a person</caption>
+ * @example <caption>Create a person</caption>
  * create("person", {
  *   names: [
  *     {
@@ -392,13 +402,13 @@ export function getEncounters(params) {
  */
 export function create(resourceType, data, callback = false) {
   return state => {
-    const { instanceUrl } = state.configuration;
     console.log(`Preparing create operation...`);
 
-    resourceType = expandReferences(resourceType)(state);
-    data = expandReferences(data)(state);
-
+    const { instanceUrl } = state.configuration;
     const url = `${instanceUrl}/ws/rest/v1/${resourceType}`;
+
+    data = expandReferences(data)(state);
+    resourceType = expandReferences(resourceType)(state);
 
     return agent
       .post(url)

--- a/packages/openmrs/src/Utils.js
+++ b/packages/openmrs/src/Utils.js
@@ -1,3 +1,5 @@
+import { composeNextState } from '@openfn/language-common';
+
 export class Log {
   static info(message) {
     return console.info(`ℹ `, message);
@@ -37,4 +39,17 @@ export function handleError(error) {
   } else {
     throw error;
   }
+}
+
+export function handleResponse(response, state, callback) {
+  const { body } = response;
+  const nextState = composeNextState(state, { body });
+  if (callback) return callback(nextState);
+  return nextState;
+}
+
+const isArray = variable => !!variable && variable.constructor === Array;
+
+export function nestArray(data, key) {
+  return isArray(data) ? { [key]: data } : data;
 }


### PR DESCRIPTION
## Summary

Add support for `upsert`, `update` & `create` in `OpenMRS` adaptor. & Add `callback` support and improve examples for 

- [x] `get()`
- [x] `post()`
- [x] `getPatient()`
- [x] `searchPerson()`
- [x] `getEncounter()`
- [x] `searchPatient()`
- [x] `createPatient()`
- [x] `getEncounters()`
- [x] `createEncounter()`

## Issues

Reference any related issues here. #263 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
