### PR TITLE
New expandReferences API

### DIFF
--- a/packages/common/build.config.js
+++ b/packages/common/build.config.js
@@ -1,4 +1,4 @@
 // override build config with an extra entry point
 export default path => ({
-  entry: [`${path}/src/index.js`, `${path}/src/metadata.js`],
+  entry: [`${path}/src/index.js`, `${path}/src/metadata.js`, `${path}/src/util.js`],
 });

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,7 +24,11 @@
     "./metadata": {
       "import": "./dist/metadata.js",
       "require": "./dist/metadata.cjs"
-    }
+    },
+    "./util": {
+      "import": "./dist/util.js",
+      "require": "./dist/util.cjs"
+    } 
   },
   "author": "Open Function Group",
   "license": "LGPL-3.0-or-later",

--- a/packages/common/src/util.js
+++ b/packages/common/src/util.js
@@ -1,0 +1,30 @@
+/**
+ * General-purpose utility functions
+ * 
+ * These are designed more for use in adaptor code than job code
+ * (but we could choose to export util from common)
+ * 
+ * None of these functions are operation factories
+ */
+
+// TODO this doesn't currently support skip
+export function expandReferences(state, ...args) {
+  return args.map((value) => expandReference(state, value));
+}
+
+function expandReference(state, value) {
+  if (Array.isArray(value)) {
+    return value.map(v => expandReference(state, v));
+  }
+
+  if (typeof value == 'object' && !!value) {
+    return Object.keys(value).reduce((acc, key) => {
+      return { ...acc, [key]: expandReference(state, value[key]) };
+    }, {});
+  }
+
+  if (typeof value == 'function') {
+    return expandReference(state, value(state));
+  }
+  return value;
+}

--- a/packages/common/test/util.test.js
+++ b/packages/common/test/util.test.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import { expandReferences } from '../src/util';
+
+describe('util', () => {
+  it('should not expand references', () => {
+    const name = 'mulder';
+    const state = {};
+
+    const [resolvedName] = expandReferences(state, name)
+
+    expect(resolvedName).to.equal('mulder')
+  });
+
+  it('should expand function references', () => {
+    const state = { name: 'mulder' };
+    const name = (s) => s.name;
+
+    const [resolvedName] = expandReferences(state, name)
+
+    expect(resolvedName).to.equal('mulder')
+  });
+
+  it('should recursively expand function references', () => {
+    const state = { name: 'mulder' };
+    const name = (s) => (s) => s.name;
+
+    const [resolvedName] = expandReferences(state, name)
+
+    expect(resolvedName).to.equal('mulder')
+  });
+
+  it('should expand multiple referencws', () => {
+    const state = { name: 'mulder', truth: 'out there' };
+    const name = (s) => s.name;
+    const truth = (s) => s.truth;
+
+    const [resolvedName, resolvedTruth] = expandReferences(state, name, truth)
+
+    expect(resolvedName).to.equal('mulder')
+    expect(resolvedTruth).to.equal('out there')
+  });
+
+  it('should expand array references', () => {
+    const state = { name: 'mulder' };
+    const name = ['fox', (s) => s.name];
+
+    const [resolvedName] = expandReferences(state, name)
+
+    const [fname, sname] = resolvedName;
+    expect(fname).to.equal('fox')
+    expect(sname).to.equal('mulder')
+  });
+
+  it('should expand object references', () => {
+    const state = { name: 'mulder' };
+    const name = {
+      first: 'fox',
+      second: (s) => s.name
+    };
+
+    const [resolvedName] = expandReferences(state, name)
+
+    expect(resolvedName.first).to.equal('fox')
+    expect(resolvedName.second).to.equal('mulder')
+  });
+});

--- a/packages/template/src/Adaptor.js
+++ b/packages/template/src/Adaptor.js
@@ -2,7 +2,7 @@ import {
   execute as commonExecute,
   composeNextState,
 } from '@openfn/language-common';
-import { expandReferences } from '@openfn/common/util'
+import { expandReferences } from '@openfn/language-common/util'
 import { request } from './Utils';
 
 /**

--- a/packages/template/src/Adaptor.js
+++ b/packages/template/src/Adaptor.js
@@ -45,16 +45,16 @@ export function execute(...operations) {
  */
 export function create(resource, data, callback) {
   return state => {
-    const [_resource, _data] = expandReferences(state, resource, data); 
+    const [resolvedResource, resolvedData] = expandReferences(state, resource, data); 
 
     const { baseUrl, username, password } = state.configuration;
 
-    const url = `${baseUrl}/api/${_resource}`;
+    const url = `${baseUrl}/api/${resolvedResource}`;
     const auth = { username, password };
 
     const options = {
       auth,
-      body: _data,
+      body: resolvedData,
       method: 'POST',
     };
 

--- a/packages/template/src/Adaptor.js
+++ b/packages/template/src/Adaptor.js
@@ -1,9 +1,8 @@
 import {
   execute as commonExecute,
   composeNextState,
-  expandReferences,
 } from '@openfn/language-common';
-
+import { expandReferences } from '@openfn/common/util'
 import { request } from './Utils';
 
 /**
@@ -46,17 +45,16 @@ export function execute(...operations) {
  */
 export function create(resource, data, callback) {
   return state => {
-    const resolvedResource = expandReferences(resource)(state);
-    const resolvedData = expandReferences(data)(state);
+    const [_resource, _data] = expandReferences(state, resource, data); 
 
     const { baseUrl, username, password } = state.configuration;
 
-    const url = `${baseUrl}/api/${resolvedResource}`;
+    const url = `${baseUrl}/api/${_resource}`;
     const auth = { username, password };
 
     const options = {
       auth,
-      body: resolvedData,
+      body: _data,
       method: 'POST',
     };
 

--- a/tools/build/src/commands/src.ts
+++ b/tools/build/src/commands/src.ts
@@ -30,6 +30,7 @@ export default async (lang: string) => {
   const defaultBuildConfig = {
     entry: [`${p}/src/index.js`],
     outDir: `${p}/dist`,
+    external: ['@openfn/common'],
     ...config,
   };
 

--- a/tools/build/src/commands/src.ts
+++ b/tools/build/src/commands/src.ts
@@ -30,7 +30,6 @@ export default async (lang: string) => {
   const defaultBuildConfig = {
     entry: [`${p}/src/index.js`],
     outDir: `${p}/dist`,
-    external: ['@openfn/common'],
     ...config,
   };
 


### PR DESCRIPTION
## Summary

I've added:

1) A new `@openfn/common/util` package which exposes utility functions (designed for other adaptors for now, but we could expose this from common for job code)
2) A new `expandReferences` utility like this:

```
 const [_resource, _data] = expandReferences(state, resource, data); 
```

It is just an experiment, but actually I think this can be merged to main very quickly.

## Details

The new `expandReferences` function is designed to resolve multiple references in a single line, with a cleaner syntax. It's clean, safe, performant and elegant for every operation factory to call this immediately.

At the time of writing, expandReferences does NOT support the `skip` functionality. That probably requires a `expandReferencesWithSkip(state, skipfn, ...args)` function.

It is up to the adaptor author what names to use on the left hand side of the expansion. However I think we should aim to provide a strong convention here.  Options are:

* `_name` - the underscore looks ugly. Usually underscore means "private method" or "unused variable" in JS convention.
* `$name` - I quite like this, but it does look a bit like a JSON path object. Or angular code.
* `Name` - we could uppercase the resolved reference. This is OK, although in Javascript world an uppercase normally means a class. 

The other approach is to flip this on its head and rename the parameters:
```
/**
 * Create some resource in some system
 * @param {string} resource - The type of entity that will be created
 * @param {object} data - The data to create the new resource
 * @param {function} callback - An optional callback function
 * @returns {Operation}
 */
export function create(_resource, _data, callback) {
  return state => {
    const [resource, data] = expandReferences(state, _resource, _data); 
``` 
This is neat and should not affect JS doc or other tooling (although this needs testing - does it make VSC and Monaco intellisense ugly?)

## Issues

Closes #264

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
