### PR TITLE
Extend `parseCsv` to `http` and `bigquery`

### DIFF
--- a/.changeset/many-moons-turn.md
+++ b/.changeset/many-moons-turn.md
@@ -2,4 +2,5 @@
 '@openfn/language-common': minor
 ---
 
-Add support for `parseCsv` in common
+- Add support for `parseCsv` in common
+- Added documentation for splitKeys

--- a/.changeset/many-moons-turn.md
+++ b/.changeset/many-moons-turn.md
@@ -2,5 +2,4 @@
 '@openfn/language-common': minor
 ---
 
-- Add support for `parseCsv` in common
-- Added documentation for splitKeys
+Add support for `parseCsv` in common

--- a/.changeset/odd-geese-joke.md
+++ b/.changeset/odd-geese-joke.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-bigquery': major
+'@openfn/language-http': major
+---
+
+use parseCsv from common

--- a/.changeset/yellow-pets-march.md
+++ b/.changeset/yellow-pets-march.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': patch
+---
+
+update parseCsv to await callback

--- a/.changeset/yellow-pets-march.md
+++ b/.changeset/yellow-pets-march.md
@@ -2,4 +2,5 @@
 '@openfn/language-common': patch
 ---
 
-update parseCsv to await callback
+- update parseCsv to await callback
+- Added documentation for splitKeys

--- a/packages/bigquery/ast.json
+++ b/packages/bigquery/ast.json
@@ -512,6 +512,80 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "parseCsv",
+      "params": [
+        "csvData",
+        "parsingOptions",
+        "callback"
+      ],
+      "docs": {
+        "description": "The function `parseCsv` takes a CSV file string or stream and parsing options as input, and returns a promise that\nresolves to the parsed CSV data.\nOptions for `parsingOptions` include:\n- `delimiter` {string/Buffer/[string/Buffer]} - Defines the character(s) used to delimitate the fields inside a record. Default: `','`\n- `quote` {string/Buffer/[string/Buffer]} - Defines the characters used to surround a field. Default: `'\"'`\n- `escape` {Buffer/string/null/boolean} - Set the escape character as one character/byte only. Default: `\"`\n- `columns` {boolean / array / function} - Generates record in the form of object literals. Default: `true`\n- `bom` {boolean} - Strips the {@link https://en.wikipedia.org/wiki/Byte_order_mark byte order mark (BOM)} from the input string or buffer. Default: `true`\n- `trim` {boolean} - Ignore whitespace characters immediately around the `delimiter`. Default: `true`\n- `ltrim` {boolean} - Ignore whitespace characters from the left side of a CSV field. Default: `true`\n- `rtrim` {boolean} - Ignore whitespace characters from the right side of a CSV field. Default: `true`\n- `chunkSize` {number} - The size of each chunk of CSV data. Default: `Infinity`\n- `skip_empty_lines` {boolean} - The `skip_empty_lines` skips any line which is empty. Default: `true`",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "A CSV string or a readable stream",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "String"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Stream"
+                }
+              ]
+            },
+            "name": "csvData"
+          },
+          {
+            "title": "param",
+            "description": "Optional. Parsing options for converting CSV to JSON. \\n",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Object"
+              }
+            },
+            "name": "parsingOptions"
+          },
+          {
+            "title": "param",
+            "description": "(Optional) callback function. If used it will be called state and an array of rows.",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "function"
+              }
+            },
+            "name": "callback"
+          },
+          {
+            "title": "returns",
+            "description": "The function returns a Promise that resolves to the result of parsing a CSV `stringOrStream`.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
     }
   ]
 }

--- a/packages/bigquery/ast.json
+++ b/packages/bigquery/ast.json
@@ -92,59 +92,6 @@
         ]
       },
       "valid": true
-    },
-    {
-      "name": "parseCSV",
-      "params": [
-        "target",
-        "config"
-      ],
-      "docs": {
-        "description": "CSV-Parse for CSV conversion to JSON",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "example",
-            "description": "parseCSV(\"/home/user/someData.csv\", {\n\t  quoteChar: '\"',\n\t  header: false,\n\t});"
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "string or local file with CSV data",
-            "type": {
-              "type": "NameExpression",
-              "name": "String"
-            },
-            "name": "target"
-          },
-          {
-            "title": "param",
-            "description": "csv-parse config object",
-            "type": {
-              "type": "NameExpression",
-              "name": "Object"
-            },
-            "name": "config"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "Operation"
-            }
-          }
-        ]
-      },
-      "valid": true
     }
   ],
   "exports": [],

--- a/packages/bigquery/src/Adaptor.js
+++ b/packages/bigquery/src/Adaptor.js
@@ -5,7 +5,6 @@ import {
   composeNextState,
 } from '@openfn/language-common';
 import fs from 'fs';
-import parse from 'csv-parse';
 import { BigQuery } from '@google-cloud/bigquery';
 
 /**

--- a/packages/bigquery/src/Adaptor.js
+++ b/packages/bigquery/src/Adaptor.js
@@ -120,52 +120,6 @@ export function load(
   };
 }
 
-/**
- * CSV-Parse for CSV conversion to JSON
- * @public
- * @example
- *  parseCSV("/home/user/someData.csv", {
- * 	  quoteChar: '"',
- * 	  header: false,
- * 	});
- * @function
- * @param {String} target - string or local file with CSV data
- * @param {Object} config - csv-parse config object
- * @returns {Operation}
- */
-export function parseCSV(target, config) {
-  return state => {
-    return new Promise(resolve => {
-      var csvData = [];
-
-      try {
-        fs.readFileSync(target);
-        fs.createReadStream(target)
-          .pipe(parse(config))
-          .on('data', csvrow => {
-            console.log(csvrow);
-            csvData.push(csvrow);
-          })
-          .on('end', () => {
-            console.log(csvData);
-            resolve(composeNextState(state, csvData));
-          });
-      } catch (err) {
-        var csvString;
-        if (typeof target === 'string') {
-          csvString = target;
-        } else {
-          csvString = expandReferences(target)(state);
-        }
-        csvData = parse(csvString, config, (err, output) => {
-          console.log(output);
-          resolve(composeNextState(state, output));
-        });
-      }
-    });
-  };
-}
-
 export {
   alterState,
   dataPath,
@@ -178,4 +132,5 @@ export {
   lastReferenceValue,
   merge,
   sourceValue,
+  parseCsv,
 } from '@openfn/language-common';

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1066,6 +1066,73 @@
       "valid": true
     },
     {
+      "name": "splitKeys",
+      "params": [
+        "obj",
+        "keys"
+      ],
+      "docs": {
+        "description": "Splits an object into two objects based on a list of keys.\nThe first object contains the keys that are not in the list,\nand the second contains the keys that are.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "The object to split.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "obj"
+          },
+          {
+            "title": "param",
+            "description": "List of keys to split on.",
+            "type": {
+              "type": "TypeApplication",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Array"
+              },
+              "applications": [
+                {
+                  "type": "NameExpression",
+                  "name": "string"
+                }
+              ]
+            },
+            "name": "keys"
+          },
+          {
+            "title": "returns",
+            "description": "Tuple of objects, first object contains keys not in list, second contains keys that are.",
+            "type": {
+              "type": "TypeApplication",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Array"
+              },
+              "applications": [
+                {
+                  "type": "NameExpression",
+                  "name": "Object"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "scrubEmojis",
       "params": [
         "text",
@@ -1165,6 +1232,80 @@
             "type": {
               "type": "NameExpression",
               "name": "Object"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
+      "name": "parseCsv",
+      "params": [
+        "csvData",
+        "parsingOptions",
+        "callback"
+      ],
+      "docs": {
+        "description": "The function `parseCsv` takes a CSV file string or stream and parsing options as input, and returns a promise that\nresolves to the parsed CSV data.\nOptions for `parsingOptions` include:\n- `delimiter` {string/Buffer/[string/Buffer]} - Defines the character(s) used to delimitate the fields inside a record. Default: `','`\n- `quote` {string/Buffer/[string/Buffer]} - Defines the characters used to surround a field. Default: `'\"'`\n- `escape` {Buffer/string/null/boolean} - Set the escape character as one character/byte only. Default: `\"`\n- `columns` {boolean / array / function} - Generates record in the form of object literals. Default: `true`\n- `bom` {boolean} - Strips the {@link https://en.wikipedia.org/wiki/Byte_order_mark byte order mark (BOM)} from the input string or buffer. Default: `true`\n- `trim` {boolean} - Ignore whitespace characters immediately around the `delimiter`. Default: `true`\n- `ltrim` {boolean} - Ignore whitespace characters from the left side of a CSV field. Default: `true`\n- `rtrim` {boolean} - Ignore whitespace characters from the right side of a CSV field. Default: `true`\n- `chunkSize` {number} - The size of each chunk of CSV data. Default: `Infinity`\n- `skip_empty_lines` {boolean} - The `skip_empty_lines` skips any line which is empty. Default: `true`",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "A CSV string or a readable stream",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "String"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Stream"
+                }
+              ]
+            },
+            "name": "csvData"
+          },
+          {
+            "title": "param",
+            "description": "Optional. Parsing options for converting CSV to JSON. \\n",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Object"
+              }
+            },
+            "name": "parsingOptions"
+          },
+          {
+            "title": "param",
+            "description": "(Optional) callback function. If used it will be called state and an array of rows.",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "function"
+              }
+            },
+            "name": "callback"
+          },
+          {
+            "title": "returns",
+            "description": "The function returns a Promise that resolves to the result of parsing a CSV `stringOrStream`.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
             }
           }
         ]

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -554,10 +554,10 @@ export function chunk(array, chunkSize) {
 }
 
 /**
- * The function `parseCsv` takes a CSV file string or stream and parsing options as input, and returns a promise that
- * resolves to the parsed CSV data.
+ * Takes a CSV file string or stream and parsing options as input, and returns a promise that
+ * resolves to the parsed CSV data as an array of objects.
  * Options for `parsingOptions` include:
- * - `delimiter` {string/Buffer/[string/Buffer]} - Defines the character(s) used to delimitate the fields inside a record. Default: `','`
+ * - `delimiter` {string/Buffer/[string/Buffer]} - Defines the character(s) used to delineate the fields inside a record. Default: `','`
  * - `quote` {string/Buffer/[string/Buffer]} - Defines the characters used to surround a field. Default: `'"'`
  * - `escape` {Buffer/string/null/boolean} - Set the escape character as one character/byte only. Default: `"`
  * - `columns` {boolean / array / function} - Generates record in the form of object literals. Default: `true`
@@ -566,11 +566,11 @@ export function chunk(array, chunkSize) {
  * - `ltrim` {boolean} - Ignore whitespace characters from the left side of a CSV field. Default: `true`
  * - `rtrim` {boolean} - Ignore whitespace characters from the right side of a CSV field. Default: `true`
  * - `chunkSize` {number} - The size of each chunk of CSV data. Default: `Infinity`
- * - `skip_empty_lines` {boolean} - The `skip_empty_lines` skips any line which is empty. Default: `true`
+ * - `skip_empty_lines` {boolean} - Ignore empty lines in the CSV file. Default: `true`
  * @public
  * @function
  * @param {String | Stream} csvData - A CSV string or a readable stream
- * @param {Object} [parsingOptions] - Optional. Parsing options for converting CSV to JSON. \n
+ * @param {Object} [parsingOptions] - Optional. Parsing options for converting CSV to JSON.
  * @param {function} [callback] - (Optional) callback function. If used it will be called state and an array of rows.
  * @returns {Operation} The function returns a Promise that resolves to the result of parsing a CSV `stringOrStream`.
  */

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -629,3 +629,19 @@ export function parseCsv(csvData, parsingOptions = {}, callback) {
     return finalState;
   };
 }
+
+// /**
+//  * Returns a unique array of objects by an attribute in those objects
+//  * @public
+//  * @example
+//  * uniqBy([{a:1}, {b:2}, {a:1, b:2}], 'a')
+//  * @function
+//  * @param {Object} array - Array of objects to be deduplicated
+//  * @param {Integer} uid - The attribute name on which to deduplicate
+//  * @returns {Object}
+//  */
+// export function uniqBy(array, uid) {
+//   return Array.from(new Set(array.map(a => a[uid]))).map(id => {
+//     return array.find(a => a[uid] === id);
+//   });
+// }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -9,16 +9,6 @@ export * as http from './http';
 export * as dateFns from './dateFns';
 
 /**
- * @typedef State
- * @type {Object}
- */
-
-/**
- * @typedef Operation
- * @type {Function}
- */
-
-/**
  * Execute a sequence of operations.
  * Main outer API for executing expressions.
  * @public
@@ -491,6 +481,16 @@ export function humanProper(str) {
   }
 }
 
+/**
+ * Splits an object into two objects based on a list of keys.
+ * The first object contains the keys that are not in the list,
+ * and the second contains the keys that are.
+ * @public
+ * @function
+ * @param {Object} obj - The object to split.
+ * @param {string[]} keys - List of keys to split on.
+ * @returns {Object[]} - Tuple of objects, first object contains keys not in list, second contains keys that are.
+ */
 export function splitKeys(obj, keys) {
   return Object.keys(obj).reduce(
     ([keep, split], key) => {
@@ -554,30 +554,24 @@ export function chunk(array, chunkSize) {
 }
 
 /**
- * This callback is displayed as part of the Requester class.
- * @callback parseCsvCallback
- * @param {} responseCode
- * @param {string} responseMessage
- */
-
-/**
  * The function `parseCsv` takes a CSV file string or stream and parsing options as input, and returns a promise that
  * resolves to the parsed CSV data.
+ * Options for `parsingOptions` include:
+ * - `delimiter` {string/Buffer/[string/Buffer]} - Defines the character(s) used to delimitate the fields inside a record. Default: `','`
+ * - `quote` {string/Buffer/[string/Buffer]} - Defines the characters used to surround a field. Default: `'"'`
+ * - `escape` {Buffer/string/null/boolean} - Set the escape character as one character/byte only. Default: `"`
+ * - `columns` {boolean / array / function} - Generates record in the form of object literals. Default: `true`
+ * - `bom` {boolean} - Strips the {@link https://en.wikipedia.org/wiki/Byte_order_mark byte order mark (BOM)} from the input string or buffer. Default: `true`
+ * - `trim` {boolean} - Ignore whitespace characters immediately around the `delimiter`. Default: `true`
+ * - `ltrim` {boolean} - Ignore whitespace characters from the left side of a CSV field. Default: `true`
+ * - `rtrim` {boolean} - Ignore whitespace characters from the right side of a CSV field. Default: `true`
+ * - `chunkSize` {number} - The size of each chunk of CSV data. Default: `Infinity`
+ * - `skip_empty_lines` {boolean} - The `skip_empty_lines` skips any line which is empty. Default: `true`
+ * @public
+ * @function
  * @param {String | Stream} csvData - A CSV string or a readable stream
- * @param {Object} [parsingOptions] - Optional. Parsing options for converting CSV to JSON.
- *     Possible options:<ul>
- *     <li>`delimiter` {string/Buffer/[string/Buffer]} - Defines the character(s) used to delimitate the fields inside a record. Default: `','`</li>
- *     <li>`quote` {string/Buffer/[string/Buffer]} - Defines the characters used to surround a field. Default: `'"'`</li>
- *     <li>`escape` {Buffer/string/null/boolean} - Set the escape character as one character/byte only. Default: `"`</li>
- *     <li>`columns` {boolean / array / function} - Generates record in the form of object literals. Default: `true`</li>
- *     <li>`bom` {boolean} - Strips the {@link https://en.wikipedia.org/wiki/Byte_order_mark byte order mark (BOM)} from the input string or buffer. Default: `true`</li>
- *     <li>`trim` {boolean} - Ignore whitespace characters immediately around the `delimiter`. Default: `true`</li>
- *     <li>`ltrim` {boolean} - Ignore whitespace characters from the left side of a CSV field. Default: `true`</li>
- *     <li>`rtrim` {boolean} - Ignore whitespace characters from the right side of a CSV field. Default: `true`</li>
- *     <li>`chunkSize` {number} - The size of each chunk of CSV data. Default: `Infinity`</li>
- *     <li>`skip_empty_lines` {boolean} - The `skip_empty_lines` skips any line which is empty. Default: `true`</li>
- * </ul>
- * @param {parseCsvCallback} callback - (Optional) callback function. If used it will take state and csvRows
+ * @param {Object} [parsingOptions] - Optional. Parsing options for converting CSV to JSON. \n
+ * @param {function} [callback] - (Optional) callback function. If used it will be called state and an array of rows.
  * @returns {Operation} The function returns a Promise that resolves to the result of parsing a CSV `stringOrStream`.
  */
 export function parseCsv(csvData, parsingOptions = {}, callback) {
@@ -635,18 +629,3 @@ export function parseCsv(csvData, parsingOptions = {}, callback) {
     return finalState;
   };
 }
-// /**
-//  * Returns a unique array of objects by an attribute in those objects
-//  * @public
-//  * @example
-//  * uniqBy([{a:1}, {b:2}, {a:1, b:2}], 'a')
-//  * @function
-//  * @param {Object} array - Array of objects to be deduplicated
-//  * @param {Integer} uid - The attribute name on which to deduplicate
-//  * @returns {Object}
-//  */
-// export function uniqBy(array, uid) {
-//   return Array.from(new Set(array.map(a => a[uid]))).map(id => {
-//     return array.find(a => a[uid] === id);
-//   });
-// }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -9,6 +9,16 @@ export * as http from './http';
 export * as dateFns from './dateFns';
 
 /**
+ * @typedef State
+ * @type {Object}
+ */
+
+/**
+ * @typedef Operation
+ * @type {Function}
+ */
+
+/**
  * Execute a sequence of operations.
  * Main outer API for executing expressions.
  * @public
@@ -544,23 +554,31 @@ export function chunk(array, chunkSize) {
 }
 
 /**
+ * This callback is displayed as part of the Requester class.
+ * @callback parseCsvCallback
+ * @param {} responseCode
+ * @param {string} responseMessage
+ */
+
+/**
  * The function `parseCsv` takes a CSV file string or stream and parsing options as input, and returns a promise that
  * resolves to the parsed CSV data.
  * @param {String | Stream} csvData - A CSV string or a readable stream
  * @param {Object} [parsingOptions] - Optional. Parsing options for converting CSV to JSON.
- *     Possible options:
- *     - `delimiter` {string|Buffer|[string|Buffer]} - Defines the character(s) used to delimitate the fields inside a record. Default: `','`
- *     - `quote` {string|Buffer|[string|Buffer]} - Defines the characters used to surround a field. Default: `'"'`
- *     - `escape` {Buffer|string|null|boolean} - Set the escape character as one character/byte only. Default: `"`
- *     - `columns` {boolean | array | function} - Generates record in the form of object literals. Default: `true`
- *     - `bom` {boolean} - Strips the {@link https://en.wikipedia.org/wiki/Byte_order_mark byte order mark (BOM)} from the input string or buffer. Default: `true`
- *     - `trim` {boolean} - Ignore whitespace characters immediately around the `delimiter`. Default: `true`
- *     - `ltrim` {boolean} - Ignore whitespace characters from the left side of a CSV field. Default: `true`
- *     - `rtrim` {boolean} - Ignore whitespace characters from the right side of a CSV field. Default: `true`
- *     - `chunkSize` {number} - The size of each chunk of CSV data. Default: `Infinity`
- *     - `skip_empty_lines` {boolean} - The `skip_empty_lines` skips any line which is empty. Default: `true`
- * @param {function} callback - (Optional) callback function. If used it will take state and csvRows
- * @returns {Promise} The function returns a Promise that resolves to the result of parsing a CSV `stringOrStream`.
+ *     Possible options:<ul>
+ *     <li>`delimiter` {string/Buffer/[string/Buffer]} - Defines the character(s) used to delimitate the fields inside a record. Default: `','`</li>
+ *     <li>`quote` {string/Buffer/[string/Buffer]} - Defines the characters used to surround a field. Default: `'"'`</li>
+ *     <li>`escape` {Buffer/string/null/boolean} - Set the escape character as one character/byte only. Default: `"`</li>
+ *     <li>`columns` {boolean / array / function} - Generates record in the form of object literals. Default: `true`</li>
+ *     <li>`bom` {boolean} - Strips the {@link https://en.wikipedia.org/wiki/Byte_order_mark byte order mark (BOM)} from the input string or buffer. Default: `true`</li>
+ *     <li>`trim` {boolean} - Ignore whitespace characters immediately around the `delimiter`. Default: `true`</li>
+ *     <li>`ltrim` {boolean} - Ignore whitespace characters from the left side of a CSV field. Default: `true`</li>
+ *     <li>`rtrim` {boolean} - Ignore whitespace characters from the right side of a CSV field. Default: `true`</li>
+ *     <li>`chunkSize` {number} - The size of each chunk of CSV data. Default: `Infinity`</li>
+ *     <li>`skip_empty_lines` {boolean} - The `skip_empty_lines` skips any line which is empty. Default: `true`</li>
+ * </ul>
+ * @param {parseCsvCallback} callback - (Optional) callback function. If used it will take state and csvRows
+ * @returns {Operation} The function returns a Promise that resolves to the result of parsing a CSV `stringOrStream`.
  */
 export function parseCsv(csvData, parsingOptions = {}, callback) {
   const defaultOptions = {
@@ -586,48 +604,35 @@ export function parseCsv(csvData, parsingOptions = {}, callback) {
     throw new Error('chunkSize must be at least 1');
   }
 
-  return state => {
-    return new Promise((resolve, reject) => {
-      let buffer = [];
+  return async state => {
+    let buffer = [];
 
-      const parser =
-        typeof csvData === 'string'
-          ? parse(csvData, options)
-          : csvData.pipe(parse(options));
+    const parser =
+      typeof csvData === 'string'
+        ? parse(csvData, options)
+        : csvData.pipe(parse(options));
 
-      const flushBuffer = currentState => {
-        const nextState = callback
-          ? callback(currentState, buffer)
-          : composeNextState(currentState, buffer);
+    const flushBuffer = async currentState => {
+      const nextState = callback
+        ? await callback(currentState, buffer)
+        : composeNextState(currentState, buffer);
 
-        buffer = [];
+      buffer = [];
 
-        return [nextState, buffer];
-      };
+      return [nextState, buffer];
+    };
 
-      parser.on('readable', function () {
-        let chunk;
-
-        while ((chunk = parser.read()) !== null) {
-          buffer.push(chunk);
-
-          if (buffer.length >= options.chunkSize) {
-            const [nextState, nextBuffer] = flushBuffer(state);
-            // eslint-disable-next-line no-param-reassign
-            state = nextState;
-            buffer = nextBuffer;
-          }
-        }
-      });
-      parser.on('error', function (error) {
-        reject(error);
-      });
-
-      parser.on('end', function () {
-        const [finalState] = flushBuffer(state);
-        resolve(finalState);
-      });
-    });
+    for await (const record of parser) {
+      buffer.push(record);
+      if (buffer.length === options.chunkSize) {
+        const [nextState, nextBuffer] = await flushBuffer(state);
+        // eslint-disable-next-line no-param-reassign
+        state = nextState;
+        buffer = nextBuffer;
+      }
+    }
+    const [finalState] = await flushBuffer(state);
+    return finalState;
   };
 }
 // /**

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -971,6 +971,73 @@
       "valid": true
     },
     {
+      "name": "splitKeys",
+      "params": [
+        "obj",
+        "keys"
+      ],
+      "docs": {
+        "description": "Splits an object into two objects based on a list of keys.\nThe first object contains the keys that are not in the list,\nand the second contains the keys that are.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "The object to split.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "obj"
+          },
+          {
+            "title": "param",
+            "description": "List of keys to split on.",
+            "type": {
+              "type": "TypeApplication",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Array"
+              },
+              "applications": [
+                {
+                  "type": "NameExpression",
+                  "name": "string"
+                }
+              ]
+            },
+            "name": "keys"
+          },
+          {
+            "title": "returns",
+            "description": "Tuple of objects, first object contains keys not in list, second contains keys that are.",
+            "type": {
+              "type": "TypeApplication",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Array"
+              },
+              "applications": [
+                {
+                  "type": "NameExpression",
+                  "name": "Object"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "scrubEmojis",
       "params": [
         "text",
@@ -1017,6 +1084,80 @@
             "type": {
               "type": "NameExpression",
               "name": "string"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
+      "name": "parseCsv",
+      "params": [
+        "csvData",
+        "parsingOptions",
+        "callback"
+      ],
+      "docs": {
+        "description": "The function `parseCsv` takes a CSV file string or stream and parsing options as input, and returns a promise that\nresolves to the parsed CSV data.\nOptions for `parsingOptions` include:\n- `delimiter` {string/Buffer/[string/Buffer]} - Defines the character(s) used to delimitate the fields inside a record. Default: `','`\n- `quote` {string/Buffer/[string/Buffer]} - Defines the characters used to surround a field. Default: `'\"'`\n- `escape` {Buffer/string/null/boolean} - Set the escape character as one character/byte only. Default: `\"`\n- `columns` {boolean / array / function} - Generates record in the form of object literals. Default: `true`\n- `bom` {boolean} - Strips the {@link https://en.wikipedia.org/wiki/Byte_order_mark byte order mark (BOM)} from the input string or buffer. Default: `true`\n- `trim` {boolean} - Ignore whitespace characters immediately around the `delimiter`. Default: `true`\n- `ltrim` {boolean} - Ignore whitespace characters from the left side of a CSV field. Default: `true`\n- `rtrim` {boolean} - Ignore whitespace characters from the right side of a CSV field. Default: `true`\n- `chunkSize` {number} - The size of each chunk of CSV data. Default: `Infinity`\n- `skip_empty_lines` {boolean} - The `skip_empty_lines` skips any line which is empty. Default: `true`",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "A CSV string or a readable stream",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "String"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Stream"
+                }
+              ]
+            },
+            "name": "csvData"
+          },
+          {
+            "title": "param",
+            "description": "Optional. Parsing options for converting CSV to JSON. \\n",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Object"
+              }
+            },
+            "name": "parsingOptions"
+          },
+          {
+            "title": "param",
+            "description": "(Optional) callback function. If used it will be called state and an array of rows.",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "function"
+              }
+            },
+            "name": "callback"
+          },
+          {
+            "title": "returns",
+            "description": "The function returns a Promise that resolves to the result of parsing a CSV `stringOrStream`.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
             }
           }
         ]

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -367,59 +367,6 @@
         ]
       },
       "valid": true
-    },
-    {
-      "name": "parseCSV",
-      "params": [
-        "target",
-        "config"
-      ],
-      "docs": {
-        "description": "CSV-Parse for CSV conversion to JSON",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "example",
-            "description": "parseCSV(\"/home/user/someData.csv\", {\n\t  quoteChar: '\"',\n\t  header: false,\n\t});"
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "string or local file with CSV data",
-            "type": {
-              "type": "NameExpression",
-              "name": "String"
-            },
-            "name": "target"
-          },
-          {
-            "title": "param",
-            "description": "csv-parse config object",
-            "type": {
-              "type": "NameExpression",
-              "name": "Object"
-            },
-            "name": "config"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "Operation"
-            }
-          }
-        ]
-      },
-      "valid": true
     }
   ],
   "exports": [],

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -16,8 +16,6 @@ import {
 import nodeRequest from 'request';
 import cheerio from 'cheerio';
 import cheerioTableparser from 'cheerio-tableparser';
-import fs from 'fs';
-import parse from 'csv-parse';
 import tough from 'tough-cookie';
 
 const { axios } = http;

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -328,52 +328,6 @@ export function parseXML(body, script) {
 }
 
 /**
- * CSV-Parse for CSV conversion to JSON
- * @public
- * @example
- *  parseCSV("/home/user/someData.csv", {
- * 	  quoteChar: '"',
- * 	  header: false,
- * 	});
- * @function
- * @param {String} target - string or local file with CSV data
- * @param {Object} config - csv-parse config object
- * @returns {Operation}
- */
-export function parseCSV(target, config) {
-  return state => {
-    return new Promise((resolve, reject) => {
-      var csvData = [];
-
-      try {
-        fs.readFileSync(target);
-        fs.createReadStream(target)
-          .pipe(parse(config))
-          .on('data', csvrow => {
-            console.log(csvrow);
-            csvData.push(csvrow);
-          })
-          .on('end', () => {
-            console.log(csvData);
-            resolve(composeNextState(state, csvData));
-          });
-      } catch (err) {
-        var csvString;
-        if (typeof target === 'string') {
-          csvString = target;
-        } else {
-          csvString = expandReferences(target)(state);
-        }
-        csvData = parse(csvString, config, (err, output) => {
-          console.log(output);
-          resolve(composeNextState(state, output));
-        });
-      }
-    });
-  };
-}
-
-/**
  * Make a request using the 'request' node module. This module is deprecated.
  * @example
  *  request(params);
@@ -421,4 +375,5 @@ export {
   sourceValue,
   splitKeys,
   toArray,
+  parseCsv,
 } from '@openfn/language-common';

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -531,21 +531,33 @@ describe('post', () => {
     const resultingState = await parseCsv(
       csv,
       { chunkSize: 2 },
-      async (state, rows) => {
-        // TODO: how do we write these in the real world? Like this?
-        if (rows.length > 0)
-          await post(
-            'https://www.example.com/api/csv-reader',
-            {
-              body: rows,
-            },
-            state => {
-              console.log("I'm a regular callback");
-              return state;
-            }
-          )(state);
-        return state;
-      }
+      (state, rows) =>
+        rows.length > 0 &&
+        post(
+          'https://www.example.com/api/csv-reader',
+          {
+            body: rows,
+          },
+          state => {
+            console.log("I'm a regular callback");
+            return state;
+          }
+        )(state)
+      // async (state, rows) => {
+      //   // TODO: how do we write these in the real world? Like this?
+      //   if (rows.length > 0)
+      //     await post(
+      //       'https://www.example.com/api/csv-reader',
+      //       {
+      //         body: rows,
+      //       },
+      //       state => {
+      //         console.log("I'm a regular callback");
+      //         return state;
+      //       }
+      //     )(state);
+      //   return state;
+      // }
     )(state);
 
     // TODO, is it be possible to write a callback above that puts the

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -513,7 +513,6 @@ describe('post', () => {
       .post('/api/csv-reader')
       .times(3)
       .reply(200, function (url, body) {
-        console.log('thanks for the message!', body);
         return body;
       });
 

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -532,41 +532,25 @@ describe('post', () => {
       csv,
       { chunkSize: 2 },
       (state, rows) =>
-        rows.length > 0 &&
         post(
           'https://www.example.com/api/csv-reader',
           {
             body: rows,
           },
           state => {
-            console.log("I'm a regular callback");
+            state.apiResponses.push(...state.response.data);
             return state;
           }
         )(state)
-      // async (state, rows) => {
-      //   // TODO: how do we write these in the real world? Like this?
-      //   if (rows.length > 0)
-      //     await post(
-      //       'https://www.example.com/api/csv-reader',
-      //       {
-      //         body: rows,
-      //       },
-      //       state => {
-      //         console.log("I'm a regular callback");
-      //         return state;
-      //       }
-      //     )(state);
-      //   return state;
-      // }
     )(state);
 
-    // TODO, is it be possible to write a callback above that puts the
-    // response of each http request into an "apiResponses" array?
-    console.log('resultingState', resultingState);
-
-    expect(resultingState).to.eql({
-      data: { references: [], data: [], apiResponses: [1, 2, 3] },
-    });
+    expect(resultingState.apiResponses).to.eql([
+      { id: '1', name: 'taylor' },
+      { id: '2', name: 'mtuchi' },
+      { id: '3', name: 'joe' },
+      { id: '4', name: 'stu' },
+      { id: '5', name: 'elias' },
+    ]);
   });
 
   it('can set JSON on the request body', async () => {

--- a/packages/sftp/ast.json
+++ b/packages/sftp/ast.json
@@ -810,6 +810,80 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "parseCsv",
+      "params": [
+        "csvData",
+        "parsingOptions",
+        "callback"
+      ],
+      "docs": {
+        "description": "The function `parseCsv` takes a CSV file string or stream and parsing options as input, and returns a promise that\nresolves to the parsed CSV data.\nOptions for `parsingOptions` include:\n- `delimiter` {string/Buffer/[string/Buffer]} - Defines the character(s) used to delimitate the fields inside a record. Default: `','`\n- `quote` {string/Buffer/[string/Buffer]} - Defines the characters used to surround a field. Default: `'\"'`\n- `escape` {Buffer/string/null/boolean} - Set the escape character as one character/byte only. Default: `\"`\n- `columns` {boolean / array / function} - Generates record in the form of object literals. Default: `true`\n- `bom` {boolean} - Strips the {@link https://en.wikipedia.org/wiki/Byte_order_mark byte order mark (BOM)} from the input string or buffer. Default: `true`\n- `trim` {boolean} - Ignore whitespace characters immediately around the `delimiter`. Default: `true`\n- `ltrim` {boolean} - Ignore whitespace characters from the left side of a CSV field. Default: `true`\n- `rtrim` {boolean} - Ignore whitespace characters from the right side of a CSV field. Default: `true`\n- `chunkSize` {number} - The size of each chunk of CSV data. Default: `Infinity`\n- `skip_empty_lines` {boolean} - The `skip_empty_lines` skips any line which is empty. Default: `true`",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "A CSV string or a readable stream",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "String"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Stream"
+                }
+              ]
+            },
+            "name": "csvData"
+          },
+          {
+            "title": "param",
+            "description": "Optional. Parsing options for converting CSV to JSON. \\n",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Object"
+              }
+            },
+            "name": "parsingOptions"
+          },
+          {
+            "title": "param",
+            "description": "(Optional) callback function. If used it will be called state and an array of rows.",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "function"
+              }
+            },
+            "name": "callback"
+          },
+          {
+            "title": "returns",
+            "description": "The function returns a Promise that resolves to the result of parsing a CSV `stringOrStream`.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Use  `common` `parseCsv` in `http` and `bigquery`

## Issues #273 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
