### PR TITLE
Noodle: run actual job code in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "license": "ISC",
   "devDependencies": {
     "@changesets/cli": "2.25.0",
-    "@openfn/buildtools": "workspace:^1.0.2",
-    "@openfn/metadata": "workspace:^1.0.1",
-    "@openfn/parse-jsdoc": "workspace:^1.0.0",
+    "@openfn/buildtools": "workspace:*",
+    "@openfn/metadata": "workspace:*",
+    "@openfn/parse-jsdoc": "workspace:*",
     "@openfn/simple-ast": "0.4.1",
+    "@openfn/test-execute": "workspace:*",
     "eslint": "8.26.0"
   }
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -12,8 +12,8 @@
   },
   "scripts": {
     "build": "pnpm clean && build-adaptor template",
-    "test": "mocha --experimental-specifier-resolution=node --no-warnings",
-    "test:watch": "mocha -w --experimental-specifier-resolution=node --no-warnings",
+    "test": "mocha --experimental-specifier-resolution=node --experimental-vm-modules --no-warnings",
+    "test:watch": "mocha -w --experimental-specifier-resolution=node --experimental-vm-modules --no-warnings",
     "clean": "rimraf dist types docs",
     "pack": "pnpm pack --pack-destination ../../dist",
     "lint": "eslint src"
@@ -30,8 +30,6 @@
     "@openfn/language-common": "^1.8.1"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
-    "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",
     "deep-eql": "4.1.1",

--- a/packages/template/src/Adaptor.js
+++ b/packages/template/src/Adaptor.js
@@ -18,6 +18,7 @@ import { request } from './Utils';
  * @returns {Operation}
  */
 export function execute(...operations) {
+  console.log('CUSTOM EXECUTE')
   const initialState = {
     references: [],
     data: null,

--- a/packages/template/test/Adaptor.test.js
+++ b/packages/template/test/Adaptor.test.js
@@ -1,10 +1,9 @@
 import { expect } from 'chai';
-// import { execute, create, dataValue } from '../src/Adaptor.js';
-import * as Adaptor from '../src/Adaptor.js';
 import execute from '@openfn/test-execute';
-
-import MockAgent from './mockAgent.js';
 import { setGlobalDispatcher } from 'undici';
+
+import * as Adaptor from '../src/Adaptor.js';
+import MockAgent from './mockAgent.js';
 
 setGlobalDispatcher(MockAgent);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,11 @@ importers:
   .:
     specifiers:
       '@changesets/cli': 2.25.0
-      '@openfn/buildtools': workspace:^1.0.2
-      '@openfn/metadata': workspace:^1.0.1
-      '@openfn/parse-jsdoc': workspace:^1.0.0
+      '@openfn/buildtools': workspace:*
+      '@openfn/metadata': workspace:*
+      '@openfn/parse-jsdoc': workspace:*
       '@openfn/simple-ast': 0.4.1
+      '@openfn/test-execute': workspace:*
       eslint: 8.26.0
     devDependencies:
       '@changesets/cli': 2.25.0
@@ -16,6 +17,7 @@ importers:
       '@openfn/metadata': link:tools/metadata
       '@openfn/parse-jsdoc': link:tools/parse-jsdoc
       '@openfn/simple-ast': 0.4.1
+      '@openfn/test-execute': link:tools/execute
       eslint: 8.26.0
 
   packages/asana:
@@ -1301,9 +1303,7 @@ importers:
 
   packages/template:
     specifiers:
-      '@openfn/buildtools': workspace:^1.0.2
       '@openfn/language-common': ^1.8.1
-      '@openfn/simple-ast': 0.4.1
       assertion-error: 2.0.0
       chai: 4.3.6
       deep-eql: 4.1.1
@@ -1314,8 +1314,6 @@ importers:
     dependencies:
       '@openfn/language-common': link:../common
     devDependencies:
-      '@openfn/buildtools': link:../../tools/build
-      '@openfn/simple-ast': 0.4.1
       assertion-error: 2.0.0
       chai: 4.3.6
       deep-eql: 4.1.1
@@ -1434,6 +1432,14 @@ importers:
       tsup: 6.3.0_mwhvu7sfp6vq5ryuwb6hlbjfka
       typescript: 4.8.4
       yargs: 17.6.0
+
+  tools/execute:
+    specifiers:
+      '@openfn/compiler': ^0.0.32
+      '@openfn/runtime': file:/home/joe/repo/openfn/kit/dist/openfn-runtime-0.0.25.tgz
+    dependencies:
+      '@openfn/compiler': 0.0.32
+      '@openfn/runtime': file:../kit/dist/openfn-runtime-0.0.25.tgz
 
   tools/import-tests:
     specifiers:
@@ -2535,6 +2541,41 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@inquirer/confirm/0.0.28-alpha.0:
+    resolution: {integrity: sha512-ZpQQMRt0yign/M2F/PRv+RwnjRhLZz2OIU3ohhDS0H6LoY2/W6xiPJpRJYxb15KN8n/QRql0yXzPg0ugeHCwKg==}
+    dependencies:
+      '@inquirer/core': 0.0.30-alpha.0
+      '@inquirer/input': 0.0.28-alpha.0
+      chalk: 5.2.0
+    dev: false
+
+  /@inquirer/core/0.0.30-alpha.0:
+    resolution: {integrity: sha512-bLDyC8LA+Aqy0/uAo9pm53qRFBvFexdo5Z1MTXbMAniNB8SeC6HtQnd4TRCJQVYbpR4C//xVtqB+jOD3oLSaCw==}
+    dependencies:
+      '@inquirer/type': 0.0.4-alpha.0
+      ansi-escapes: 6.2.0
+      chalk: 5.2.0
+      cli-spinners: 2.9.0
+      cli-width: 4.0.0
+      lodash: 4.17.21
+      mute-stream: 0.0.8
+      run-async: 2.4.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+      wrap-ansi: 8.1.0
+    dev: false
+
+  /@inquirer/input/0.0.28-alpha.0:
+    resolution: {integrity: sha512-jbMvmAY7irZFQco9i1+H+S/yMozOEvBp+gYgk1zhP+1J/4dBywCi3E/s0U6eq/U3CUm5HaxkRphl9d9OP13Lpg==}
+    dependencies:
+      '@inquirer/core': 0.0.30-alpha.0
+      chalk: 5.2.0
+    dev: false
+
+  /@inquirer/type/0.0.4-alpha.0:
+    resolution: {integrity: sha512-D+6Z4o89zClJkfM6tMaASjiS29YzAMi18/ZgG1nxUhMLjldSnnRUw6EceIqv4fZp5PL2O6MyZkcV9c4GgREdKg==}
+    dev: false
+
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -2652,6 +2693,45 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+
+  /@openfn/compiler/0.0.32:
+    resolution: {integrity: sha512-wrMORSFLSHNzu+Eh7Yj/Or17rMaBDovW5k/ilRmtUtc0Xw8ducR1vqXN1eL4OGXBmenjCLVtXaaGA0M/MwkXVw==}
+    engines: {node: '>=16', pnpm: '>=7'}
+    dependencies:
+      '@openfn/describe-package': 0.0.16
+      '@openfn/logger': 0.0.13
+      acorn: 8.8.1
+      ast-types: 0.14.2
+      recast: 0.21.5
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@openfn/describe-package/0.0.16:
+    resolution: {integrity: sha512-q7MILQ/f0V3tRBMC2DxIrYp1WXvMy0SUHs3ujPv1+zNDAPCPiatnsc3UO/q8S3BA6xt6HCss0yhFdv8p7YBl+Q==}
+    engines: {node: '>=16', pnpm: '>=7'}
+    dependencies:
+      '@typescript/vfs': 1.4.0
+      cross-fetch: 3.1.6
+      node-localstorage: 2.2.1
+      typescript: 4.8.4
+      url-join: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@openfn/logger/0.0.13:
+    resolution: {integrity: sha512-5xx2D6CJBKohhP8AENItOT8nDBUvlkeSeMm6xfxcaXcjdhn9Ff2kN75dTKbs5KdgB4GNgMOl0zb3Ju4l2HXaIA==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@inquirer/confirm': 0.0.28-alpha.0
+      chalk: 5.2.0
+      fast-safe-stringify: 2.1.1
+      figures: 5.0.0
+    dev: false
 
   /@openfn/simple-ast/0.3.2:
     resolution: {integrity: sha512-NIvZsKSBQmGjQwqv8uDFpsTQquHkpoBH09pg+SJsInoa4L8CEW1g+ZU2O9D+i4xYeNciYb1nsfJ9n9TjxYAvzg==}
@@ -2852,6 +2932,14 @@ packages:
       '@types/node': 18.11.7
     dev: true
 
+  /@typescript/vfs/1.4.0:
+    resolution: {integrity: sha512-Pood7yv5YWMIX+yCHo176OnF8WUlKGImFG7XlsuH14Zb1YN5+dYD3uUtS7lqZtsH7tAveNUi2NzdpQCN0yRbaw==}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@ungap/promise-all-settled/1.1.2:
     resolution: {integrity: sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==}
     dev: true
@@ -2956,6 +3044,13 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       array-back: 3.1.0
+    dev: false
+
+  /ansi-escapes/6.2.0:
+    resolution: {integrity: sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      type-fest: 3.12.0
     dev: false
 
   /ansi-regex/2.1.1:
@@ -3214,7 +3309,14 @@ packages:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
+    dev: false
+
+  /ast-types/0.15.2:
+    resolution: {integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==}
+    engines: {node: '>=4'}
+    dependencies:
+      tslib: 2.5.0
     dev: false
 
   /async-each/1.0.3:
@@ -4635,12 +4737,22 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /cli-spinners/2.9.0:
+    resolution: {integrity: sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==}
+    engines: {node: '>=6'}
+    dev: false
+
   /cli-truncate/3.1.0:
     resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       slice-ansi: 5.0.0
       string-width: 5.1.2
+    dev: false
+
+  /cli-width/4.0.0:
+    resolution: {integrity: sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==}
+    engines: {node: '>= 12'}
     dev: false
 
   /cliui/3.2.0:
@@ -4859,7 +4971,7 @@ packages:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       md5-hex: 3.0.1
-      semver: 7.3.8
+      semver: 7.5.1
       well-known-symbols: 2.0.0
     dev: false
 
@@ -4933,6 +5045,14 @@ packages:
 
   /create-require/1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: false
+
+  /cross-fetch/3.1.6:
+    resolution: {integrity: sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==}
+    dependencies:
+      node-fetch: 2.6.11
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /cross-spawn/5.1.0:
@@ -8109,7 +8229,7 @@ packages:
       jws: 3.2.2
       lodash: 4.17.21
       ms: 2.1.3
-      semver: 7.5.0
+      semver: 7.5.1
     dev: false
 
   /jsprim/1.4.2:
@@ -8261,7 +8381,7 @@ packages:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
@@ -8961,6 +9081,10 @@ packages:
     hasBin: true
     dev: false
 
+  /mute-stream/0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+    dev: false
+
   /mysql/2.18.1:
     resolution: {integrity: sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==}
     engines: {node: '>= 0.6'}
@@ -9131,6 +9255,18 @@ packages:
       semver: 5.7.1
     dev: true
 
+  /node-fetch/2.6.11:
+    resolution: {integrity: sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
   /node-fetch/2.6.9:
     resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
     engines: {node: 4.x || >=6.0.0}
@@ -9146,6 +9282,13 @@ packages:
   /node-forge/1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
+    dev: false
+
+  /node-localstorage/2.2.1:
+    resolution: {integrity: sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      write-file-atomic: 1.3.4
     dev: false
 
   /node-releases/2.0.12:
@@ -10216,6 +10359,16 @@ packages:
     dependencies:
       picomatch: 2.3.1
 
+  /recast/0.21.5:
+    resolution: {integrity: sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==}
+    engines: {node: '>= 4'}
+    dependencies:
+      ast-types: 0.15.2
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tslib: 2.5.0
+    dev: false
+
   /redent/3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -10511,6 +10664,11 @@ packages:
     resolution: {integrity: sha512-R3wLbuAYejpxQjL/SjXo1Cjv4wcJECnMRT/FlcCfTwCBhaji9rWaRCoVEQ1SPiTJ4kKK+yh+bZLAV7SCafoDDw==}
     dev: false
 
+  /run-async/2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+    dev: false
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -10745,6 +10903,10 @@ packages:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 4.0.0
+    dev: false
+
+  /slide/1.1.6:
+    resolution: {integrity: sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==}
     dev: false
 
   /smart-buffer/4.2.0:
@@ -11393,7 +11555,7 @@ packages:
       indent-string: 5.0.0
       js-yaml: 3.14.1
       serialize-error: 7.0.1
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
     dev: false
 
   /supports-color/2.0.0:
@@ -11734,10 +11896,6 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /tslib/2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-    dev: false
-
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: false
@@ -11881,6 +12039,11 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
     dev: true
+
+  /type-fest/3.12.0:
+    resolution: {integrity: sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==}
+    engines: {node: '>=14.16'}
+    dev: false
 
   /typed-array-length/1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
@@ -12046,6 +12209,11 @@ packages:
     deprecated: Please see https://github.com/lydell/urix#deprecated
     dev: true
     optional: true
+
+  /url-join/5.0.0:
+    resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
 
   /url-parse/1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -12338,8 +12506,25 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  /wrap-ansi/8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+    dev: false
+
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  /write-file-atomic/1.3.4:
+    resolution: {integrity: sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==}
+    dependencies:
+      graceful-fs: 4.2.11
+      imurmurhash: 0.1.4
+      slide: 1.1.6
+    dev: false
 
   /write-file-atomic/5.0.0:
     resolution: {integrity: sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==}
@@ -12602,6 +12787,16 @@ packages:
   /yocto-queue/1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: false
+
+  file:../kit/dist/openfn-runtime-0.0.25.tgz:
+    resolution: {integrity: sha512-sJ0uLjbPgqRt2zhAaZ9GseIm0QuAtUMYGOBSAlYaj7oLqhGwiNKTun/f6+aYGDJ+yJozOHIhvT2RKEV7YA5u+w==, tarball: file:../kit/dist/openfn-runtime-0.0.25.tgz}
+    name: '@openfn/runtime'
+    version: 0.0.25
+    dependencies:
+      '@openfn/logger': 0.0.13
+      fast-safe-stringify: 2.1.1
+      semver: 7.5.1
     dev: false
 
   github.com/openfn/language-common/b8047f82680d95387cbe4596f55e24e4d0b128c6:

--- a/tools/execute/execute.js
+++ b/tools/execute/execute.js
@@ -1,0 +1,25 @@
+/*
+helper function to execute job source in unit tests
+
+We need to basucally inject the adaptor api at runtime
+
+Is this going to handle execute overrides properly though? I don't think the runtime will see them
+*/
+
+import compile from '@openfn/compiler';
+import execute from '@openfn/runtime';
+
+export default (job, adaptor, state = {}) => {
+  // Compile without an adaptor, so there's no import statements
+  const compiledJob = compile(job)
+  try {
+    return execute(compiledJob, state, {
+      globals: {
+        ...adaptor,
+      },
+      strict: false
+    })
+  } catch(e) {
+    console.error(e)
+  }
+}

--- a/tools/execute/execute.js
+++ b/tools/execute/execute.js
@@ -1,10 +1,6 @@
-/*
-helper function to execute job source in unit tests
-
-We need to basucally inject the adaptor api at runtime
-
-Is this going to handle execute overrides properly though? I don't think the runtime will see them
-*/
+/**
+ * Helper function to execute job source in unit tests
+ */
 
 import compile from '@openfn/compiler';
 import execute from '@openfn/runtime';
@@ -12,14 +8,10 @@ import execute from '@openfn/runtime';
 export default (job, adaptor, state = {}) => {
   // Compile without an adaptor, so there's no import statements
   const compiledJob = compile(job)
-  try {
-    return execute(compiledJob, state, {
-      globals: {
-        ...adaptor,
-      },
-      strict: false
-    })
-  } catch(e) {
-    console.error(e)
-  }
+  return execute(compiledJob, state, {
+    globals: {
+      ...adaptor,
+    },
+    strict: false
+  })
 }

--- a/tools/execute/index.js
+++ b/tools/execute/index.js
@@ -1,0 +1,3 @@
+import execute from './execute';
+
+export default execute;

--- a/tools/execute/package.json
+++ b/tools/execute/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openfn/test-execute",
+  "version": "1.0.0",
+  "description": "Unit test helper to run jobs from source",
+  "main": "index.js",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@openfn/compiler": "^0.0.32",
+    "@openfn/runtime": "file:/home/joe/repo/openfn/kit/dist/openfn-runtime-0.0.25.tgz"
+  }
+}


### PR DESCRIPTION
Imagine if our unit tests looked like this:
```
  it('executes each operation in sequence', async () => {
    const job = `
      fn(() => ({ counter: 1 }))
      fn(() => ({ counter: 2 }))
      fn(() => ({ counter: 3 }))
    `

    const finalState = await execute(job, Adaptor)
    expect(finalState).to.eql({ counter: 3 });
  });
```
It would be so much easier to write tests and properly compose operations.

I've tested this in `template` just to get a vibe for how it works. So far so good.

This depends on changes in kit. I expect it to fail on local machines right now.

## How it works

I've added a helped function in `tools` which calls `@openfn/compile` and `@openfn/execute`.

Usually the compiler will inject an import statement for the adaptor, and the runtime's linker will load it. But because we want to unit test from source, not the built adaptor, this doesn't really work.

So instead, we inject the adaptor function's exports into the runtime as globals. This is good enough to run adaptor code through the actual runtime pipeline.

I've added support to the runtime to:
a) accept globals injected into the runtime context.
b) use `globals.execute`, if available, instead of the default execute function 

## Still to do

This is just an initial spike/noodle into what a solution might be.

We need to think about and merge the changes in kit. I am having some problems pushing to kit from this laptop (??) so this ma need to wait until I get back.

Aside from adding/rewriting tests, I'm not sure much else is needed here