### PR TITLE
Normalize access token

### DIFF
--- a/.changeset/large-monkeys-protect.md
+++ b/.changeset/large-monkeys-protect.md
@@ -1,0 +1,11 @@
+---
+'@openfn/language-common': minor
+'@openfn/language-dynamics': patch
+'@openfn/language-facebook': patch
+'@openfn/language-googlehealthcare': patch
+'@openfn/language-googlesheets': patch
+'@openfn/language-msgraph': patch
+---
+
+Ensure that standard OAuth2 credentials with snake-cased "access_token" keys can
+be used for OAuth2-reliant adaptors

--- a/packages/common/src/util.js
+++ b/packages/common/src/util.js
@@ -1,15 +1,15 @@
 /**
  * General-purpose utility functions
- * 
+ *
  * These are designed more for use in adaptor code than job code
  * (but we could choose to export util from common)
- * 
+ *
  * None of these functions are operation factories
  */
 
 // TODO this doesn't currently support skip
 export function expandReferences(state, ...args) {
-  return args.map((value) => expandReference(state, value));
+  return args.map(value => expandReference(state, value));
 }
 
 function expandReference(state, value) {
@@ -27,4 +27,25 @@ function expandReference(state, value) {
     return expandReference(state, value(state));
   }
   return value;
+}
+
+export function normalizeOauthConfig(configuration) {
+  const { access_token, accessToken } = configuration;
+
+  if (access_token && accessToken)
+    throw new Error(
+      'Both "accessToken" & "access_token" keys found in configuration; ' +
+        'please use only "access_token" for OAuth2 credentials.'
+    );
+
+  if (access_token) return { ...configuration, accessToken: access_token };
+
+  console.log(
+    'Key "access_token" not found in state.configuration;',
+    'is this a standard OAuth 2.0 JSON credential?'
+  );
+
+  if (accessToken) console.log('Using "accessToken" from state.configuration');
+
+  return configuration;
 }

--- a/packages/common/test/util.test.js
+++ b/packages/common/test/util.test.js
@@ -1,66 +1,97 @@
 import { expect } from 'chai';
-import { expandReferences } from '../src/util';
+import { expandReferences, normalizeOauthConfig } from '../src/util';
 
-describe('util', () => {
-  it('should not expand references', () => {
+describe('util expandReferences', () => {
+  it('should not modify string references', () => {
     const name = 'mulder';
     const state = {};
 
-    const [resolvedName] = expandReferences(state, name)
+    const [resolvedName] = expandReferences(state, name);
 
-    expect(resolvedName).to.equal('mulder')
+    expect(resolvedName).to.equal('mulder');
   });
 
   it('should expand function references', () => {
     const state = { name: 'mulder' };
-    const name = (s) => s.name;
+    const name = s => s.name;
 
-    const [resolvedName] = expandReferences(state, name)
+    const [resolvedName] = expandReferences(state, name);
 
-    expect(resolvedName).to.equal('mulder')
+    expect(resolvedName).to.equal('mulder');
   });
 
   it('should recursively expand function references', () => {
     const state = { name: 'mulder' };
-    const name = (s) => (s) => s.name;
+    const name = s => s => s.name;
 
-    const [resolvedName] = expandReferences(state, name)
+    const [resolvedName] = expandReferences(state, name);
 
-    expect(resolvedName).to.equal('mulder')
+    expect(resolvedName).to.equal('mulder');
   });
 
-  it('should expand multiple referencws', () => {
+  it('should expand multiple references', () => {
     const state = { name: 'mulder', truth: 'out there' };
-    const name = (s) => s.name;
-    const truth = (s) => s.truth;
+    const name = s => s.name;
+    const truth = s => s.truth;
 
-    const [resolvedName, resolvedTruth] = expandReferences(state, name, truth)
+    const [resolvedName, resolvedTruth] = expandReferences(state, name, truth);
 
-    expect(resolvedName).to.equal('mulder')
-    expect(resolvedTruth).to.equal('out there')
+    expect(resolvedName).to.equal('mulder');
+    expect(resolvedTruth).to.equal('out there');
   });
 
   it('should expand array references', () => {
     const state = { name: 'mulder' };
-    const name = ['fox', (s) => s.name];
+    const name = ['fox', s => s.name];
 
-    const [resolvedName] = expandReferences(state, name)
+    const [resolvedName] = expandReferences(state, name);
 
     const [fname, sname] = resolvedName;
-    expect(fname).to.equal('fox')
-    expect(sname).to.equal('mulder')
+    expect(fname).to.equal('fox');
+    expect(sname).to.equal('mulder');
   });
 
   it('should expand object references', () => {
     const state = { name: 'mulder' };
     const name = {
       first: 'fox',
-      second: (s) => s.name
+      second: s => s.name,
     };
 
-    const [resolvedName] = expandReferences(state, name)
+    const [resolvedName] = expandReferences(state, name);
 
-    expect(resolvedName.first).to.equal('fox')
-    expect(resolvedName.second).to.equal('mulder')
+    expect(resolvedName.first).to.equal('fox');
+    expect(resolvedName.second).to.equal('mulder');
+  });
+});
+
+describe('util normalizeOauthConfig', () => {
+  it('should create an `accessToken` key for a standard OAuth2 JSON credential', () => {
+    const configuration = { access_token: 'abc123' };
+
+    const normalizedConfig = normalizeOauthConfig(configuration);
+
+    expect(normalizedConfig).to.eql({
+      ...configuration,
+      accessToken: 'abc123',
+    });
+  });
+
+  it('should use `accessToken` if `access_token` is not provided', () => {
+    const configuration = { accessToken: 'def456' };
+
+    const normalizedConfig = normalizeOauthConfig(configuration);
+
+    expect(normalizedConfig).to.eql({
+      accessToken: 'def456',
+    });
+  });
+
+  it('should throw an error when both `accessToken` and `access_token` are provided', () => {
+    const configuration = { access_token: 'abc123', accessToken: 'def456' };
+
+    expect(function () {
+      normalizeOauthConfig(configuration);
+    }).to.throw('Both "accessToken" & "access_token" keys found');
   });
 });

--- a/packages/dynamics/configuration-schema.json
+++ b/packages/dynamics/configuration-schema.json
@@ -1,42 +1,35 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-        "resource": {
-            "title": "Resource",
-            "type": "string",
-            "description": "Dynamics resource URL",
-            "format": "uri",
-            "minLength": 1,
-            "examples": [
-                "https://openfn.crm2.dynamics.com"
-            ]
-        },
-        "apiVersion": {
-            "title": "API Version",
-            "type": "string",
-            "default": "8.2.0",
-            "description": "Dynamics API version to use",
-            "minLength": 1,
-            "examples": [
-                "8.2.0"
-            ]
-        },
-        "accessToken": {
-            "title": "Access Token",
-            "type": "string",
-            "description": "Dynamics API access token",
-            "writeOnly": true,
-            "minLength": 1,
-            "examples": [
-                "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjlGWERwYmZNRlQyU3ZRdVhoODQ2WVR3RUlCdyIsI"
-            ]
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "OAuth2",
+  "properties": {
+    "resource": {
+      "title": "Resource",
+      "type": "string",
+      "description": "Dynamics resource URL",
+      "format": "uri",
+      "minLength": 1,
+      "examples": ["https://openfn.crm2.dynamics.com"]
     },
-    "type": "object",
-    "additionalProperties": true,
-    "required": [
-        "resource",
-        "apiVersion",
-        "accessToken"
-    ]
+    "apiVersion": {
+      "title": "API Version",
+      "type": "string",
+      "default": "8.2.0",
+      "description": "Dynamics API version to use",
+      "minLength": 1,
+      "examples": ["8.2.0"]
+    },
+    "access_token": {
+      "title": "Access Token",
+      "type": "string",
+      "description": "Dynamics API access token",
+      "writeOnly": true,
+      "minLength": 1,
+      "examples": [
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjlGWERwYmZNRlQyU3ZRdVhoODQ2WVR3RUlCdyIsI"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["resource", "apiVersion", "access_token"]
 }

--- a/packages/dynamics/src/Adaptor.js
+++ b/packages/dynamics/src/Adaptor.js
@@ -2,7 +2,7 @@ import {
   execute as commonExecute,
   expandReferences,
 } from '@openfn/language-common';
-import { normalizeOauthConfig } from '@openfn/language-common/src/util';
+import { normalizeOauthConfig } from '@openfn/language-common/util';
 import request from 'request';
 
 /**

--- a/packages/dynamics/src/Adaptor.js
+++ b/packages/dynamics/src/Adaptor.js
@@ -2,6 +2,7 @@ import {
   execute as commonExecute,
   expandReferences,
 } from '@openfn/language-common';
+import { normalizeOauthConfig } from '@openfn/language-common/src/util';
 import request from 'request';
 
 /**
@@ -23,7 +24,11 @@ export function execute(...operations) {
   };
 
   return state => {
-    return commonExecute(...operations)({ ...initialState, ...state });
+    return commonExecute(...operations)({
+      ...initialState,
+      ...state,
+      configuration: normalizeOauthConfig(state.configuration),
+    });
   };
 }
 

--- a/packages/facebook/configuration-schema.json
+++ b/packages/facebook/configuration-schema.json
@@ -1,17 +1,16 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-        "accessToken": {
-            "title": "Access Token",
-            "type": "string",
-            "description": "Your Facebook API access token",
-            "writeOnly": true,
-            "minLength": 1
-        }
-    },
-    "type": "object",
-    "additionalProperties": true,
-    "required": [
-        "accessToken"
-    ]
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "OAuth2",
+  "properties": {
+    "access_token": {
+      "title": "Access Token",
+      "type": "string",
+      "description": "Your Facebook API access token",
+      "writeOnly": true,
+      "minLength": 1
+    }
+  },
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["access_token"]
 }

--- a/packages/facebook/src/Adaptor.js
+++ b/packages/facebook/src/Adaptor.js
@@ -3,6 +3,7 @@ import {
   expandReferences,
   composeNextState,
 } from '@openfn/language-common';
+import { normalizeOauthConfig } from '@openfn/language-common/src/util';
 import request from 'request';
 
 /**
@@ -27,6 +28,7 @@ export function execute(...operations) {
     return commonExecute(...operations)({
       ...initialState,
       ...state,
+      configuration: normalizeOauthConfig(state.configuration),
     });
   };
 }

--- a/packages/facebook/src/Adaptor.js
+++ b/packages/facebook/src/Adaptor.js
@@ -3,7 +3,7 @@ import {
   expandReferences,
   composeNextState,
 } from '@openfn/language-common';
-import { normalizeOauthConfig } from '@openfn/language-common/src/util';
+import { normalizeOauthConfig } from '@openfn/language-common/util';
 import request from 'request';
 
 /**

--- a/packages/facebook/test/index.js
+++ b/packages/facebook/test/index.js
@@ -8,7 +8,7 @@ const { execute, post } = Adaptor;
 
 describe('execute', () => {
   it('executes each operation in sequence', done => {
-    let state = {};
+    let state = { configuration: {}, data: {} };
     let operations = [
       state => {
         return { counter: 1 };
@@ -30,7 +30,7 @@ describe('execute', () => {
   });
 
   it('assigns references, data to the initialState', () => {
-    let state = {};
+    let state = { configuration: {}, data: {} };
 
     let finalState = execute()(state);
 

--- a/packages/googlehealthcare/configuration-schema.json
+++ b/packages/googlehealthcare/configuration-schema.json
@@ -1,8 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "OAuth2",
   "type": "object",
   "properties": {
-    "accessToken": {
+    "access_token": {
       "title": "Access Token",
       "type": "string",
       "description": "Your Google Cloud Healthcare access token",
@@ -17,34 +18,23 @@
       "type": "string",
       "description": "The API version",
       "default": "v1",
-      "examples": [
-        "v1",
-        "v1beta1"
-      ]
+      "examples": ["v1", "v1beta1"]
     },
     "cloudRegion": {
       "type": "string",
-      "examples": [
-        "us-central1"
-      ]
+      "examples": ["us-central1"]
     },
     "projectId": {
       "type": "string",
-      "examples": [
-        "adjective-noun-123"
-      ]
+      "examples": ["adjective-noun-123"]
     },
     "datasetId": {
       "type": "string",
-      "examples": [
-        "my-dataset"
-      ]
+      "examples": ["my-dataset"]
     },
     "fhirStoreId": {
       "type": "string",
-      "examples": [
-        "my-fhir-store"
-      ]
+      "examples": ["my-fhir-store"]
     }
   },
   "required": [
@@ -52,6 +42,6 @@
     "projectId",
     "datasetId",
     "fhirStoreId",
-    "accessToken"
+    "access_token"
   ]
 }

--- a/packages/googlehealthcare/src/Adaptor.js
+++ b/packages/googlehealthcare/src/Adaptor.js
@@ -2,7 +2,10 @@ import {
   execute as commonExecute,
   composeNextState,
 } from '@openfn/language-common';
-import { expandReferences } from '@openfn/language-common/util';
+import {
+  expandReferences,
+  normalizeOauthConfig,
+} from '@openfn/language-common/util';
 
 import { buildUrl, request } from './Utils';
 
@@ -28,6 +31,7 @@ export function execute(...operations) {
     return commonExecute(...operations)({
       ...initialState,
       ...state,
+      configuration: normalizeOauthConfig(state.configuration),
     });
   };
 }
@@ -89,9 +93,7 @@ export function createFhirResource(resource, callback) {
     });
 
     const payload = {
-      auth: {
-        accessToken: accessToken,
-      },
+      auth: { accessToken },
       ...resolvedResource,
     };
 

--- a/packages/googlehealthcare/test/Adaptor.test.js
+++ b/packages/googlehealthcare/test/Adaptor.test.js
@@ -46,7 +46,7 @@ describe('createFhirResource', () => {
         projectId: 'test-007',
         datasetId: 'fhir-007',
         fhirStoreId: 'testing-fhir-007',
-        accessToken: 'aGVsbG86dGhlcmU=',
+        access_token: 'aGVsbG86dGhlcmU=',
       },
       data: {
         resourceType: 'Patient',

--- a/packages/googlehealthcare/test/Adaptor.test.js
+++ b/packages/googlehealthcare/test/Adaptor.test.js
@@ -8,7 +8,7 @@ setGlobalDispatcher(MockAgent);
 
 describe('execute', () => {
   it('executes each operation in sequence', done => {
-    const state = {};
+    const state = { configuration: {}, data: {} };
     const operations = [
       state => {
         return { counter: 1 };
@@ -30,7 +30,7 @@ describe('execute', () => {
   });
 
   it('assigns references, data to the initialState', () => {
-    const state = {};
+    const state = { configuration: {}, data: {} };
 
     execute()(state).then(finalState => {
       expect(finalState).to.eql({ references: [], data: null });

--- a/packages/googlesheets/configuration-schema.json
+++ b/packages/googlesheets/configuration-schema.json
@@ -1,20 +1,19 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-        "accessToken": {
-            "title": "Access Token",
-            "type": "string",
-            "description": "Your Google Sheets access token",
-            "writeOnly": true,
-            "minLength": 1,
-            "examples": [
-                "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjlGWERwYmZNRlQyU3ZRdVhoODQ2WVR3RUlCdyIsI"
-            ]
-        }
-    },
-    "type": "object",
-    "additionalProperties": true,
-    "required": [
-        "accessToken"
-    ]
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "OAuth2",
+  "properties": {
+    "access_token": {
+      "title": "Access Token",
+      "type": "string",
+      "description": "Your Google Sheets access token",
+      "writeOnly": true,
+      "minLength": 1,
+      "examples": [
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjlGWERwYmZNRlQyU3ZRdVhoODQ2WVR3RUlCdyIsI"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["access_token"]
 }

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -1,10 +1,9 @@
 import {
   execute as commonExecute,
   expandReferences,
-} from "@openfn/language-common";
-import { google } from "googleapis";
-
-
+} from '@openfn/language-common';
+import { normalizeOauthConfig } from '@openfn/language-common/src/util';
+import { google } from 'googleapis';
 
 /**
  * Execute a sequence of operations.
@@ -26,10 +25,14 @@ export function execute(...operations) {
 
   // why not here?
 
-  return (state) => {
+  return state => {
     // Note: we no longer need `steps` anymore since `commonExecute`
     // takes each operation as an argument.
-    return commonExecute(...operations)({ ...initialState, ...state });
+    return commonExecute(...operations)({
+      ...initialState,
+      ...state,
+      configuration: normalizeOauthConfig(state.configuration),
+    });
   };
 }
 
@@ -51,7 +54,7 @@ export function execute(...operations) {
  * @returns {Operation}
  */
 export function appendValues(params) {
-  return (state) => {
+  return state => {
     const { accessToken } = state.configuration;
 
     const oauth2Client = new google.auth.OAuth2();
@@ -59,7 +62,7 @@ export function appendValues(params) {
 
     const { spreadsheetId, range, values } = expandReferences(params)(state);
 
-    var sheets = google.sheets("v4");
+    var sheets = google.sheets('v4');
 
     return new Promise((resolve, reject) => {
       sheets.spreadsheets.values.append(
@@ -67,20 +70,20 @@ export function appendValues(params) {
           auth: oauth2Client,
           spreadsheetId,
           range,
-          valueInputOption: "USER_ENTERED",
+          valueInputOption: 'USER_ENTERED',
           resource: {
             range,
-            majorDimension: "ROWS",
+            majorDimension: 'ROWS',
             values: values,
           },
         },
         function (err, response) {
           if (err) {
-            console.log("The API returned an error:");
+            console.log('The API returned an error:');
             console.log(err);
             reject(err);
           } else {
-            console.log("Success! Here is the response from Google:");
+            console.log('Success! Here is the response from Google:');
             console.log(response);
             resolve(state);
           }
@@ -103,4 +106,4 @@ export {
   lastReferenceValue,
   merge,
   sourceValue,
-} from "@openfn/language-common";
+} from '@openfn/language-common';

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -2,7 +2,7 @@ import {
   execute as commonExecute,
   expandReferences,
 } from '@openfn/language-common';
-import { normalizeOauthConfig } from '@openfn/language-common/src/util';
+import { normalizeOauthConfig } from '@openfn/language-common/util';
 import { google } from 'googleapis';
 
 /**

--- a/packages/googlesheets/test/index.js
+++ b/packages/googlesheets/test/index.js
@@ -3,22 +3,22 @@ import { expect } from 'chai';
 import { execute } from '../src';
 
 describe('execute', () => {
-  it('executes each operation in sequence', (done) => {
-    let state = {};
+  it('executes each operation in sequence', done => {
+    const state = { configuration: {}, data: {} };
     let operations = [
-      (state) => {
+      state => {
         return { counter: 1 };
       },
-      (state) => {
+      state => {
         return { counter: 2 };
       },
-      (state) => {
+      state => {
         return { counter: 3 };
       },
     ];
 
     execute(...operations)(state)
-      .then((finalState) => {
+      .then(finalState => {
         expect(finalState).to.eql({ counter: 3 });
       })
       .then(done)
@@ -26,9 +26,9 @@ describe('execute', () => {
   });
 
   it('assigns references, data to the initialState', () => {
-    let state = {};
+    const state = { configuration: {}, data: {} };
 
-    execute()(state).then((finalState) => {
+    execute()(state).then(finalState => {
       expect(finalState).to.eql({
         references: [],
         data: null,

--- a/packages/msgraph/configuration-schema.json
+++ b/packages/msgraph/configuration-schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "OAuth2",
   "properties": {
     "apiVersion": {
       "title": "API Version",
@@ -14,25 +15,18 @@
       "placeholder": "v1.0",
       "description": "Microsoft Graph api version",
       "minLength": 1,
-      "examples": [
-        "v1.0",
-        "beta"
-      ]
+      "examples": ["v1.0", "beta"]
     },
-    "accessToken": {
+    "access_token": {
       "title": "Access Token",
       "type": "string",
       "description": "Your Microsoft Graph access token",
       "writeOnly": true,
       "minLength": 1,
-      "examples": [
-        "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjlGWERwYmZNRlQyU3ZRdVhoODQ2WVR3RUlCdyIsI"
-      ]
+      "examples": ["eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjlGWERwYmZNRl"]
     }
   },
   "type": "object",
   "additionalProperties": true,
-  "required": [
-    "accessToken"
-  ]
+  "required": ["access_token"]
 }


### PR DESCRIPTION
@josephjclark , this is a bit of a compromise, but as I started to change `accessToken` to `access_token` all over so many Javascript files, I realized that what we actually want is to accept standard JSON credentials (which we now do, see configuration-schemas) and then convert them in a standard way to some JavaScript-sensible configuration.

This is a much lighter change, will handle both snakes and camels, and provides us with an interface for further OAuth2 credential-to-adaptor-auth magic if we need it.

There is a bunch of formatting that got applied (prettier must not have been run on these files before) but the change that's indicative of all this stuff is here: https://github.com/OpenFn/adaptors/pull/298/files#diff-a5033e85ba9e830835a40e0ced8f110c61ba2c8640e42c8c88287932cf542f68R30

Thoughts?