### PR TITLE
Update `googlehealthcare` configuration-schema

### DIFF
--- a/.changeset/happy-days-sin.md
+++ b/.changeset/happy-days-sin.md
@@ -1,5 +1,5 @@
 ---
-'@openfn/language-googlehealthcare': patch
+'@openfn/language-googlehealthcare': major
 ---
 
-Add title and description for properties in configuration-schema
+remove projectId, dataSetId, cloudRegion, and fhirStoreId out of configuration

--- a/.changeset/happy-days-sin.md
+++ b/.changeset/happy-days-sin.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-googlehealthcare': patch
+---
+
+Add title and description for properties in configuration-schema

--- a/.changeset/happy-days-sin.md
+++ b/.changeset/happy-days-sin.md
@@ -2,4 +2,11 @@
 '@openfn/language-googlehealthcare': major
 ---
 
-remove projectId, dataSetId, cloudRegion, and fhirStoreId out of configuration
+remove `projectId`, `dataSetId`, `cloudRegion`, and `fhirStoreId` out of
+configuration
+
+The new implementation of `createFhirResource(fhirStore, resource, callback)`
+allows you to use one set of credentials to access different Google Healthcare
+Cloud FHIR stores. `fhirStore` is an object that contains the FHIR store
+information
+(`{cloudRegion: string, projectId: string, datasetId: string, fhirStoreId: string}`).

--- a/packages/googlehealthcare/ast.json
+++ b/packages/googlehealthcare/ast.json
@@ -3,6 +3,7 @@
     {
       "name": "createFhirResource",
       "params": [
+        "fhirStore",
         "resource",
         "callback"
       ],
@@ -16,11 +17,11 @@
           },
           {
             "title": "example",
-            "description": "createFhirResource({\n  cloudRegion: 'us-central1',\n  projectId: 'adjective-noun-123',\n  datasetId: 'my-dataset',\n  fhirStoreId: 'my-fhir-store',\n  resourceType: \"Patient\",\n  name: [{ use: \"official\", family: \"Smith\", given: [\"Darcy\"] }],\n  gender: \"female\",\n  birthDate: \"1970-01-01\",\n});"
+            "description": "createFhirResource(\n  {\n    cloudRegion: \"us-central1\",\n    projectId: \"adjective-noun-123\",\n    datasetId: \"my-dataset\",\n    fhirStoreId: \"my-fhir-store\",\n  },\n  {\n    resourceType: \"Patient\",\n    name: [{ use: \"official\", family: \"Smith\", given: [\"Darcy\"] }],\n    gender: \"female\",\n    birthDate: \"1970-01-01\",\n  }\n);"
           },
           {
             "title": "example",
-            "description": "createFhirResource(state => ({\n cloudRegion: 'us-central1',\n projectId: 'adjective-noun-123',\n datasetId: 'my-dataset',\n fhirStoreId: 'my-fhir-store',\n resourceType: 'Encounter',\n status: 'finished',\n class: {\n   system: 'http://hl7.org/fhir/v3/ActCode',\n   code: 'IMP',\n   display: 'inpatient encounter',\n },\n reasonCode: [\n   {\n     text: 'The patient had an abnormal heart rate. She was concerned about this.',\n   },\n ],\n subject: {\n   reference: `Patient/${state.data.id}`,\n },\n}));"
+            "description": "createFhirResource(\n  {\n    cloudRegion: \"us-central1\",\n    projectId: \"adjective-noun-123\",\n    datasetId: \"my-dataset\",\n    fhirStoreId: \"my-fhir-store\",\n  },\n  (state) => ({\n    resourceType: \"Encounter\",\n    status: \"finished\",\n    class: {\n      system: \"http://hl7.org/fhir/v3/ActCode\",\n      code: \"IMP\",\n      display: \"inpatient encounter\",\n    },\n    reasonCode: [\n      {\n        text: \"The patient had an abnormal heart rate. She was concerned about this.\",\n      },\n    ],\n    subject: {\n      reference: `Patient/${state.data.id}`,\n    },\n  })\n);"
           },
           {
             "title": "function",
@@ -29,7 +30,52 @@
           },
           {
             "title": "param",
-            "description": "The data to create the new resource",
+            "description": "The FHIR store information.\n   - `cloudRegion` (string): The cloud region where the FHIR store is located.\n   - `projectId` (string): The ID of the project that contains the FHIR store.\n   - `datasetId` (string): The ID of the dataset that contains the FHIR store.\n   - `fhirStoreId` (string): The ID of the FHIR store.",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "RecordType",
+                "fields": [
+                  {
+                    "type": "FieldType",
+                    "key": "cloudRegion",
+                    "value": {
+                      "type": "NameExpression",
+                      "name": "string"
+                    }
+                  },
+                  {
+                    "type": "FieldType",
+                    "key": "projectId",
+                    "value": {
+                      "type": "NameExpression",
+                      "name": "string"
+                    }
+                  },
+                  {
+                    "type": "FieldType",
+                    "key": "datasetId",
+                    "value": {
+                      "type": "NameExpression",
+                      "name": "string"
+                    }
+                  },
+                  {
+                    "type": "FieldType",
+                    "key": "fhirStoreId",
+                    "value": {
+                      "type": "NameExpression",
+                      "name": "string"
+                    }
+                  }
+                ]
+              }
+            },
+            "name": "fhirStore"
+          },
+          {
+            "title": "param",
+            "description": "The FHIR resource data to be created",
             "type": {
               "type": "NameExpression",
               "name": "object"

--- a/packages/googlehealthcare/ast.json
+++ b/packages/googlehealthcare/ast.json
@@ -16,11 +16,11 @@
           },
           {
             "title": "example",
-            "description": "createFhirResource({\n  name: [{ use: \"official\", family: \"Smith\", given: [\"Darcy\"] }],\n  gender: \"female\",\n  birthDate: \"1970-01-01\",\n  resourceType: \"Patient\",\n});"
+            "description": "createFhirResource({\n  cloudRegion: 'us-central1',\n  projectId: 'adjective-noun-123',\n  datasetId: 'my-dataset',\n  fhirStoreId: 'my-fhir-store',\n  resourceType: \"Patient\",\n  name: [{ use: \"official\", family: \"Smith\", given: [\"Darcy\"] }],\n  gender: \"female\",\n  birthDate: \"1970-01-01\",\n});"
           },
           {
             "title": "example",
-            "description": "createFhirResource(state => ({\n resourceType: 'Encounter',\n status: 'finished',\n class: {\n   system: 'http://hl7.org/fhir/v3/ActCode',\n   code: 'IMP',\n   display: 'inpatient encounter',\n },\n reasonCode: [\n   {\n     text: 'The patient had an abnormal heart rate. She was concerned about this.',\n   },\n ],\n subject: {\n   reference: `Patient/${state.data.id}`,\n },\n}));"
+            "description": "createFhirResource(state => ({\n cloudRegion: 'us-central1',\n projectId: 'adjective-noun-123',\n datasetId: 'my-dataset',\n fhirStoreId: 'my-fhir-store',\n resourceType: 'Encounter',\n status: 'finished',\n class: {\n   system: 'http://hl7.org/fhir/v3/ActCode',\n   code: 'IMP',\n   display: 'inpatient encounter',\n },\n reasonCode: [\n   {\n     text: 'The patient had an abnormal heart rate. She was concerned about this.',\n   },\n ],\n subject: {\n   reference: `Patient/${state.data.id}`,\n },\n}));"
           },
           {
             "title": "function",

--- a/packages/googlehealthcare/configuration-schema.json
+++ b/packages/googlehealthcare/configuration-schema.json
@@ -22,45 +22,9 @@
         "v1",
         "v1beta1"
       ]
-    },
-    "cloudRegion": {
-      "type": "string",
-      "title": "cloudRegion",
-      "description": "The region Google Cloud region of your dataset",
-      "examples": [
-        "us-central1"
-      ]
-    },
-    "projectId": {
-      "type": "string",
-      "title": "projectId",
-      "description": "The ID of your Google Cloud project",
-      "examples": [
-        "adjective-noun-123"
-      ]
-    },
-    "datasetId": {
-      "type": "string",
-      "title": "datasetId",
-      "description": "The FHIR store's parent dataset",
-      "examples": [
-        "my-dataset"
-      ]
-    },
-    "fhirStoreId": {
-      "type": "string",
-      "title": "fhirStoreId",
-      "description": "An identifier for the FHIR store",
-      "examples": [
-        "my-fhir-store"
-      ]
     }
   },
   "required": [
-    "cloudRegion",
-    "projectId",
-    "datasetId",
-    "fhirStoreId",
     "access_token"
   ]
 }

--- a/packages/googlehealthcare/configuration-schema.json
+++ b/packages/googlehealthcare/configuration-schema.json
@@ -26,7 +26,7 @@
     "cloudRegion": {
       "type": "string",
       "title": "cloudRegion",
-      "description": " The dataset location",
+      "description": "The region Google Cloud region of your dataset",
       "examples": [
         "us-central1"
       ]

--- a/packages/googlehealthcare/configuration-schema.json
+++ b/packages/googlehealthcare/configuration-schema.json
@@ -18,23 +18,42 @@
       "type": "string",
       "description": "The API version",
       "default": "v1",
-      "examples": ["v1", "v1beta1"]
+      "examples": [
+        "v1",
+        "v1beta1"
+      ]
     },
     "cloudRegion": {
       "type": "string",
-      "examples": ["us-central1"]
+      "title": "cloudRegion",
+      "description": " The dataset location",
+      "examples": [
+        "us-central1"
+      ]
     },
     "projectId": {
       "type": "string",
-      "examples": ["adjective-noun-123"]
+      "title": "projectId",
+      "description": "The ID of your Google Cloud project",
+      "examples": [
+        "adjective-noun-123"
+      ]
     },
     "datasetId": {
       "type": "string",
-      "examples": ["my-dataset"]
+      "title": "datasetId",
+      "description": "The FHIR store's parent dataset",
+      "examples": [
+        "my-dataset"
+      ]
     },
     "fhirStoreId": {
       "type": "string",
-      "examples": ["my-fhir-store"]
+      "title": "fhirStoreId",
+      "description": "An identifier for the FHIR store",
+      "examples": [
+        "my-fhir-store"
+      ]
     }
   },
   "required": [

--- a/packages/googlehealthcare/src/Adaptor.js
+++ b/packages/googlehealthcare/src/Adaptor.js
@@ -41,13 +41,21 @@ export function execute(...operations) {
  * @public
  * @example
  * createFhirResource({
+ *   cloudRegion: 'us-central1',
+ *   projectId: 'adjective-noun-123',
+ *   datasetId: 'my-dataset',
+ *   fhirStoreId: 'my-fhir-store',
+ *   resourceType: "Patient",
  *   name: [{ use: "official", family: "Smith", given: ["Darcy"] }],
  *   gender: "female",
  *   birthDate: "1970-01-01",
- *   resourceType: "Patient",
  * });
  * @example
  * createFhirResource(state => ({
+ *  cloudRegion: 'us-central1',
+ *  projectId: 'adjective-noun-123',
+ *  datasetId: 'my-dataset',
+ *  fhirStoreId: 'my-fhir-store',
  *  resourceType: 'Encounter',
  *  status: 'finished',
  *  class: {
@@ -71,17 +79,11 @@ export function execute(...operations) {
  */
 export function createFhirResource(resource, callback) {
   return async state => {
-    const {
-      cloudRegion,
-      projectId,
-      datasetId,
-      fhirStoreId,
-      apiVersion,
-      accessToken,
-    } = state.configuration;
+    const { apiVersion, access_token } = state.configuration;
 
     const [resolvedResource] = expandReferences(state, resource);
-    const { resourceType } = resolvedResource;
+    const { cloudRegion, projectId, datasetId, fhirStoreId, resourceType } =
+      resolvedResource;
 
     const url = buildUrl({
       apiVersion,
@@ -93,7 +95,7 @@ export function createFhirResource(resource, callback) {
     });
 
     const payload = {
-      auth: { accessToken },
+      auth: { access_token },
       ...resolvedResource,
     };
 

--- a/packages/googlehealthcare/src/Adaptor.js
+++ b/packages/googlehealthcare/src/Adaptor.js
@@ -40,50 +40,82 @@ export function execute(...operations) {
  * Create some resource in Google Cloud Healthcare
  * @public
  * @example
- * createFhirResource({
- *   cloudRegion: 'us-central1',
- *   projectId: 'adjective-noun-123',
- *   datasetId: 'my-dataset',
- *   fhirStoreId: 'my-fhir-store',
- *   resourceType: "Patient",
- *   name: [{ use: "official", family: "Smith", given: ["Darcy"] }],
- *   gender: "female",
- *   birthDate: "1970-01-01",
- * });
+ * createFhirResource(
+ *   {
+ *     cloudRegion: "us-central1",
+ *     projectId: "adjective-noun-123",
+ *     datasetId: "my-dataset",
+ *     fhirStoreId: "my-fhir-store",
+ *   },
+ *   {
+ *     resourceType: "Patient",
+ *     name: [{ use: "official", family: "Smith", given: ["Darcy"] }],
+ *     gender: "female",
+ *     birthDate: "1970-01-01",
+ *   }
+ * );
  * @example
- * createFhirResource(state => ({
- *  cloudRegion: 'us-central1',
- *  projectId: 'adjective-noun-123',
- *  datasetId: 'my-dataset',
- *  fhirStoreId: 'my-fhir-store',
- *  resourceType: 'Encounter',
- *  status: 'finished',
- *  class: {
- *    system: 'http://hl7.org/fhir/v3/ActCode',
- *    code: 'IMP',
- *    display: 'inpatient encounter',
- *  },
- *  reasonCode: [
- *    {
- *      text: 'The patient had an abnormal heart rate. She was concerned about this.',
- *    },
- *  ],
- *  subject: {
- *    reference: `Patient/${state.data.id}`,
- *  },
- * }));
+ * createFhirResource(
+ *   {
+ *     cloudRegion: "us-central1",
+ *     projectId: "adjective-noun-123",
+ *     datasetId: "my-dataset",
+ *     fhirStoreId: "my-fhir-store",
+ *   },
+ *   (state) => ({
+ *     resourceType: "Encounter",
+ *     status: "finished",
+ *     class: {
+ *       system: "http://hl7.org/fhir/v3/ActCode",
+ *       code: "IMP",
+ *       display: "inpatient encounter",
+ *     },
+ *     reasonCode: [
+ *       {
+ *         text: "The patient had an abnormal heart rate. She was concerned about this.",
+ *       },
+ *     ],
+ *     subject: {
+ *       reference: `Patient/${state.data.id}`,
+ *     },
+ *   })
+ * );
+ *
  * @function
- * @param {object} resource - The data to create the new resource
+ * @param {{cloudRegion: string, projectId: string, datasetId: string, fhirStoreId: string}} [fhirStore] - The FHIR store information.
+ *    - `cloudRegion` (string): The cloud region where the FHIR store is located.
+ *    - `projectId` (string): The ID of the project that contains the FHIR store.
+ *    - `datasetId` (string): The ID of the dataset that contains the FHIR store.
+ *    - `fhirStoreId` (string): The ID of the FHIR store.
+ * @param {object} resource - The FHIR resource data to be created
  * @param {function} callback - An optional callback function
  * @returns {Operation}
  */
-export function createFhirResource(resource, callback) {
+export function createFhirResource(fhirStore, resource, callback) {
   return async state => {
-    const { apiVersion, access_token } = state.configuration;
+    const { apiVersion, accessToken } = state.configuration;
 
-    const [resolvedResource] = expandReferences(state, resource);
-    const { cloudRegion, projectId, datasetId, fhirStoreId, resourceType } =
-      resolvedResource;
+    const [resolvedFhirStore, resolvedResource] = expandReferences(
+      state,
+      fhirStore,
+      resource
+    );
+    const { resourceType } = resolvedResource;
+    const { cloudRegion, projectId, datasetId, fhirStoreId } =
+      resolvedFhirStore;
+
+    const requiredKeys = [
+      'cloudRegion',
+      'projectId',
+      'datasetId',
+      'fhirStoreId',
+    ];
+
+    const missingKeys = requiredKeys.filter(key => !(key in resolvedFhirStore));
+
+    if (missingKeys.length > 0) {
+      throw new Error(`Missing key(s) in fhirStore: ${missingKeys.join(', ')}`);
+    }
 
     const url = buildUrl({
       apiVersion,
@@ -95,7 +127,7 @@ export function createFhirResource(resource, callback) {
     });
 
     const payload = {
-      auth: { access_token },
+      auth: { accessToken },
       ...resolvedResource,
     };
 

--- a/packages/googlehealthcare/src/Utils.js
+++ b/packages/googlehealthcare/src/Utils.js
@@ -21,7 +21,7 @@ export const request = async (url, params = {}, method = 'GET') => {
     body: JSON.stringify(params),
     headers: {
       'Content-Type': 'application/fhir+json',
-      Authorization: `Bearer ${auth.access_token}`,
+      Authorization: `Bearer ${auth.accessToken}`,
     },
   };
 

--- a/packages/googlehealthcare/src/Utils.js
+++ b/packages/googlehealthcare/src/Utils.js
@@ -21,7 +21,7 @@ export const request = async (url, params = {}, method = 'GET') => {
     body: JSON.stringify(params),
     headers: {
       'Content-Type': 'application/fhir+json',
-      Authorization: `Bearer ${auth.accessToken}`,
+      Authorization: `Bearer ${auth.access_token}`,
     },
   };
 

--- a/packages/googlehealthcare/test/Adaptor.test.js
+++ b/packages/googlehealthcare/test/Adaptor.test.js
@@ -42,13 +42,13 @@ describe('createFhirResource', () => {
   it('creates a patient resource to google cloud healthcare', async () => {
     const state = {
       configuration: {
+        access_token: 'aGVsbG86dGhlcmU=',
+      },
+      data: {
         cloudRegion: 'us-east7',
         projectId: 'test-007',
         datasetId: 'fhir-007',
         fhirStoreId: 'testing-fhir-007',
-        access_token: 'aGVsbG86dGhlcmU=',
-      },
-      data: {
         resourceType: 'Patient',
         name: [{ use: 'official', family: 'Smith', given: ['Darcy'] }],
         gender: 'female',
@@ -84,16 +84,19 @@ describe('createFhirResource', () => {
   it('throws an error for a 400', async () => {
     const state = {
       configuration: {
-        cloudRegion: 'us-east7',
-        projectId: 'test-007',
-        datasetId: 'fhir-007',
-        fhirStoreId: 'testing-fhir-007',
-        accessToken: 'aGVsbG86dGhlcmU=',
+        access_token: 'aGVsbG86dGhlcmU=',
       },
     };
 
     const error = await execute(
-      createFhirResource({ name: 'taylor', resourceType: 'noAccess' })
+      createFhirResource({
+        name: 'taylor',
+        cloudRegion: 'us-east7',
+        projectId: 'test-007',
+        datasetId: 'fhir-007',
+        fhirStoreId: 'testing-fhir-007',
+        resourceType: 'noAccess',
+      })
     )(state).catch(error => {
       return error;
     });
@@ -104,16 +107,19 @@ describe('createFhirResource', () => {
   it('throws an error for a 401', async () => {
     const state = {
       configuration: {
-        cloudRegion: 'us-east7',
-        projectId: 'test-007',
-        datasetId: 'fhir-007',
-        fhirStoreId: 'testing-fhir-007',
-        accessToken: 'aGVsbG86dGhlcmU=a',
+        access_token: 'aGVsbG86dGhlcmU=a',
       },
     };
 
     const error = await execute(
-      createFhirResource({ name: 'taylor', resourceType: 'Patient' })
+      createFhirResource({
+        name: 'taylor',
+        cloudRegion: 'us-east7',
+        projectId: 'test-007',
+        datasetId: 'fhir-007',
+        fhirStoreId: 'testing-fhir-007',
+        resourceType: 'Patient',
+      })
     )(state).catch(error => {
       return error;
     });

--- a/packages/googlehealthcare/test/Adaptor.test.js
+++ b/packages/googlehealthcare/test/Adaptor.test.js
@@ -165,7 +165,6 @@ describe('createFhirResource', () => {
       return error;
     });
 
-    console.log(error.message);
     expect(error.message).to.contains(
       'Missing key(s) in fhirStore: cloudRegion, projectId, datasetId, fhirStoreId'
     );

--- a/packages/googlehealthcare/test/Adaptor.test.js
+++ b/packages/googlehealthcare/test/Adaptor.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { execute, dataValue, createFhirResource } from '../src/Adaptor.js';
+import { execute, createFhirResource } from '../src/Adaptor.js';
 
 import MockAgent from './mockAgent.js';
 import { setGlobalDispatcher } from 'undici';
@@ -8,22 +8,26 @@ setGlobalDispatcher(MockAgent);
 
 describe('execute', () => {
   it('executes each operation in sequence', done => {
-    const state = { configuration: {}, data: {} };
+    const state = {
+      configuration: { accessToken: 'aGVsbG86dGhlcmU' },
+      data: {},
+      references: [],
+    };
     const operations = [
       state => {
-        return { counter: 1 };
+        return { ...state, counter: 1 };
       },
       state => {
-        return { counter: 2 };
+        return { ...state, counter: 2 };
       },
       state => {
-        return { counter: 3 };
+        return { ...state, counter: 3 };
       },
     ];
 
     execute(...operations)(state)
       .then(finalState => {
-        expect(finalState).to.eql({ counter: 3 });
+        expect(finalState).to.eql({ ...state, counter: 3 });
       })
       .then(done)
       .catch(done);
@@ -42,23 +46,30 @@ describe('createFhirResource', () => {
   it('creates a patient resource to google cloud healthcare', async () => {
     const state = {
       configuration: {
-        access_token: 'aGVsbG86dGhlcmU=',
+        accessToken: 'aGVsbG86dGhlcmU=',
       },
       data: {
-        cloudRegion: 'us-east7',
-        projectId: 'test-007',
-        datasetId: 'fhir-007',
-        fhirStoreId: 'testing-fhir-007',
-        resourceType: 'Patient',
-        name: [{ use: 'official', family: 'Smith', given: ['Darcy'] }],
-        gender: 'female',
-        birthDate: '1970-01-01',
+        fhirStore: {
+          cloudRegion: 'us-east7',
+          projectId: 'test-007',
+          datasetId: 'fhir-007',
+          fhirStoreId: 'testing-fhir-007',
+        },
+        resource: {
+          resourceType: 'Patient',
+          name: [{ use: 'official', family: 'Smith', given: ['Darcy'] }],
+          gender: 'female',
+          birthDate: '1970-01-01',
+        },
       },
     };
 
-    const finalState = await execute(createFhirResource(state => state.data))(
-      state
-    );
+    const finalState = await execute(
+      createFhirResource(
+        state => state.data.fhirStore,
+        state => state.data.resource
+      )
+    )(state);
 
     expect(finalState.data).to.eql({
       data: {
@@ -84,19 +95,23 @@ describe('createFhirResource', () => {
   it('throws an error for a 400', async () => {
     const state = {
       configuration: {
-        access_token: 'aGVsbG86dGhlcmU=',
+        accessToken: 'aGVsbG86dGhlcmU=',
       },
     };
 
     const error = await execute(
-      createFhirResource({
-        name: 'taylor',
-        cloudRegion: 'us-east7',
-        projectId: 'test-007',
-        datasetId: 'fhir-007',
-        fhirStoreId: 'testing-fhir-007',
-        resourceType: 'noAccess',
-      })
+      createFhirResource(
+        {
+          cloudRegion: 'us-east7',
+          projectId: 'test-007',
+          datasetId: 'fhir-007',
+          fhirStoreId: 'testing-fhir-007',
+        },
+        {
+          name: 'taylor',
+          resourceType: 'noAccess',
+        }
+      )
     )(state).catch(error => {
       return error;
     });
@@ -107,23 +122,52 @@ describe('createFhirResource', () => {
   it('throws an error for a 401', async () => {
     const state = {
       configuration: {
-        access_token: 'aGVsbG86dGhlcmU=a',
+        accessToken: 'aGVsbG86dGhlcmU=a',
       },
     };
 
     const error = await execute(
-      createFhirResource({
-        name: 'taylor',
-        cloudRegion: 'us-east7',
-        projectId: 'test-007',
-        datasetId: 'fhir-007',
-        fhirStoreId: 'testing-fhir-007',
-        resourceType: 'Patient',
-      })
+      createFhirResource(
+        {
+          cloudRegion: 'us-east7',
+          projectId: 'test-007',
+          datasetId: 'fhir-007',
+          fhirStoreId: 'testing-fhir-007',
+        },
+        {
+          name: 'taylor',
+          resourceType: 'Patient',
+        }
+      )
     )(state).catch(error => {
       return error;
     });
 
     expect(error.message).to.contains('Unauthorized');
+  });
+
+  it('throws an error if fhirStore infromation are not provided', async () => {
+    const state = {
+      configuration: {
+        accessToken: 'aGVsbG86dGhlcmU=a',
+      },
+    };
+
+    const error = await execute(
+      createFhirResource(
+        {},
+        {
+          name: 'taylor',
+          resourceType: 'Patient',
+        }
+      )
+    )(state).catch(error => {
+      return error;
+    });
+
+    console.log(error.message);
+    expect(error.message).to.contains(
+      'Missing key(s) in fhirStore: cloudRegion, projectId, datasetId, fhirStoreId'
+    );
   });
 });


### PR DESCRIPTION
## Summary

Add a title and description in properties of `googlehealthcare` configuration schema

This should fix the empty input box when adding Google Healthcare credentials on Lighting 
![image](https://github.com/OpenFn/adaptors/assets/6592749/a00b1aae-6ac0-40ae-b561-5afaf9a70b35)


## Review Checklist

Before merging, the reviewer should check the following items:
- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
