### PR TITLE
new version of http that uses fetch

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -46,7 +46,8 @@
     "csvtojson": "^2.0.10",
     "date-fns": "^2.25.0",
     "jsonpath-plus": "^4.0.0",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
+    "undici": "^5.22.1"
   },
   "devDependencies": {
     "@openfn/buildtools": "workspace:^1.0.2",

--- a/packages/common/src/http.js
+++ b/packages/common/src/http.js
@@ -61,9 +61,9 @@ function withAgent(params) {
  * @param {object} requestParams - Supports the exact parameters as Axios. See {@link https://github.com/axios/axios#axios-api here}
  * @returns {Operation} - Function which takes state and returns a Promise
  * @example <caption>Get an item with a specified id from state</caption>
- *  get({
- *      url: state => `https://www.example.com/api/items/${state.id},
- *      headers: {"content-type": "application/json"}
+ * get({
+ *    url: state => `https://www.example.com/api/items/${state.id}`,
+ *    headers: {"content-type": "application/json"}
  * });
  */
 export function get(requestParams) {

--- a/packages/common/src/http.js
+++ b/packages/common/src/http.js
@@ -2,6 +2,7 @@ import { expandReferences, splitKeys } from './Adaptor';
 import axios from 'axios';
 import https from 'https';
 
+import { request } from './util';
 export { axios };
 
 /**
@@ -68,8 +69,10 @@ function withAgent(params) {
 export function get(requestParams) {
   return state => {
     const params = expandRequestReferences(requestParams)(state);
+    const url = params.url;
+    delete params.url;
 
-    return axios({ method: 'get', ...withAgent(params) });
+    return request(url, { method: 'GET', ...withAgent(params) });
   };
 }
 
@@ -97,8 +100,10 @@ export function get(requestParams) {
 export function post(requestParams) {
   return state => {
     const params = expandRequestReferences(requestParams)(state);
+    const url = params.url;
+    delete params.url;
 
-    return axios({ method: 'post', ...withAgent(params) });
+    return request(url, { method: 'POST', ...withAgent(params) });
   };
 }
 
@@ -116,8 +121,10 @@ export function post(requestParams) {
 function del(requestParams) {
   return state => {
     const params = expandRequestReferences(requestParams)(state);
+    const url = params.url;
+    delete params.url;
 
-    return axios({ method: 'delete', ...withAgent(params) });
+    return request(url, { method: 'DELETE', ...withAgent(params) });
   };
 }
 
@@ -137,8 +144,10 @@ export { del as delete };
 export function head(requestParams) {
   return state => {
     const params = expandRequestReferences(requestParams)(state);
+    const url = params.url;
+    delete params.url;
 
-    return axios({ method: 'head', ...withAgent(params) });
+    return request(url, { method: 'HEAD', ...withAgent(params) });
   };
 }
 
@@ -157,8 +166,10 @@ export function head(requestParams) {
 export function put(requestParams) {
   return state => {
     const params = expandRequestReferences(requestParams)(state);
+    const url = params.url;
+    delete params.url;
 
-    return axios({ method: 'put', ...withAgent(params) });
+    return request(url, { method: 'PUT', ...withAgent(params) });
   };
 }
 
@@ -177,8 +188,10 @@ export function put(requestParams) {
 export function patch(requestParams) {
   return state => {
     const params = expandRequestReferences(requestParams)(state);
+    const url = params.url;
+    delete params.url;
 
-    return axios({ method: 'patch', ...withAgent(params) });
+    return request(url, { method: 'PATCH', ...withAgent(params) });
   };
 }
 
@@ -196,7 +209,9 @@ export function patch(requestParams) {
 export function options(requestParams) {
   return state => {
     const params = expandRequestReferences(requestParams)(state);
+    const url = params.url;
+    delete params.url;
 
-    return axios({ method: 'options', ...withAgent(params) });
+    return request(url, { method: 'OPTIONS', ...withAgent(params) });
   };
 }

--- a/packages/common/src/util.js
+++ b/packages/common/src/util.js
@@ -103,14 +103,23 @@ function buildRequest(url, method, queryParams, data, headers) {
 export async function request(url, params = { method: 'GET' }) {
   const { method, data, headers, ...otherOptions } = params;
   const options = {
-    method: 'GET',
-    headers: {},
-    body: '', //Blob, ArrayBuffer, TypedArray, Dataview, URLSearchParms, ReadableStream >> GET or HEAD method cannot have body,
-    mode: '', // cors, no-cors, same-origin
-    credentials: '', // omit, same-origin, include
-    cache: '', // default, no-store, reload, no-cache, force-cache and only-if-cached
-    redirect: '', // follow, error, manual
-    referrer: ''
+    method: 'GET', // POST, PUT, DELETE, HEAD, etc.
+    headers: {
+      // the content type header value is usually auto-set
+      // depending on the request body
+    },
+    body: undefined, //Blob, ArrayBuffer, TypedArray, Dataview, URLSearchParms, ReadableStream >> GET or HEAD method cannot have body,
+    mode: 'cors', // cors, no-cors, same-origin
+    credentials: 'same-origin', // omit, same-origin, include
+    cache: 'default', // default, no-store, reload, no-cache, force-cache and only-if-cached
+    redirect: 'follow', // follow, error, manual
+    referrer: 'about:client', // A string specifying the referrer of the request. This can be a same-origin URL, about:client, or an empty string.,
+    referrerPolicy: 'strict-origin-when-cross-origin', // no-referrer-when-downgrade, no-referrer, origin, same-origin...
+    integrity: '', //a hash, like "sha256-abcdef1234567890"
+    keepAlive: true,
+    signal: undefined, // AbortController to abort request
+    priority: 'auto', //Specifies the priority of the fetch request relative to other requests of the same. Must be one of the following strings: high, low, auto
+    params: {}, // An object implementing `URLSearchParams.string()` which returns a string containing a query string suitable for use in a URL.
   };
 
   const request = buildRequest(url, method, otherOptions, data, headers);

--- a/packages/common/src/util.js
+++ b/packages/common/src/util.js
@@ -7,6 +7,8 @@
  * None of these functions are operation factories
  */
 
+import { fetch } from 'undici';
+
 // TODO this doesn't currently support skip
 export function expandReferences(state, ...args) {
   return args.map(value => expandReference(state, value));
@@ -86,10 +88,7 @@ function buildRequest(url, method, queryParams, data, headers) {
 
   switch (method) {
     case 'GET':
-      return new Request(
-        buildUrl(url, queryParams),
-        initialOptions
-      );
+      return new Request(buildUrl(url, queryParams), initialOptions);
     case 'POST':
       return new Request(buildUrl(url, queryParams), {
         ...initialOptions,
@@ -100,26 +99,21 @@ function buildRequest(url, method, queryParams, data, headers) {
   }
 }
 
-import { fetch } from 'undici';
-
 // Wrapper for all requests, handles errors and logs
 export async function request(url, params = { method: 'GET' }) {
-  const { method, data, headers, ...rest } = params;
-
+  const { method, data, headers, ...otherOptions } = params;
   const options = {
-    method,
-    headers,
-    body: JSON.stringify(data),
-    ...rest,
+    method: 'GET',
+    headers: {},
+    body: '', //Blob, ArrayBuffer, TypedArray, Dataview, URLSearchParms, ReadableStream >> GET or HEAD method cannot have body,
+    mode: '', // cors, no-cors, same-origin
+    credentials: '', // omit, same-origin, include
+    cache: '', // default, no-store, reload, no-cache, force-cache and only-if-cached
+    redirect: '', // follow, error, manual
+    referrer: ''
   };
 
-  console.log(JSON.stringify(options, null, 2));
-  if (method == 'GET') delete options.body;
-
-  const resolvedUrl =
-    method == 'GET' ? `${url}?${new URLSearchParams(params).toString()}` : url;
-
-  const request = buildRequest(url, method, params, data, headers);
+  const request = buildRequest(url, method, otherOptions, data, headers);
 
   const response = await fetch(request);
   // const response = await fetch(resolvedUrl, options);

--- a/packages/common/src/util.js
+++ b/packages/common/src/util.js
@@ -49,3 +49,50 @@ export function normalizeOauthConfig(configuration) {
 
   return configuration;
 }
+
+export function handleResponseError(response, data, method) {
+  const { status, statusText, url } = response;
+
+  if (isEmpty(data)) {
+    const responseString = [
+      `Message: 0 results returned`,
+      `Request: ${method} ${url}`,
+      `Status: ${status}`,
+    ].join('\n\t∟ ');
+
+    console.log(`Info at ${new Date()}\n${responseString}`);
+  }
+  if (!response.ok) {
+    const errorString = [
+      `Message: ${statusText}`,
+      `Request: ${method} ${url}`,
+      `Status: ${status}`,
+      `Body: ${JSON.stringify(data, null, 2).replace(/\n/g, '\n\t  ')}`,
+    ].join('\n\t∟ ');
+    throw new Error(errorString);
+  }
+}
+
+export const request = async (url, params = { method: 'GET' }) => {
+  const { method, data, headers, ...rest } = params;
+
+  const options = {
+    method,
+    headers,
+    body: JSON.stringify(data),
+    ...rest,
+  };
+
+  console.log(JSON.stringify(options, null, 2));
+  if (method == 'GET') delete options.body;
+
+  const resolvedUrl =
+    method == 'GET' ? `${url}?${new URLSearchParams(params).toString()}` : url;
+
+  const response = await fetch(resolvedUrl, options);
+  const results = await response.json();
+
+  handleResponseError(response, results, method);
+
+  return results;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,7 @@ importers:
       mocha: 9.2.2
       nock: 13.2.9
       rimraf: ^3.0.2
+      undici: ^5.22.1
     dependencies:
       axios: 1.1.3
       csv-parse: 5.4.0
@@ -212,6 +213,7 @@ importers:
       date-fns: 2.29.3
       jsonpath-plus: 4.0.0
       lodash: 4.17.21
+      undici: 5.22.1
     devDependencies:
       '@openfn/buildtools': link:../../tools/build
       '@openfn/simple-ast': 0.4.1
@@ -4305,7 +4307,6 @@ packages:
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
-    dev: true
 
   /bytes/3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -11043,7 +11044,6 @@ packages:
   /streamsearch/1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
-    dev: true
 
   /strict-uri-encode/1.1.0:
     resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
@@ -11963,7 +11963,6 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
-    dev: true
 
   /union-value/1.0.1:
     resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}


### PR DESCRIPTION
## Summary

Migrate from using `axios` to `fetch` in `common.http`

1. we have request()  in `common/util.js`  that uses `fetch()` from `undici`
2. http common to have all http function (`get()`, `post()`, `head()`, `patch()`, etc) and all these function `expandRefences` in their arguments.
3. All other adaptors that need access http functions they should use http common function and not implement their own version of `get()` or `post()` etc
4. If other adaptors can not  use http common function then extend it from common (For example in other adaptors we have create() which is basically a http common `post()` so it make sense to extend post from http common)

## Details

- [ ] buildRequest
- [ ] buildUrl
- [ ] request 
- [ ] tests

## Issues 
Ref #283 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
