### PR TITLE
`msgraph` cleanup state before throw

### DIFF
--- a/.changeset/fresh-comics-talk.md
+++ b/.changeset/fresh-comics-talk.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-msgraph': patch
+---
+
+Clean-up state before throwing an error

--- a/packages/msgraph/src/Adaptor.js
+++ b/packages/msgraph/src/Adaptor.js
@@ -33,7 +33,10 @@ export function execute(...operations) {
       ...state,
     })
       .then(cleanup)
-      .catch(cleanup);
+      .catch(error => {
+        cleanup(state);
+        throw error;
+      });
   };
 }
 

--- a/packages/msgraph/test/Adaptor.test.js
+++ b/packages/msgraph/test/Adaptor.test.js
@@ -57,9 +57,12 @@ describe('execute', () => {
       },
     ];
 
-    const finalState = await execute(...operations)(state).catch(e => {
-      expect(e.message).to.contain('Failed operation');
+    let e;
+    const finalState = await execute(...operations)(state).catch(err => {
+      e = err;
     });
+
+    expect(e.message).to.contain('Failed operation');
 
     expect(finalState).to.eql(undefined);
   });

--- a/packages/msgraph/test/Adaptor.test.js
+++ b/packages/msgraph/test/Adaptor.test.js
@@ -38,6 +38,31 @@ describe('execute', () => {
       expect(finalState).to.eql({ references: [], data: null });
     });
   });
+
+  it('should stop operation on error', async () => {
+    const state = {
+      drives: {
+        default: {
+          id: 'b!YXzpkoLwR06bxC8tNdg71m_',
+        },
+      },
+    };
+    const operations = [
+      state => {
+        state.counter++;
+        throw new Error('Failed operation');
+      },
+      state => {
+        return { ...state, counter: 1 };
+      },
+    ];
+
+    const finalState = await execute(...operations)(state).catch(e => {
+      expect(e.message).to.contain('Failed operation');
+    });
+
+    expect(finalState).to.eql(undefined);
+  });
 });
 describe('getDrive', () => {
   it('should get a drive by id and set it to state', async () => {


### PR DESCRIPTION
## Summary

When catching an error on `execute()` i added a cleanup step then throw an error. Before that we were doing cleanup without throwing an error which made job code to pass even if there is a `throw new Error()` in that job code 

Ref #319 
## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [x] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
