### PR TITLE
Update configuration schema for MongoDB adaptor. 

### DIFF
--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @openfn/language-mongodb
 
+## 1.2.0
+
+### Minor Changes
+
+- Update configuration schema for MongoDB adaptor:
+  - Rename `clusterUrl` to `clusterHostname`
+  - Change `clusterHostname` format from `uri` to `hostname`
+  - Update `Adaptor.js` and tests to use new name
+
+  The MongoDB adaptor configuration expects a hostname, not a strict
+  URI. The existing configuration prevented a user from saving a 
+  "correct" configuration in Lightning, due to the JSON schema verification
+  failing. Changing the format of this configuration property to `hostname`
+  resolves this issue and justifies a name change of the property.
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/mongodb/configuration-schema.json
+++ b/packages/mongodb/configuration-schema.json
@@ -1,11 +1,11 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
-        "clusterUrl": {
-            "title": "Cluster URL",
+        "clusterHostname": {
+            "title": "Cluster Hostname",
             "type": "string",
-            "description": "Your MongoDB cluster / host URL",
-            "format": "uri",
+            "description": "Your MongoDB cluster hostname",
+            "format": "hostname",
             "minLength": 1,
             "examples": [
                 "yourCluster-xxxyzzz.mongodb.net"
@@ -34,7 +34,7 @@
     "type": "object",
     "additionalProperties": true,
     "required": [
-        "clusterUrl",
+        "clusterHostname",
         "username",
         "password"
     ]

--- a/packages/mongodb/src/Adaptor.js
+++ b/packages/mongodb/src/Adaptor.js
@@ -43,13 +43,13 @@ export function execute(...operations) {
  * @returns {State}
  */
 function connect(state) {
-  const { clusterUrl, username, password } = state.configuration;
+  const { clusterHostname, username, password } = state.configuration;
 
   const uri = `mongodb+srv://${encodeURIComponent(
     username
   )}:${encodeURIComponent(
     password
-  )}@${clusterUrl}/test?retryWrites=true&w=majority`;
+  )}@${clusterHostname}/test?retryWrites=true&w=majority`;
 
   const client = new MongoClient(uri, { useNewUrlParser: true });
 

--- a/packages/mongodb/test/index.js
+++ b/packages/mongodb/test/index.js
@@ -13,7 +13,7 @@ describe('execute', () => {
       configuration: {
         username: 'hello',
         password: 'there',
-        clusterUrl: 'demo.mongodb.net',
+        clusterHostname: 'demo.mongodb.net',
       },
     };
     let operations = [


### PR DESCRIPTION
Fixes OpenFn/adaptors#353

## Summary
Fixes JSON schema verification for mongodb clusterUrl configuration 

## Details

In packages/mongodb/src/Adaptor.js, the connect() function constructs the URI for the MongoDB cluster as follows:

```
  const uri = `mongodb+srv://${encodeURIComponent(
    username
  )}:${encodeURIComponent(
    password
  )}@${clusterUrl}/test?retryWrites=true&w=majority`;
```

The adaptor expects the `clusterUrl` configuration property be provided as a hostname and not a full URI, but the current JSON schema specifies the format of this property as `uri`, which fails validation when providing a normal hostname. This PR changes the JSON schema to verify this property as the correct format (`hostname`, not `uri`). The PR also renames the property and fixes all references to the property in the adaptor and unit tests.

## Issues

#353 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
