### PR TITLE
`mailchimp` improvements

### DIFF
--- a/.changeset/popular-taxis-shave.md
+++ b/.changeset/popular-taxis-shave.md
@@ -1,0 +1,7 @@
+---
+'@openfn/language-mailchimp': minor
+---
+
+- Add chunk from common
+- Improve error logs
+- Return `state` in request finalState

--- a/packages/mailchimp/ast.json
+++ b/packages/mailchimp/ast.json
@@ -418,6 +418,59 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "chunk",
+      "params": [
+        "array",
+        "chunkSize"
+      ],
+      "docs": {
+        "description": "Chunks an array into an array of arrays, each with no more than a certain size.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "chunk([1,2,3,4,5], 2)"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Array to be chunked",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "array"
+          },
+          {
+            "title": "param",
+            "description": "The maxiumum size of each chunks",
+            "type": {
+              "type": "NameExpression",
+              "name": "Integer"
+            },
+            "name": "chunkSize"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            }
+          }
+        ]
+      },
+      "valid": true
     }
   ]
 }

--- a/packages/mailchimp/src/Adaptor.js
+++ b/packages/mailchimp/src/Adaptor.js
@@ -440,5 +440,6 @@ export {
   fields,
   lastReferenceValue,
   merge,
+  chunk,
   sourceValue,
 } from '@openfn/language-common';

--- a/packages/mailchimp/src/Adaptor.js
+++ b/packages/mailchimp/src/Adaptor.js
@@ -324,12 +324,19 @@ const defaultOptions = {
 
 // Assert response
 const assertOK = (response, fullUrl) => {
-  if (response.statusCode >= 400) {
-    const defaultErrorMesssage = `Request to ${fullUrl} failed with status: ${response.statusCode}`;
+  if (response.status >= 400) {
+    const defaultErrorMesssage = `Request to ${fullUrl} failed with status: ${response.status}`;
 
     const error = new Error(defaultErrorMesssage);
-    error.code = response.statusCode;
+
     error.url = fullUrl;
+    error.type = response.type;
+    error.title = response.title;
+    error.status = response.status;
+    error.detail = response.detail;
+    error.instance = response.instance;
+    error.errors = response.errors;
+
     throw error;
   }
 };
@@ -377,11 +384,11 @@ export const request = (method, path, options, callback) => {
       body: body ? JSON.stringify(body) : undefined,
     });
 
-    assertOK(response, `https://${server}.api.mailchimp.com${urlPath}`);
-
     const responseBody = await response.body.json();
+    assertOK(responseBody, `https://${server}.api.mailchimp.com${urlPath}`);
 
     const nextState = {
+      ...state,
       data: responseBody,
       response: responseBody,
     };
@@ -418,6 +425,7 @@ export const get = (path, query, callback) =>
 export const post = (path, body, query, callback) =>
   request('POST', path, { body, query }, callback);
 
+// TODO Remove axios export
 // Note that we expose the entire axios package to the user here.
 export { axios, md5 };
 

--- a/packages/mailchimp/test/index.js
+++ b/packages/mailchimp/test/index.js
@@ -145,9 +145,16 @@ describe('request', () => {
         method: 'GET',
         headers,
       })
-      .reply(401);
+      .reply(401, {
+        type: 'https://mailchimp.com/developer/marketing/docs/errors/',
+        title: 'API Key Invalid',
+        status: 401,
+        detail: 'API key has been disabled',
+        instance: '82e67146-6d11-9301-ffa1-893f2918013a',
+      });
 
     await execute(request('GET', '/'))(state).catch(error => {
+      console.log(error);
       expect(error.message).to.eql(
         'Request to https://us11.api.mailchimp.com/3.0/ failed with status: 401'
       );


### PR DESCRIPTION
## Summary

**Add `chunk` from common**

> Most of Mailchimp operations have a limitation of `500` records per request, having access to `chunk` helper function simplify job code and make it easy to chunk your data before making a request to Mailchimp 

**Improved error message**

> The error response returned did not have enough details to help you debug your job code, This improvement will give you more details about the Mailchimp error

**Return state in request**

> The return for `request()` helper did not include `state`. This improvement return state when use `request()` function

Fixes #365 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [x] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
