### PR TITLE
Watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,10 +277,19 @@ The `build` command accepts a list of build steps as arguments: `ast`, `src`,
 `docs` and `dts`. Calling build on an adaptor with no arguments will build
 everything.
 
+Add `--watch` to watch the `src` for changes and rebuild this dist. This is
+useful when developing with the CLI.
+
 Each adaptor's build command should simply call `build-adaptor` with the package
 name.
 
 You can run `build --help` for more information.
+
+Examples:
+
+```
+pnpm -C packages/salesforce build --watch
+```
 
 ## Metadata
 

--- a/packages/mailchimp/src/Adaptor.js
+++ b/packages/mailchimp/src/Adaptor.js
@@ -386,6 +386,7 @@ export const request = (method, path, options, callback) => {
       response: responseBody,
     };
     if (callback) return callback(nextState);
+
     return nextState;
   };
 };

--- a/tools/build/src/cli.ts
+++ b/tools/build/src/cli.ts
@@ -17,10 +17,14 @@ export const cmd = yargs(hideBin(process.argv))
     array: true,
     description: 'src, ast, docs, dts',
   })
+  .option('watch', {
+    boolean: true,
+    description: 'watch for changes and rebuild (only really works for src)',
+  })
   .parse();
 
 if (!cmd.tasks) {
   cmd.tasks = ['src', 'dts', 'docs', 'ast'];
 }
 
-run(cmd.lang, cmd.tasks);
+run(cmd.lang, cmd.tasks, { watch: cmd.watch });

--- a/tools/build/src/commands/ast.ts
+++ b/tools/build/src/commands/ast.ts
@@ -1,7 +1,8 @@
 import { exec } from 'node:child_process';
 import resolvePath from '../util/resolve-path';
+import type { Options } from '../pipeline';
 
-export default (lang: string) => {
+export default (lang: string, options: Options) => {
   const root = resolvePath(lang);
   console.log();
   console.log(`Building AST`);

--- a/tools/build/src/commands/src.ts
+++ b/tools/build/src/commands/src.ts
@@ -1,7 +1,8 @@
-import { build, Options } from 'tsup';
+import { build, Options as TsupOptions } from 'tsup';
 import resolvePath from '../util/resolve-path';
+import type { Options } from '../pipeline';
 
-const config: Options = {
+const config: TsupOptions = {
   format: ['esm', 'cjs'],
   target: 'node14',
   platform: 'node',
@@ -21,7 +22,7 @@ const fetchConfig = async (adaptorPath: string) => {
   return {};
 };
 
-export default async (lang: string) => {
+export default async (lang: string, options: Options = {}) => {
   const p = resolvePath(lang);
   console.log();
   console.log('Building JS');
@@ -38,5 +39,6 @@ export default async (lang: string) => {
   return build({
     ...defaultBuildConfig,
     ...overrides,
+    watch: options.watch,
   });
 };

--- a/tools/build/src/pipeline.ts
+++ b/tools/build/src/pipeline.ts
@@ -11,14 +11,22 @@ type Config = {
   out: string;
 };
 
-const run = async (lang: string, tasks: string[] = ['src', 'dts', 'docs']) => {
+export type Options = {
+  watch?: boolean;
+};
+
+const run = async (
+  lang: string,
+  tasks: string[] = ['src', 'dts', 'docs'],
+  options: Options = {}
+) => {
   console.log('Running pipeline for', lang);
   console.log(`Root dir: ${resolvePath(lang)}`);
 
   tasks
     .map(t => commands[t])
     .filter(fn => fn)
-    .reduce((p, task) => p.then(() => task(lang)), Promise.resolve());
+    .reduce((p, task) => p.then(() => task(lang, options)), Promise.resolve());
 };
 
 export default run;


### PR DESCRIPTION
This PR add a watch mode to build.

It only works for the `src` build (it doesn't work for dts, docs or ast). This is probably the most important as it's what you need when testing with the CLI.

To watch changes in salesforce, you can do:
```
pnpm -C package/salesforce build --watch
```
Or
```
cd packages/salesforce
pnpm build --watch
```

In watch mode, saving a file in `src` will cause the bundle in `dist` to be immediately regenerated.

Note that this won't detect changes in `common` if you're working on another adaptor - if working on common stuff you might want to set up two watches.

Closes #367