### PR TITLE
Allow IPs for postgres host

### DIFF
--- a/packages/postgresql/configuration-schema.json
+++ b/packages/postgresql/configuration-schema.json
@@ -4,7 +4,7 @@
     "host": {
       "title": "Host",
       "type": "string",
-      "description": "Postgres instance host URL",
+      "description": "Postgres instance host URL or IP address",
       "minLength": 1,
       "anyOf": [
         {

--- a/packages/postgresql/configuration-schema.json
+++ b/packages/postgresql/configuration-schema.json
@@ -2,10 +2,18 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "host": {
-      "title": "Host URL",
+      "title": "Host",
       "type": "string",
       "description": "Postgres instance host URL",
       "minLength": 1,
+      "anyOf": [
+        {
+          "format": "uri"
+        },
+        {
+          "format": "ipv4"
+        }
+      ],
       "examples": [
         "https://some-host.compute-1.amazonaws.com",
         "201.220.61.246"

--- a/packages/postgresql/configuration-schema.json
+++ b/packages/postgresql/configuration-schema.json
@@ -5,10 +5,10 @@
       "title": "Host URL",
       "type": "string",
       "description": "Postgres instance host URL",
-      "format": "uri",
       "minLength": 1,
       "examples": [
-        "some-host-url.compute-1.amazonaws.com"
+        "https://some-host.compute-1.amazonaws.com",
+        "201.220.61.246",
       ]
     },
     "port": {

--- a/packages/postgresql/configuration-schema.json
+++ b/packages/postgresql/configuration-schema.json
@@ -8,7 +8,7 @@
       "minLength": 1,
       "examples": [
         "https://some-host.compute-1.amazonaws.com",
-        "201.220.61.246",
+        "201.220.61.246"
       ]
     },
     "port": {
@@ -66,5 +66,9 @@
   },
   "type": "object",
   "additionalProperties": true,
-  "required": ["host", "port", "database"]
+  "required": [
+    "host",
+    "port",
+    "database"
+  ]
 }


### PR DESCRIPTION
Fixes #381 

This commit removes the URI formatting requirement so we can use IP addresses for the postgres adaptor.

@mtuchi , is there a way to allow _either_ a URI or an IP address? maybe `hostname`? Note that right now the only example on `main` fails on Lightning, since it doesn't start with `http(s):`

https://opis.io/json-schema/2.x/formats.html#hostname

How would this be handled by Lightning when it does form validation?

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
