### PR TITLE
Remove enum from Kobotoolbox configuration-schema.json

### DIFF
--- a/.changeset/chatty-tips-shop.md
+++ b/.changeset/chatty-tips-shop.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-kobotoolbox': minor
+---
+
+Removed the API version enum values in the credential configuration json schema
+and added a placeholder

--- a/packages/kobotoolbox/configuration-schema.json
+++ b/packages/kobotoolbox/configuration-schema.json
@@ -34,12 +34,8 @@
         "apiVersion": {
             "title": "API Version",
             "type": "string",
-            "default": "v2",
+            "placeholder": "v2",
             "description": "Kobotoolbox API version to use",
-            "enum": [
-                "v1",
-                "v2"
-            ],
             "minLength": 1,
             "examples": [
                 "v2"


### PR DESCRIPTION
## Summary

This PR addresses[ this issue](https://github.com/OpenFn/Lightning/issues/1089). The root cause of this bug stems from the mismatch between the JSON-schema definition and the UI behavior. Specifically, while the schema defined an enum for a particular field, the app used an input field for user entry instead of a select box.

## Details

- Removed the Enum Definition - The enum in the schema has been replaced with a type definition of string. This offers flexibility for the app's input mechanism without restricting to predefined values.

- Added Placeholder - A placeholder has been introduced to guide users on the expected value for this field.

## Issues

Fixes [#1089](https://github.com/OpenFn/Lightning/issues/1089)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
