### PR TITLE
add filter in list function

### DIFF
--- a/.changeset/nine-pugs-collect.md
+++ b/.changeset/nine-pugs-collect.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-sftp': minor
+---
+
+add filter option in list function

--- a/.changeset/nine-pugs-collect.md
+++ b/.changeset/nine-pugs-collect.md
@@ -1,5 +1,5 @@
 ---
-'@openfn/language-sftp': minor
+'@openfn/language-sftp': major
 ---
 
-add filter option in list function
+add `filter` option in `list()` function

--- a/packages/sftp/ast.json
+++ b/packages/sftp/ast.json
@@ -4,6 +4,7 @@
       "name": "list",
       "params": [
         "dirPath",
+        "filter",
         "callback"
       ],
       "docs": {
@@ -25,12 +26,21 @@
           },
           {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Path to remote directory",
             "type": {
               "type": "NameExpression",
               "name": "string"
             },
             "name": "dirPath"
+          },
+          {
+            "title": "param",
+            "description": "a filter function used to select return entries",
+            "type": {
+              "type": "NameExpression",
+              "name": "function"
+            },
+            "name": "filter"
           },
           {
             "title": "param",

--- a/packages/sftp/ast.json
+++ b/packages/sftp/ast.json
@@ -17,7 +17,18 @@
           },
           {
             "title": "example",
-            "description": "list('/some/path/')"
+            "description": "list('/some/path/')",
+            "caption": "basic files listing"
+          },
+          {
+            "title": "example",
+            "description": "list('/some/path/', file=> {\n return /foo.\\.txt/.test(file.name);\n})",
+            "caption": "list files with filters"
+          },
+          {
+            "title": "example",
+            "description": "list(\n  \"/some/path/\",\n  (file) => /foo.\\.txt/.test(file.name),\n  (state) => {\n    const latestFile = state.data.filter(\n      (file) => file.modifyTime <= new Date()\n    );\n    return { ...state, latestFile };\n  }\n);",
+            "caption": "list files with filters and use callback"
           },
           {
             "title": "function",

--- a/packages/sftp/src/Adaptor.js
+++ b/packages/sftp/src/Adaptor.js
@@ -56,14 +56,15 @@ function disconnect(state) {
  * @example
  * list('/some/path/')
  * @function
- * @param {string} dirPath - Path to resource
+ * @param {string} dirPath - Path to remote directory
+ * @param {function} filter - a filter function used to select return entries
  * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
-export function list(dirPath, callback = x => x) {
+export function list(dirPath, filter, callback) {
   return state => {
     return sftp
-      .list(dirPath)
+      .list(dirPath, filter)
       .then(files => handleResponse(files, state, callback))
       .catch(handleError);
   };

--- a/packages/sftp/src/Adaptor.js
+++ b/packages/sftp/src/Adaptor.js
@@ -54,7 +54,25 @@ function disconnect(state) {
  * List files present in a directory
  * @public
  * @example
+ * <caption>basic files listing</caption>
  * list('/some/path/')
+ * @example
+ * <caption>list files with filters</caption>
+ * list('/some/path/', file=> {
+ *  return /foo.\.txt/.test(file.name);
+ * })
+ * @example
+ * <caption>list files with filters and use callback</caption>
+ * list(
+ *   "/some/path/",
+ *   (file) => /foo.\.txt/.test(file.name),
+ *   (state) => {
+ *     const latestFile = state.data.filter(
+ *       (file) => file.modifyTime <= new Date()
+ *     );
+ *     return { ...state, latestFile };
+ *   }
+ * );
  * @function
  * @param {string} dirPath - Path to remote directory
  * @param {function} filter - a filter function used to select return entries


### PR DESCRIPTION
## Summary

Add a filter `option` in `list()` function. The new function signature `list(dirPath, filter, callback)`

Related issue https://github.com/OpenFn/women-for-women/issues/126

## Review Checklist

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
