### PR TITLE
`salesforce` BulkV2 support

### DIFF
--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-salesforce
 
+## 5.0.0-alpha
+
+### Major Changes
+
+- Update jsforce dependency [29cce5b]
+- Add `bulk2` function [97d3729]
+- Update `bulkQuery` function to use jsforce `bulk2.query` [97d3729]
+
 ## 4.2.2
 
 ### Patch Changes

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.0.0-alpha
 
+> This is an experimental alpha release based on jsforce beta 2. It is not
+> recommended for production use.
+
 ### Major Changes
 
 - Update jsforce dependency [29cce5b]

--- a/packages/salesforce/ast.json
+++ b/packages/salesforce/ast.json
@@ -293,7 +293,7 @@
           },
           {
             "title": "param",
-            "description": "Polling timeout in milliseconds.",
+            "description": "Polling timeout in milliseconds. Default 3000",
             "type": {
               "type": "OptionalType",
               "expression": {
@@ -305,7 +305,7 @@
           },
           {
             "title": "param",
-            "description": "Polling interval in milliseconds.",
+            "description": "Polling interval in milliseconds. Default 9000",
             "type": {
               "type": "OptionalType",
               "expression": {

--- a/packages/salesforce/ast.json
+++ b/packages/salesforce/ast.json
@@ -427,7 +427,7 @@
           },
           {
             "title": "example",
-            "description": "bulk2('Patient__c', 'insert', { failOnError: true, pollInterval: 3000, pollTimeout: 240000 }, state => {\n  return state.data.someArray.map(x => {\n    return { 'Age__c': x.age, 'Name': x.name }\n  })\n});"
+            "description": "bulk2(\n  \"Patient__c\",\n  \"insert\",\n  { failOnError: true, pollInterval: 3000, pollTimeout: 240000 },\n  (state) => {\n    return state.someArray.map((x) => ({ Age__c: x.age, Name: x.name }));\n  }\n);"
           },
           {
             "title": "function",
@@ -499,7 +499,7 @@
           },
           {
             "title": "example",
-            "description": "destroy('obj_name', [\n '0060n00000JQWHYAA5',\n '0090n00000JQEWHYAA5\n], { failOnError: true })"
+            "description": "destroy('obj_name', [\n '0060n00000JQWHYAA5',\n '0090n00000JQEWHYAA5'\n], { failOnError: true })"
           },
           {
             "title": "function",

--- a/packages/salesforce/ast.json
+++ b/packages/salesforce/ast.json
@@ -410,6 +410,79 @@
       "valid": true
     },
     {
+      "name": "bulk2",
+      "params": [
+        "sObject",
+        "operation",
+        "options",
+        "fun"
+      ],
+      "docs": {
+        "description": "Create and execute a bulk job using Salesforce Bulk API v2.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "bulk2('Patient__c', 'insert', { failOnError: true, pollInterval: 3000, pollTimeout: 240000 }, state => {\n  return state.data.someArray.map(x => {\n    return { 'Age__c': x.age, 'Name': x.name }\n  })\n});"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "API name of the sObject.",
+            "type": {
+              "type": "NameExpression",
+              "name": "String"
+            },
+            "name": "sObject"
+          },
+          {
+            "title": "param",
+            "description": "The bulk operation to be performed",
+            "type": {
+              "type": "NameExpression",
+              "name": "String"
+            },
+            "name": "operation"
+          },
+          {
+            "title": "param",
+            "description": "Options passed to the bulk api.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "options"
+          },
+          {
+            "title": "param",
+            "description": "A function which takes state and returns an array.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Function"
+            },
+            "name": "fun"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "destroy",
       "params": [
         "sObject",

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.2.2",
+  "version": "5.0.0-alpha",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@openfn/language-common": "workspace:*",
     "axios": "^0.21.4",
-    "jsforce": "^1.11.1",
+    "jsforce": "2.0.0-beta.28",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -188,16 +188,12 @@ export function query(qs) {
  * @function
  * @param {String} qs - A query string.
  * @param {Object} options - Options passed to the bulk api.
- * @param {integer} [options.pollTimeout] - Polling timeout in milliseconds.
- * @param {integer} [options.pollInterval] - Polling interval in milliseconds.
+ * @param {integer} [options.pollTimeout] - Polling timeout in milliseconds. Default 3000
+ * @param {integer} [options.pollInterval] - Polling interval in milliseconds. Default 9000
  * @param {Function} callback - A callback to execute once the record is retrieved
  * @returns {Operation}
  */
 export function bulkQuery(qs, options, callback) {
-  const defaultOptions = {
-    pollTimeout: 90000, // in ms
-    pollInterval: 3000, // in ms
-  };
   return async state => {
     const { connection } = state;
     const [resolvedQs, resolvedOptions] = newExpandReferences(
@@ -206,10 +202,7 @@ export function bulkQuery(qs, options, callback) {
       options
     );
 
-    const { pollTimeout, pollInterval } = {
-      ...defaultOptions,
-      ...resolvedOptions,
-    };
+    const { pollInterval = 3000, pollTimeout = 9000 } = resolvedOptions;
 
     console.log(`Executing query: ${resolvedQs}`);
 
@@ -356,10 +349,16 @@ const defaultBulkOptions = {
 export function bulk2(sObject, operation, options, fun) {
   return async state => {
     const { connection } = state;
-    const { failOnError, allowNoOp, pollTimeout, pollInterval } = {
-      ...defaultBulkOptions,
-      ...options,
-    };
+    const {
+      failOnError = true,
+      allowNoOp = true,
+      pollInterval = 3000,
+      pollTimeout = 9000,
+    } = options;
+
+    console.log(pollInterval, 'pollInterval');
+    console.log(pollTimeout, 'pollTimeout');
+
     const finalAttrs = fun(state);
 
     if (allowNoOp && finalAttrs.length === 0) {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -170,10 +170,6 @@ export function query(qs) {
   };
 }
 
-const defaultOptions = {
-  pollTimeout: 90000, // in ms
-  pollInterval: 3000, // in ms
-};
 /**
  * Execute an SOQL Bulk Query.
  * This function uses bulk query to efficiently query large data sets and reduce the number of API requests.
@@ -198,6 +194,10 @@ const defaultOptions = {
  * @returns {Operation}
  */
 export function bulkQuery(qs, options, callback) {
+  const defaultOptions = {
+    pollTimeout: 90000, // in ms
+    pollInterval: 3000, // in ms
+  };
   return async state => {
     const { connection } = state;
     const [resolvedQs, resolvedOptions] = newExpandReferences(

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -170,62 +170,10 @@ export function query(qs) {
   };
 }
 
-async function pollJobResult(conn, job, pollInterval, pollTimeout) {
-  let attempt = 0;
-
-  const maxPollingAttempts = Math.floor(pollTimeout / pollInterval);
-
-  while (attempt < maxPollingAttempts) {
-    // Make an HTTP GET request to check the job status
-    const jobInfo = await conn
-      .request({
-        method: 'GET',
-        url: `/services/data/v${conn.version}/jobs/query/${job.id}`,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
-      .catch(error => {
-        console.log('Failed to fetch job information', error);
-      });
-
-    if (jobInfo && jobInfo.state === 'JobComplete') {
-      const response = await conn.request({
-        method: 'GET',
-        url: `/services/data/v${conn.version}/jobs/query/${job.id}/results`,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      console.log('Job result retrieved', response.length);
-      return response;
-    } else {
-      // Handle maxPollingAttempts
-      if (attempt + 1 === maxPollingAttempts) {
-        console.error(
-          'Maximum polling attempt reached, Please increase pollInterval and pollTimeout'
-        );
-        throw new Error(`Polling time out. Job Id = ${job.id}`);
-      }
-      console.log(
-        `Attempt ${attempt + 1} - Job ${jobInfo.id} is still in ${
-          jobInfo.state
-        }:`
-      );
-    }
-
-    // Wait for the polling interval before the next attempt
-    await new Promise(resolve => setTimeout(resolve, pollInterval));
-    attempt++;
-  }
-}
-
 const defaultOptions = {
   pollTimeout: 90000, // in ms
   pollInterval: 3000, // in ms
 };
-
 /**
  * Execute an SOQL Bulk Query.
  * This function uses bulk query to efficiently query large data sets and reduce the number of API requests.
@@ -257,7 +205,6 @@ export function bulkQuery(qs, options, callback) {
       qs,
       options
     );
-    const apiVersion = connection.version;
 
     const { pollTimeout, pollInterval } = {
       ...defaultOptions,
@@ -266,24 +213,10 @@ export function bulkQuery(qs, options, callback) {
 
     console.log(`Executing query: ${resolvedQs}`);
 
-    const queryJob = await connection.request({
-      method: 'POST',
-      url: `/services/data/v${apiVersion}/jobs/query`,
-      body: JSON.stringify({
-        operation: 'query',
-        query: resolvedQs,
-      }),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    const result = await pollJobResult(
-      connection,
-      queryJob,
+    const result = await connection.bulk2.query(resolvedQs, {
+      pollTimeout,
       pollInterval,
-      pollTimeout
-    );
+    });
 
     const nextState = {
       ...composeNextState(state, result),
@@ -395,13 +328,111 @@ export function bulk(sObject, operation, options, fun) {
   };
 }
 
+const defaultBulkOptions = {
+  failOnError: true,
+  allowNoOp: true,
+  pollInterval: 6000,
+  pollTimeout: 240000,
+};
+/**
+ * Create and execute a bulk job using Salesforce Bulk API v2.
+ * @public
+ * @example
+ * bulk2(
+ *   "Patient__c",
+ *   "insert",
+ *   { failOnError: true, pollInterval: 3000, pollTimeout: 240000 },
+ *   (state) => {
+ *     return state.someArray.map((x) => ({ Age__c: x.age, Name: x.name }));
+ *   }
+ * );
+ * @function
+ * @param {String} sObject - API name of the sObject.
+ * @param {String} operation - The bulk operation to be performed
+ * @param {Object} options - Options passed to the bulk api.
+ * @param {Function} fun - A function which takes state and returns an array.
+ * @returns {Operation}
+ */
+export function bulk2(sObject, operation, options, fun) {
+  return async state => {
+    const { connection } = state;
+    const { failOnError, allowNoOp, pollTimeout, pollInterval } = {
+      ...defaultBulkOptions,
+      ...options,
+    };
+    const finalAttrs = fun(state);
+
+    if (allowNoOp && finalAttrs.length === 0) {
+      console.info(
+        `No items in ${sObject} array. Skipping bulk ${operation} operation.`
+      );
+      return state;
+    }
+
+    if (finalAttrs.length > 10000) {
+      console.log('Your batch is bigger than 10,000 records; chunking...');
+    }
+
+    const chunkedBatches = chunk(finalAttrs, 10000);
+
+    let mapOptions = options;
+    if (mapOptions?.extIdField) {
+      const { extIdField, ...opts } = mapOptions;
+      mapOptions = { ...opts, externalIdFieldName: extIdField };
+    }
+
+    const results = await Promise.all(
+      chunkedBatches.map(async chunkedBatch => {
+        connection.bulk2.pollInterval = pollInterval;
+        connection.bulk2.pollTimeout = pollTimeout;
+
+        console.info(
+          `Creating bulk ${operation} job for ${sObject} with ${chunkedBatch.length} records`
+        );
+
+        await connection.bulk2
+          .loadAndWaitForResults({
+            object: sObject,
+            operation,
+            input: chunkedBatch,
+            ...mapOptions,
+          })
+          .then(res => {
+            const errors = res.failedResults;
+
+            errors.forEach(err => {
+              err[`${options.extIdField}`] =
+                chunkedBatch[err.position - 1][options.extIdField];
+            });
+
+            if (failOnError && errors.length > 0) {
+              console.error('Errors detected:');
+
+              throw new Error(JSON.stringify(errors, null, 2));
+            } else {
+              console.log('Successful Result : ', res.successfulResults.length);
+              console.log(
+                'Unprocessed Records : ',
+                res.unprocessedRecords.length
+              );
+              return res;
+            }
+          });
+      })
+    );
+
+    console.log('Merging results arrays.');
+    const merged = [].concat(...results);
+    return { ...state, references: [merged, ...state.references] };
+  };
+}
 /**
  * Delete records of an object.
  * @public
  * @example
  * destroy('obj_name', [
  *  '0060n00000JQWHYAA5',
- *  '0090n00000JQEWHYAA5
+ *  '0090n00000JQEWHYAA5'
  * ], { failOnError: true })
  * @function
  * @param {String} sObject - API name of the sObject.

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -321,12 +321,6 @@ export function bulk(sObject, operation, options, fun) {
   };
 }
 
-const defaultBulkOptions = {
-  failOnError: true,
-  allowNoOp: true,
-  pollInterval: 6000,
-  pollTimeout: 240000,
-};
 /**
  * Create and execute a bulk job using Salesforce Bulk API v2.
  * @public
@@ -421,8 +415,7 @@ export function bulk2(sObject, operation, options, fun) {
     );
 
     console.log('Merging results arrays.');
-    const merged = [].concat(...results);
-    return { ...state, references: [merged, ...state.references] };
+    return { ...state, references: results.concat(state.references) };
   };
 }
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1630,8 +1630,8 @@ importers:
         specifier: ^0.21.4
         version: 0.21.4
       jsforce:
-        specifier: ^1.11.1
-        version: 1.11.1
+        specifier: 2.0.0-beta.28
+        version: 2.0.0-beta.28
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -2400,6 +2400,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.22.19
+
+  /@babel/runtime-corejs3@7.23.2:
+    resolution: {integrity: sha512-54cIh74Z1rp4oIjsHjqN+WM4fMyCBYe+LpZ9jWm51CZ1fbH3SkAzQD/3XLoNkjbJ7YEmjobLXyvQrFypRHOrXw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      core-js-pure: 3.33.0
+      regenerator-runtime: 0.14.0
+    dev: false
 
   /@babel/runtime@7.22.15:
     resolution: {integrity: sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==}
@@ -3204,7 +3212,6 @@ packages:
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-    dev: true
 
   /@types/node@18.17.5:
     resolution: {integrity: sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA==}
@@ -3324,6 +3331,13 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       array-back: 3.1.0
+    dev: false
+
+  /ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.21.3
     dev: false
 
   /ansi-regex@2.1.1:
@@ -4462,9 +4476,9 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: false
 
-  /base64-url@2.3.3:
-    resolution: {integrity: sha512-dLMhIsK7OplcDauDH/tZLvK7JmUZK3A7KiQpjNzsBrM6Etw7hzNI1tLEywqJk9NnwkgWuFKSlx/IUO7vF6Mo8Q==}
-    engines: {node: '>=6'}
+  /base64url@3.0.1:
+    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
+    engines: {node: '>=6.0.0'}
     dev: false
 
   /base@0.11.2:
@@ -4882,7 +4896,6 @@ packages:
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
-    dev: true
 
   /charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
@@ -5005,12 +5018,24 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+    dependencies:
+      restore-cursor: 3.1.0
+    dev: false
+
   /cli-truncate@3.1.0:
     resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       slice-ansi: 5.0.0
       string-width: 5.1.2
+    dev: false
+
+  /cli-width@3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
     dev: false
 
   /cliui@3.2.0:
@@ -5077,12 +5102,6 @@ packages:
     resolution: {integrity: sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==}
     engines: {node: '>=0.8.0'}
     deprecated: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
-    hasBin: true
-    dev: false
-
-  /coffeescript@1.12.7:
-    resolution: {integrity: sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==}
-    engines: {node: '>=0.8.0'}
     hasBin: true
     dev: false
 
@@ -5256,6 +5275,11 @@ packages:
     dev: true
     optional: true
 
+  /core-js-pure@3.33.0:
+    resolution: {integrity: sha512-FKSIDtJnds/YFIEaZ4HszRX7hkxGpNKM7FC9aJ9WLJbSd3lD4vOltFuVIBLR8asSx9frkTSqL0dw90SKQxgKrg==}
+    requiresBuild: true
+    dev: false
+
   /core-js@1.0.1:
     resolution: {integrity: sha512-zJjMnWELJrSpquUFc5MD9dAvFitwDmrBNAwOjQu+z4y+e8kyotQx/x6vLRxIuy0AFtKNKbNG9uRDaGM99U8+1Q==}
     deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
@@ -5266,6 +5290,11 @@ packages:
     deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
     requiresBuild: true
     dev: true
+
+  /core-js@3.33.0:
+    resolution: {integrity: sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==}
+    requiresBuild: true
+    dev: false
 
   /core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -5341,15 +5370,8 @@ packages:
     resolution: {integrity: sha512-RxruSK3M4XgzcD7Trm2wEN+SJ26ChIb903+IWxNOcB5q4jT2Cs+hFr6QP39J05EohshRFEvyzEBoZ/466S2sbw==}
     dev: false
 
-  /csv-stringify@1.1.2:
-    resolution: {integrity: sha512-3NmNhhd+AkYs5YtM1GEh01VR6PKj6qch2ayfQaltx5xpcAdThjnbbI5eT8CzRVpXfGKAxnmrSYLsNl/4f3eWiw==}
-    dependencies:
-      lodash.get: 4.4.2
-    dev: false
-
   /csv-stringify@5.6.5:
     resolution: {integrity: sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==}
-    dev: true
 
   /csv@5.5.3:
     resolution: {integrity: sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==}
@@ -6514,7 +6536,6 @@ packages:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
-    dev: true
 
   /extglob@0.3.2:
     resolution: {integrity: sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==}
@@ -6600,6 +6621,13 @@ packages:
       safe-buffer: 5.2.1
       tough-cookie: 4.1.3
       tunnel-agent: 0.6.0
+    dev: false
+
+  /figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+    dependencies:
+      escape-string-regexp: 1.0.5
     dev: false
 
   /figures@5.0.0:
@@ -6877,7 +6905,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
-    dev: true
 
   /fs-readdir-recursive@1.1.0:
     resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
@@ -7448,7 +7475,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -7508,6 +7534,25 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  /inquirer@7.3.3:
+    resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      external-editor: 3.1.0
+      figures: 3.2.0
+      lodash: 4.17.21
+      mute-stream: 0.0.8
+      run-async: 2.4.1
+      rxjs: 6.6.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+    dev: false
 
   /internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
@@ -7938,11 +7983,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /is-wsl@1.1.0:
-    resolution: {integrity: sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==}
-    engines: {node: '>=4'}
-    dev: false
-
   /is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
@@ -8142,28 +8182,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  /jsforce@1.11.1:
-    resolution: {integrity: sha512-u1vL2F4FYRNccwjwA3ftMULEf9Ekeyvsz7vYKeQ03sKg6m7DNwB2O9d0erCM7k5sQUJ44J39CI05nokDKN3ktw==}
-    engines: {node: '>=4.0'}
-    hasBin: true
-    dependencies:
-      base64-url: 2.3.3
-      co-prompt: 1.0.0
-      coffeescript: 1.12.7
-      commander: 2.20.3
-      csv-parse: 4.16.3
-      csv-stringify: 1.1.2
-      faye: 1.4.0
-      inherits: 2.0.4
-      lodash: 4.17.21
-      multistream: 2.1.1
-      opn: 5.5.0
-      promise: 7.3.1
-      readable-stream: 2.3.8
-      request: 2.88.2
-      xml2js: 0.5.0
-    dev: false
-
   /jsforce@1.5.1:
     resolution: {integrity: sha512-q9l3e3vmpgo1kkgZdgoCqScmjYiX98egocf6NyUDoznOQYkUVk3S3+WJxKvLAQXaNcN+jHA2+1hZ5G4p4gDcWA==}
     engines: {node: '>=0.10.0'}
@@ -8181,6 +8199,36 @@ packages:
       through2: 1.1.1
       underscore: 1.13.6
       xml2js: 0.4.23
+    dev: false
+
+  /jsforce@2.0.0-beta.28:
+    resolution: {integrity: sha512-tTmKRhr4yWNinhmurY/tiiltLFQq9RQ+gpYAt3wjFdCGjzd49/wqYQIFw4SsI3+iLjxXnc0uTgGwdAkDjxDWnA==}
+    engines: {node: '>=8.0'}
+    hasBin: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@babel/runtime-corejs3': 7.23.2
+      '@types/node': 12.20.55
+      abort-controller: 3.0.0
+      base64url: 3.0.1
+      commander: 4.1.1
+      core-js: 3.33.0
+      csv-parse: 4.16.3
+      csv-stringify: 5.6.5
+      faye: 1.4.0
+      form-data: 4.0.0
+      fs-extra: 8.1.0
+      https-proxy-agent: 5.0.1
+      inquirer: 7.3.3
+      multistream: 3.1.0
+      node-fetch: 2.7.0
+      open: 7.4.2
+      regenerator-runtime: 0.13.11
+      strip-ansi: 6.0.1
+      xml2js: 0.5.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: false
 
   /json-bigint@1.0.0:
@@ -8257,7 +8305,6 @@ packages:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: true
 
   /jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -9140,17 +9187,21 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  /multistream@2.1.1:
-    resolution: {integrity: sha512-xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==}
+  /multistream@3.1.0:
+    resolution: {integrity: sha512-zBgD3kn8izQAN/TaL1PCMv15vYpf+Vcrsfub06njuYVYlzUldzpopTlrEZ53pZVEbfn3Shtv7vRFoOv6LOV87Q==}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 2.3.8
+      readable-stream: 3.6.2
     dev: false
 
   /mustache@2.3.2:
     resolution: {integrity: sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==}
     engines: {npm: '>=1.4.0'}
     hasBin: true
+    dev: false
+
+  /mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     dev: false
 
   /mysql@2.18.1:
@@ -9522,6 +9573,14 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: false
 
+  /open@7.4.2:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+    dev: false
+
   /open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -9529,13 +9588,6 @@ packages:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
-    dev: false
-
-  /opn@5.5.0:
-    resolution: {integrity: sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==}
-    engines: {node: '>=4'}
-    dependencies:
-      is-wsl: 1.1.0
     dev: false
 
   /optimist@0.3.7:
@@ -9599,7 +9651,6 @@ packages:
   /os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -10101,12 +10152,6 @@ packages:
       asap: 1.0.0
     dev: false
 
-  /promise@7.3.1:
-    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
-    dependencies:
-      asap: 2.0.6
-    dev: false
-
   /promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
     dependencies:
@@ -10385,7 +10430,6 @@ packages:
 
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-    dev: true
 
   /regenerator-runtime@0.14.0:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
@@ -10576,6 +10620,14 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
+  /restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+    dev: false
+
   /ret@0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
     engines: {node: '>=0.12'}
@@ -10628,10 +10680,22 @@ packages:
     resolution: {integrity: sha512-R3wLbuAYejpxQjL/SjXo1Cjv4wcJECnMRT/FlcCfTwCBhaji9rWaRCoVEQ1SPiTJ4kKK+yh+bZLAV7SCafoDDw==}
     dev: false
 
+  /run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+    dev: false
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+
+  /rxjs@6.6.7:
+    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
+    engines: {npm: '>=2.0.0'}
+    dependencies:
+      tslib: 1.14.1
+    dev: false
 
   /safe-array-concat@1.0.1:
     resolution: {integrity: sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==}
@@ -11593,6 +11657,10 @@ packages:
       xtend: 4.0.2
     dev: false
 
+  /through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+    dev: false
+
   /time-zone@1.0.0:
     resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
     engines: {node: '>=4'}
@@ -11603,7 +11671,6 @@ packages:
     engines: {node: '>=0.6.0'}
     dependencies:
       os-tmpdir: 1.0.2
-    dev: true
 
   /to-fast-properties@1.0.3:
     resolution: {integrity: sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==}
@@ -11742,6 +11809,10 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: false
+
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: false
@@ -11871,6 +11942,11 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
     dev: true
+
+  /type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+    dev: false
 
   /type-fest@0.6.0:
     resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
@@ -12007,7 +12083,6 @@ packages:
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
-    dev: true
 
   /universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}


### PR DESCRIPTION
## Summary

Add a `bulk2` function that creates and execute a bulk job using Salesforce Bulk API v2. Also updated the `bulkQuery` function to use jsforce `bulk2.query` function

## Details

I have updated the `jsforce` dependency to `v2.0.0-beta.28`. This version supports Salesforce Bulk V2.
For the implementation of `bulk2` behind the scene we are using [bulk2.loadAndWaitForResult](https://jsforce.github.io/jsforce/classes/api_bulk.BulkV2.html#loadAndWaitForResults) function and for `bulkQuery` we are using [bulk2.query()](https://jsforce.github.io/jsforce/classes/api_bulk.BulkV2.html#query)

Ref #407 
## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Update changelog and version
