### PR TITLE
`sftp` disconnect then throw

### DIFF
--- a/.changeset/angry-suns-give.md
+++ b/.changeset/angry-suns-give.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-sftp': patch
+---
+
+On error disconnect then throw

--- a/packages/sftp/src/Adaptor.js
+++ b/packages/sftp/src/Adaptor.js
@@ -32,8 +32,8 @@ export function execute(...operations) {
       ...operations,
       disconnect
     )({ ...initialState, ...state }).catch(e => {
-      console.error(e);
-      return disconnect(state);
+      disconnect(state);
+      throw e;
     });
 }
 


### PR DESCRIPTION
## Summary

This is a fix for `sftp` adaptor that was missed on #422. When an error happens, The adaptor will disconnect then throw the error instead of `console.error(error)`. This makes sure that we get `Exit Code 1` on platform-app

Ref #421

## Review Checklist

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
