### PR TITLE
`http` lighten `response.request`

### DIFF
--- a/.changeset/brave-carrots-suffer.md
+++ b/.changeset/brave-carrots-suffer.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-http': minor
----
-
-Clean up `state.response.request` by returning only
-`{ method, path, host, protocol, _headers }`

--- a/.changeset/brave-carrots-suffer.md
+++ b/.changeset/brave-carrots-suffer.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-http': patch
+---
+
+Clean up `state.response.request` by returning only
+`{ method, path, host, protocol }`

--- a/.changeset/brave-carrots-suffer.md
+++ b/.changeset/brave-carrots-suffer.md
@@ -1,6 +1,6 @@
 ---
-'@openfn/language-http': patch
+'@openfn/language-http': minor
 ---
 
 Clean up `state.response.request` by returning only
-`{ method, path, host, protocol }`
+`{ method, path, host, protocol, _headers }`

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-http
 
+## 5.1.0
+
+### Minor Changes
+
+- 8e2b79c: Clean up `state.response.request` by returning only
+  `{ method, path, host, protocol, _headers }`
+
 ## 5.0.4
 
 ### Patch Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-http",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -95,8 +95,8 @@ function handleResponse(state, response) {
     response.status,
     '✓'
   );
-  const { method, path, host, protocol } = response.request;
-  response.request = { method, path, host, protocol };
+  const { method, path, host, protocol, _headers } = response.request;
+  response.request = { method, path, host, protocol, _headers };
 
   const compatibleResp = {
     ...response,

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -95,6 +95,8 @@ function handleResponse(state, response) {
     response.status,
     '✓'
   );
+  const { method, path, host, protocol } = response.request;
+  response.request = { method, path, host, protocol };
 
   const compatibleResp = {
     ...response,


### PR DESCRIPTION
## Summary

Returned only `{ method, path, host, protocol }` for `response.request`. which lighten the final state  

## Issues

Reference #432 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
