### PR TITLE
Add `expandReferences` on `parseXML`

### DIFF
--- a/.changeset/perfect-crews-love.md
+++ b/.changeset/perfect-crews-love.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-http': patch
----
-
-Update `parseXML` to use `expandReferences`

--- a/.changeset/perfect-crews-love.md
+++ b/.changeset/perfect-crews-love.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-http': patch
+---
+
+Update `parseXML` to use `expandReferences`

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-http
 
+## 5.1.1
+
+### Patch Changes
+
+- a8d655e: Update `parseXML` to use `expandReferences`
+
 ## 5.1.0
 
 ### Minor Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-http",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -310,7 +310,8 @@ export function del(path, params, callback) {
  */
 export function parseXML(body, script) {
   return state => {
-    const $ = cheerio.load(body);
+    const resolvedBody = expandReferences(body)(state);
+    const $ = cheerio.load(resolvedBody);
     cheerioTableparser($);
 
     if (script) {
@@ -322,7 +323,7 @@ export function parseXML(body, script) {
         return composeNextState(state, { body: result });
       }
     } else {
-      return composeNextState(state, { body: body });
+      return composeNextState(state, { body: resolvedBody });
     }
   };
 }


### PR DESCRIPTION
## Summary

Add `expandReferences` on `parseXML` `body` argument 

## Details

Using the old `expandReferences` from `'@openfn/language-common'` in `parseXML` `body` param


## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
