### PR TITLE
Make GoData Adaptor Email Field Be In Read & Write Mode

### DIFF
--- a/.changeset/sour-shirts-wonder.md
+++ b/.changeset/sour-shirts-wonder.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-godata': minor
----
-
-Change godata/configuration-schema.json to make email field read and write

--- a/.changeset/sour-shirts-wonder.md
+++ b/.changeset/sour-shirts-wonder.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-godata': minor
+---
+
+Change godata/configuration-schema.json to make email field read and write

--- a/packages/godata/CHANGELOG.md
+++ b/packages/godata/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-godata
 
+## 3.4.0
+
+### Minor Changes
+
+- df4cfca: Switch from `'writeOnly: true'` to `'format: email'` in the godata
+  configuration schema.
+
 ## 3.3.1
 
 ### Patch Changes

--- a/packages/godata/configuration-schema.json
+++ b/packages/godata/configuration-schema.json
@@ -16,7 +16,7 @@
             "title": "Email",
             "type": "string",
             "description": "Your Godata login email",
-            "writeOnly": true,
+            "format": "email",
             "minLength": 1,
             "examples": [
                 "test@openfn.org"

--- a/packages/godata/package.json
+++ b/packages/godata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-godata",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "An OpenFn adaptor for use with the WHO's GoData API",
   "main": "dist/index.cjs",
   "scripts": {


### PR DESCRIPTION
## Summary

Make Godata email field be in read and write mode for Lightning

## Details

This PR proposes to update the `godata/configuration-schema.json` to make the email field in read and write mode for Lightning

## Issues

Fixes [#1545](https://github.com/OpenFn/Lightning/issues/1545)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
