### PR TITLE
Remove Regex Patterns In Configuration Schemas

### DIFF
--- a/.changeset/angry-grapes-cover.md
+++ b/.changeset/angry-grapes-cover.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-mailchimp': patch
-'@openfn/language-salesforce': patch
----
-
-Remove regex pattern for validation and bump minLength to 1

--- a/.changeset/angry-grapes-cover.md
+++ b/.changeset/angry-grapes-cover.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-mailchimp': patch
+'@openfn/language-salesforce': patch
+---
+
+Remove regex pattern for validation and bump minLength to 1

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-mailchimp
 
+## 0.7.2
+
+### Patch Changes
+
+- 1131c34: Remove regex pattern for validation and changed minLength to 1
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/mailchimp/configuration-schema.json
+++ b/packages/mailchimp/configuration-schema.json
@@ -10,8 +10,7 @@
                 "us11",
                 "uk8",
                 "in10"
-            ],
-            "pattern": "^[a-zA-Z]{2}\\d{1,2}$"
+            ]
         },
         "apiKey": {
             "title": "API Key",
@@ -20,8 +19,7 @@
             "minLength": 32,
             "examples": [
                 "0eb22c7b4a1c5bcd789379bf8a92902d-us13"
-            ],
-            "pattern": "^[a-zA-Z0-9]{20}-[a-zA-Z]{2}\\d{1,2}$"
+            ]
         }
     },
     "type": "object",

--- a/packages/mailchimp/configuration-schema.json
+++ b/packages/mailchimp/configuration-schema.json
@@ -5,7 +5,7 @@
             "title": "Data Center",
             "type": "string",
             "description": "Mailchimp Data Center for your account",
-            "minLength": 3,
+            "minLength": 1,
             "examples": [
                 "us11",
                 "uk8",
@@ -16,7 +16,7 @@
             "title": "API Key",
             "type": "string",
             "description": "Mailchimp API Key",
-            "minLength": 32,
+            "minLength": 1,
             "examples": [
                 "0eb22c7b4a1c5bcd789379bf8a92902d-us13"
             ]

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mailchimp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "An OpenFn adaptor for use with Mailchimp",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-salesforce
 
+## 4.3.1
+
+### Patch Changes
+
+- 1131c34: Remove regex pattern for validation and changed minLength to 1
+
 ## 4.3.0
 
 ### Minor Changes

--- a/packages/salesforce/configuration-schema.json
+++ b/packages/salesforce/configuration-schema.json
@@ -42,7 +42,6 @@
     "apiVersion": {
       "title": "API Version",
       "type": "string",
-      "pattern": "^[0-9]{2}\\.[0-9]$",
       "placeholder": "52.0",
       "description": "Salesforce API Version",
       "minLength": 1,

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {


### PR DESCRIPTION
## Summary

This PR ships code that removes the regex patterns that were used for validation in the mailchimp and salesforce adaptors configuration-schema.json file. We are removing those because:

- they were introducing severe bugs to Lightning migrations.
- the regex patterns seems to not match as expected

We need to discuss whether we need those patterns, in that case make sure we have the right ones

## Issues

Fixes #451 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
