### PR TITLE
Only run Docs after Publish

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,10 @@
 name: Build & deploy adaptor documentation
 
 on:
+  workflow_run:
+    workflows: [Publish]
+    types:
+      - completed
   push:
     branches: [main]
 


### PR DESCRIPTION
This PR ensures that the docs action only runs AFTER the publish action. This guarantees we don't build docs for unreleased software, which suddenly became a risk when I added automated releases.

I don't know how to test this. I'm going to keep it open to the next release so that it's visible. I don't want to merge it, forget it, then waste an hour trying to work out why the docs site doesn't build.

Closes #467 

