### PR TITLE
`OAuth2` support in salesforce

### DIFF
--- a/.changeset/four-coats-rhyme.md
+++ b/.changeset/four-coats-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-salesforce': minor
+---
+
+Add `OAuth` support

--- a/packages/salesforce/configuration-schema.json
+++ b/packages/salesforce/configuration-schema.json
@@ -55,7 +55,6 @@
   "required": [
     "loginUrl",
     "username",
-    "password",
-    "securityToken"
+    "password"
   ]
 }

--- a/packages/salesforce/oauth-configuration-schema.json
+++ b/packages/salesforce/oauth-configuration-schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$comment": "OAuth2",
+    "properties": {
+        "accessToken": {
+            "title": "Access Token",
+            "type": "string",
+            "description": "Your Salesforce OAuth2 token",
+            "writeOnly": true,
+            "minLength": 1,
+            "examples": [
+                "00DU0000000Krrw!AQgAQG7lgt2Eq9yaOy_sU9e4pSwcoUTm7YGkGWTnltn0dJBkjdNhmOhdRtMMuakaO9GjXToh5b_enUIcjOGm5uU.mFhxR.R4"
+            ]
+        },
+        "instanceUrl": {
+            "title": "Instance URL",
+            "type": "string",
+            "description": "Your Salesforce instance URL",
+            "writeOnly": true,
+            "minLength": 1,
+            "examples": [
+                "https://na1.salesforce.com"
+            ]
+        }
+    },
+    "type": "object",
+    "additionalProperties": true,
+    "required": [
+        "accessToken",
+        "instanceUrl"
+    ]
+}

--- a/packages/salesforce/oauth-configuration-schema.json
+++ b/packages/salesforce/oauth-configuration-schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$comment": "OAuth2",
     "properties": {
-        "accessToken": {
+        "access_token": {
             "title": "Access Token",
             "type": "string",
             "description": "Your Salesforce OAuth2 token",
@@ -12,21 +12,30 @@
                 "00DU0000000Krrw!AQgAQG7lgt2Eq9yaOy_sU9e4pSwcoUTm7YGkGWTnltn0dJBkjdNhmOhdRtMMuakaO9GjXToh5b_enUIcjOGm5uU.mFhxR.R4"
             ]
         },
-        "instanceUrl": {
-            "title": "Instance URL",
-            "type": "string",
-            "description": "Your Salesforce instance URL",
-            "writeOnly": true,
-            "minLength": 1,
-            "examples": [
-                "https://na1.salesforce.com"
+        "other_oparams": {
+            "type": "object",
+            "properties": {
+                "instance_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "title": "Instance URL",
+                    "description": "Your Salesforce instance URL",
+                    "writeOnly": true,
+                    "minLength": 1,
+                    "examples": [
+                        "https://na1.salesforce.com"
+                    ]
+                }
+            },
+            "required": [
+                "instance_url"
             ]
         }
     },
     "type": "object",
     "additionalProperties": true,
     "required": [
-        "accessToken",
-        "instanceUrl"
+        "access_token",
+        "other_oparams"
     ]
 }

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -164,7 +164,7 @@ export function query(qs) {
     return connection.query(resolvedQs, function (err, result) {
       if (err) {
         const { message, errorCode } = err;
-        console.error(`${errorCode}: ${message}`);
+        console.log(`Error ${errorCode}: ${message}`);
         throw err;
       }
 

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -718,17 +718,18 @@ async function createBasicAuthConnection(state) {
 
 function createAccessTokenConnection(state) {
   console.log('Attempting to connect with OAuth');
-  const { apiVersion, instanceUrl, accessToken } = state.configuration;
+  const { apiVersion, other_params, access_token } = state.configuration;
+  const { instance_url } = other_params;
 
-  if (!instanceUrl || !accessToken) {
+  if (!instance_url || !access_token) {
     throw new Error(
-      'instanceUrl and accessToken are required for OAuth authentication.'
+      'instance_url and access_token are required for OAuth authentication.'
     );
   }
 
   const connectionOptions = {
-    instanceUrl,
-    accessToken,
+    instanceUrl: instance_url,
+    accessToken: access_token,
   };
 
   if (apiVersion) {
@@ -750,9 +751,9 @@ function createAccessTokenConnection(state) {
  * @returns {State}
  */
 function createConnection(state) {
-  const { accessToken } = state.configuration;
+  const { access_token } = state.configuration;
 
-  return accessToken
+  return access_token
     ? createAccessTokenConnection(state)
     : createBasicAuthConnection(state);
 }


### PR DESCRIPTION
## Summary

Add support for `OAuth2` in salesforce adaptor

## Details

Improved the `createConnection` function to handle both `accessToken` connection and Basic Auth connection. I have created two functions [`createBasicAuthConnection` and `createAccessTokenConnection`] that gets called in `createConnection` depending on configuration-schema. I have also created another configuration-schema for `OAuth` which requires `other_params.instance_url` and `access_token`. 

Also in `configuration-schema` I have removed the `securityToken` from `required` property since it's an optional value

## Issues #410 #423 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
