### PR TITLE
Put `instance_url` at the root of configuration schema for Salesforce OAuth

### DIFF
--- a/.changeset/itchy-spiders-scream.md
+++ b/.changeset/itchy-spiders-scream.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-salesforce': major
+---
+
+Remove instance_url under other_params and put it at the root level of the
+configuration schema

--- a/.changeset/itchy-spiders-scream.md
+++ b/.changeset/itchy-spiders-scream.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-salesforce': major
----
-
-Remove instance_url under other_params and put it at the root level of the
-configuration schema

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,6 +1,15 @@
 # @openfn/language-salesforce
 
+## 4.5.0
+
+### Minor Changes
+
+- 0d2b478: Remove `instance_url` under `other_params` and put it at the root
+  level of the configuration schema
+
 ## 4.4.0
+
+Deprecated because it does not work with Lightning
 
 ### Minor Changes
 

--- a/packages/salesforce/oauth-configuration-schema.json
+++ b/packages/salesforce/oauth-configuration-schema.json
@@ -12,23 +12,15 @@
                 "00DU0000000Krrw!AQgAQG7lgt2Eq9yaOy_sU9e4pSwcoUTm7YGkGWTnltn0dJBkjdNhmOhdRtMMuakaO9GjXToh5b_enUIcjOGm5uU.mFhxR.R4"
             ]
         },
-        "other_oparams": {
-            "type": "object",
-            "properties": {
-                "instance_url": {
-                    "type": "string",
-                    "format": "uri",
-                    "title": "Instance URL",
-                    "description": "Your Salesforce instance URL",
-                    "writeOnly": true,
-                    "minLength": 1,
-                    "examples": [
-                        "https://na1.salesforce.com"
-                    ]
-                }
-            },
-            "required": [
-                "instance_url"
+        "instance_url": {
+            "type": "string",
+            "format": "uri",
+            "title": "Instance URL",
+            "description": "Your Salesforce instance URL",
+            "writeOnly": true,
+            "minLength": 1,
+            "examples": [
+                "https://na1.salesforce.com"
             ]
         }
     },
@@ -36,6 +28,6 @@
     "additionalProperties": true,
     "required": [
         "access_token",
-        "other_oparams"
+        "instance_url"
     ]
 }

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -685,8 +685,7 @@ async function createBasicAuthConnection(state) {
 }
 
 function createAccessTokenConnection(state) {
-  const { other_params, access_token } = state.configuration;
-  const { instance_url } = other_params;
+  const { instance_url, access_token } = state.configuration;
 
   const connection = getConnection(state, {
     instanceUrl: instance_url,


### PR DESCRIPTION
## Summary
Update `instance_url` in `oauth-configration-schema.json` to be in the root of configuration schema for Salesforce OAuth. And update `createAccessTokenConnection` in `adaptors.js`

## Issues 
Ref #472 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
