### PR TITLE
Update `mailgun` configuration-schema

### DIFF
--- a/.changeset/healthy-countries-dream.md
+++ b/.changeset/healthy-countries-dream.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-mailgun': patch
+---
+
+Update configuration-schema

--- a/.changeset/healthy-countries-dream.md
+++ b/.changeset/healthy-countries-dream.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-mailgun': patch
----
-
-Update configuration-schema

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-mailgun
 
+## 0.4.4
+
+### Patch Changes
+
+- e7ff766: Update configuration-schema
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/mailgun/configuration-schema.json
+++ b/packages/mailgun/configuration-schema.json
@@ -2,13 +2,13 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
         "domain": {
-            "title": "Domain URL",
+            "title": "Domain Name",
             "type": "string",
-            "description": "Mailgun API domain URL",
-            "format": "uri",
+            "description": "Mailgun API Domain Name",
+            "format": "hostname",
             "minLength": 1,
             "examples": [
-                "https://mailgun.com/api/example"
+                "sandbox-123.mailgun.org"
             ]
         },
         "apiKey": {

--- a/packages/mailgun/package.json
+++ b/packages/mailgun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mailgun",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "mailgun Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {


### PR DESCRIPTION
## Summary

Update configuration schema for `mailgun` adaptor

## Details
Using the adaptor `mailgun` adaptor you only need the `hostname` in you're credentials. This PR changes the `Domain URL` to `Domain Name` and update the format from `uri` to `hostname`.  

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
