### PR TITLE
Cursor Helper

### DIFF
--- a/.changeset/odd-apples-wait.md
+++ b/.changeset/odd-apples-wait.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': minor
+---
+
+Added cursor() helper

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1313,6 +1313,83 @@
       "valid": true
     },
     {
+      "name": "cursor",
+      "params": [
+        "value",
+        "options"
+      ],
+      "docs": {
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "cursor($.cursor, { defaultValue: 'today' })",
+            "caption": "Use a cursor from state if present, or else use the default value"
+          },
+          {
+            "title": "example",
+            "description": "cursor(22)",
+            "caption": "Use a pagination cursor"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "the cursor value. Usually an ISO date, natural language date, or page number",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "value"
+          },
+          {
+            "title": "param",
+            "description": "options to control the cursor.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "options"
+          },
+          {
+            "title": "param",
+            "description": "set the cursor key. Will persist through the whole run.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "options.key"
+          },
+          {
+            "title": "param",
+            "description": "the value to use if value is falsy",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "options.defaultValue"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
+    },
+    {
       "name": "map",
       "params": [
         "path",

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -827,7 +827,7 @@ export function cursor(value, options = {}) {
       }
     }
     state[cursorKey] = cursor;
-    console.log(`Setting cursor to ${cursor}`);
+    console.log('Setting cursor to:', cursor);
 
     return state;
   }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -778,26 +778,19 @@ export function validate(schema = 'schema', data = 'data') {
   };
 }
 
-// Note that we don't write cursorStart to state,
-// because it should not affect the next job
-
 let cursorStart = undefined;
 let cursorKey = 'cursor';
 
-// TODO timezones
-// All times should use UTC internally. But you can have strings parsed in a different time zone
-// Also,when we log a cursor time, we should log it in the timezone provided
 /**
- * Sets a cursor value on state (writes to `state.cursor`, or whatever value you set on options.key).
- * The first time this is called, a `cursorStart` key will be set on state,
- * which you can use to set the final state.cursor ready for the next run with `cursor('start')`
+ * Sets a cursor property on state.
  * Supports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,
  * which will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones 
  * are not yet supported.
+ * See the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}
  * @public
- * @example <caption>use a cursor from state if present, or else use the default value</caption>
+ * @example <caption>Use a cursor from state if present, or else use the default value</caption>
  * cursor($.cursor, { defaultValue: 'today' })
- * @example <caption>cursor for pagination</caption>
+ * @example <caption>Use a pagination cursor</caption>
  * cursor(22)
  * @function
  * @param {any} value - the cursor value. Usually an ISO date, natural language date, or page number

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -813,17 +813,18 @@ export function cursor(value, options = {}) {
     }
 
     if (!cursorStart) {
-      cursorStart = new Date().toISOString()
+      cursorStart = new Date().toISOString();
     }
 
     const cursor = resolvedValue ?? defaultValue;
 
     if (typeof cursor === 'string') {
-      state[cursorKey] = parseDate(cursor, cursorStart)
-      console.log(`Setting cursor "${cursor}" to ${new Date(state.cursor).toLocaleString()}`)
+      state[cursorKey] = parseDate(cursor, cursorStart);
+      const humanLocaleDate = state[cursorKey].toLocaleString(undefined, { timeZoneName: 'short' });
+      console.log(`Setting cursor "${cursor}" to ${humanLocaleDate}`);
     } else {
       state[cursorKey] = cursor;
-      console.log(`Setting cursor to ${cursor}`)
+      console.log(`Setting cursor to ${cursor}`);
     }
 
     return state;

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -813,19 +813,21 @@ export function cursor(value, options = {}) {
     }
 
     if (!cursorStart) {
-      cursorStart = new Date().toISOString();
+      cursorStart = new Date();
     }
 
     const cursor = resolvedValue ?? defaultValue;
-
     if (typeof cursor === 'string') {
-      state[cursorKey] = parseDate(cursor, cursorStart);
-      const humanLocaleDate = state[cursorKey].toLocaleString(undefined, { timeZoneName: 'short' });
-      console.log(`Setting cursor "${cursor}" to ${humanLocaleDate}`);
-    } else {
-      state[cursorKey] = cursor;
-      console.log(`Setting cursor to ${cursor}`);
+      const date = parseDate(cursor, cursorStart)
+      if (date instanceof Date && date.toString !== "Invalid Date") {
+        state[cursorKey] = date.toISOString();
+        const humanLocaleDate = date.toLocaleString(undefined, { timeZoneName: 'short' });
+        console.log(`Setting cursor "${cursor}" to: ${humanLocaleDate}`);
+        return state;
+      }
     }
+    state[cursorKey] = cursor;
+    console.log(`Setting cursor to ${cursor}`);
 
     return state;
   }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -801,7 +801,7 @@ let cursorStart = undefined;
  * @param {any} options - options to control the cursor. Options will persist after the first call.
  * @returns {Operation}
  */
-export function cursor(value, options) {
+export function cursor(value, options = {}) {
   return (state) => {
     const [resolvedValue] = newExpandReferences(state, value);
 
@@ -813,15 +813,14 @@ export function cursor(value, options) {
     } = options;
 
     if (!cursorStart) {
-      cursorStart = converter(new Date().toISOString())
+      cursorStart = new Date().toISOString()
     }
 
     const cursor = resolvedValue ?? defaultValue;
 
     if (typeof cursor === 'string') {
       state[key] = parseDate(cursor, cursorStart)
-      // TODO we should format the output more nicely
-      console.log(`Setting cursor "${cursor}" to ${new Date(state.cursor).toUTCString()}`)
+      console.log(`Setting cursor "${cursor}" to ${new Date(state.cursor).toLocaleString()}`)
     } else {
       state[key] = cursor;
       console.log(`Setting cursor to ${cursor}`)

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -782,6 +782,7 @@ export function validate(schema = 'schema', data = 'data') {
 // because it should not affect the next job
 
 let cursorStart = undefined;
+let cursorKey = 'cursor';
 
 // TODO timezones
 // All times should use UTC internally. But you can have strings parsed in a different time zone
@@ -798,7 +799,9 @@ let cursorStart = undefined;
  * cursor(22)
  * @function
  * @param {any} value - the cursor value. Usually an ISO date, natural language date, or page number
- * @param {any} options - options to control the cursor. Options will persist after the first call.
+ * @param {object} options - options to control the cursor.
+ * @param {string} options.key - set the cursor key. Will persist through the whole run.
+ * @param {any} options.defaultValue - the value to use if value is falsy
  * @returns {Operation}
  */
 export function cursor(value, options = {}) {
@@ -807,10 +810,12 @@ export function cursor(value, options = {}) {
 
     const {
       defaultValue, // if there is no cursor on state, this will be used
-      key = 'cursor', // the key to use on state. idk why you want to change this, but sure
-      
-      // timezone, // time zone as in UTC, GMT, PST? Or locale?
+      key, // the key to use on state
     } = options;
+
+    if (key) {
+      cursorKey = key;
+    }
 
     if (!cursorStart) {
       cursorStart = new Date().toISOString()
@@ -819,10 +824,10 @@ export function cursor(value, options = {}) {
     const cursor = resolvedValue ?? defaultValue;
 
     if (typeof cursor === 'string') {
-      state[key] = parseDate(cursor, cursorStart)
+      state[cursorKey] = parseDate(cursor, cursorStart)
       console.log(`Setting cursor "${cursor}" to ${new Date(state.cursor).toLocaleString()}`)
     } else {
-      state[key] = cursor;
+      state[cursorKey] = cursor;
       console.log(`Setting cursor to ${cursor}`)
     }
 

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -801,12 +801,12 @@ let cursorKey = 'cursor';
  */
 export function cursor(value, options = {}) {
   return (state) => {
-    const [resolvedValue] = newExpandReferences(state, value);
+    const [resolvedValue, resolvedOptions] = newExpandReferences(state, value, options);
 
     const {
       defaultValue, // if there is no cursor on state, this will be used
       key, // the key to use on state
-    } = options;
+    } = resolvedOptions;
 
     if (key) {
       cursorKey = key;

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -792,7 +792,7 @@ let cursorKey = 'cursor';
  * The first time this is called, a `cursorStart` key will be set on state,
  * which you can use to set the final state.cursor ready for the next run with `cursor('start')`
  * Supports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,
- * which will be converted into a UTC time relative to the current UTC time. Relative timezones 
+ * which will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones 
  * are not yet supported.
  * @public
  * @example <caption>use a cursor from state if present, or else use the default value</caption>

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -791,7 +791,9 @@ let cursorKey = 'cursor';
  * Sets a cursor value on state (writes to `state.cursor`, or whatever value you set on options.key).
  * The first time this is called, a `cursorStart` key will be set on state,
  * which you can use to set the final state.cursor ready for the next run with `cursor('start')`
- * Supports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`
+ * Supports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,
+ * which will be converted into a UTC time relative to the current UTC time. Relative timezones 
+ * are not yet supported.
  * @public
  * @example <caption>use a cursor from state if present, or else use the default value</caption>
  * cursor($.cursor, { defaultValue: 'today' })

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -803,6 +803,7 @@ let cursorStart = undefined;
  */
 export function cursor(value, options) {
   return (state) => {
+    const [resolvedValue] = newExpandReferences(state, value);
 
     const {
       defaultValue, // if there is no cursor on state, this will be used
@@ -815,7 +816,7 @@ export function cursor(value, options) {
       cursorStart = converter(new Date().toISOString())
     }
 
-    const cursor = value ?? defaultValue;
+    const cursor = resolvedValue ?? defaultValue;
 
     if (typeof cursor === 'string') {
       state[key] = parseDate(cursor, cursorStart)

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -6,6 +6,7 @@ import { parse } from 'csv-parse';
 import { Readable } from 'node:stream';
 
 import { request } from 'undici';
+import { format } from 'date-fns';
 
 import { expandReferences as newExpandReferences, parseDate } from './util';
 
@@ -821,8 +822,10 @@ export function cursor(value, options = {}) {
       const date = parseDate(cursor, cursorStart)
       if (date instanceof Date && date.toString !== "Invalid Date") {
         state[cursorKey] = date.toISOString();
-        const humanLocaleDate = date.toLocaleString(undefined, { timeZoneName: 'short' });
-        console.log(`Setting cursor "${cursor}" to: ${humanLocaleDate}`);
+        // Log the converted date in a very international, human-friendly format
+        // See https://date-fns.org/v3.6.0/docs/format
+        const formatted = format(date, 'HH:MM d MMM yyyy (OOO)')
+        console.log(`Setting cursor "${cursor}" to: ${formatted}`);
         return state;
       }
     }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -781,7 +781,7 @@ export function validate(schema = 'schema', data = 'data') {
 // Note that we don't write cursorStart to state,
 // because it should not affect the next job
 
-let cursorStart;
+let cursorStart = undefined;
 
 /**
  * Sets a cursor value on state (writes to `state.cursor`).

--- a/packages/common/src/util/index.js
+++ b/packages/common/src/util/index.js
@@ -1,2 +1,5 @@
 export * from './http';
 export * from './references';
+import parseDate from './parse-date';
+
+export  { parseDate }

--- a/packages/common/src/util/parse-date.js
+++ b/packages/common/src/util/parse-date.js
@@ -1,0 +1,34 @@
+import { startOfToday, startOfYesterday, subHours, subDays } from 'date-fns'
+
+// Helper function to parse a natural-langauge date string into an ISO date
+export default (d, startDate) => {
+  try {
+    if (d === 'start') {
+      return startDate;
+    } else if (d === 'now' || d === 'end') {
+      return new Date().toISOString()
+    }
+    else if (d === 'today') {
+      return startOfToday().toISOString()
+    }
+    else if (d === 'yesterday') {
+      return startOfYesterday().toISOString()
+    }
+    else if (/(hours? ago)$/.test(d)) {
+      // return the same minute n hours ago
+      const [diff] = d.match(/\d+/)
+      return subHours(new Date(), diff).toISOString()
+    }
+    else if (/(days? ago)$/.test(d)) {
+      // return the start of today - n days
+      const [diff] = d.match(/\d+/)
+      return startOfToday(subDays(new Date(), diff)).toISOString()
+    }
+  } catch(e) {
+    console.log(`Error converting ${d} into a date`)
+    console.log(e)
+  }
+
+  // Just return the value if we couldn't parse it
+  return d;
+}

--- a/packages/common/src/util/parse-date.js
+++ b/packages/common/src/util/parse-date.js
@@ -1,6 +1,6 @@
 import { startOfToday, startOfYesterday, subHours, subDays } from 'date-fns'
 
-// Helper function to parse a natural-langauge date string into an ISO date
+// Helper function to parse a natural-language date string into an ISO date
 export default (d, startDate) => {
   try {
     if (d === 'start') {

--- a/packages/common/src/util/parse-date.js
+++ b/packages/common/src/util/parse-date.js
@@ -1,4 +1,4 @@
-import { startOfToday, startOfYesterday, subHours, subDays } from 'date-fns'
+import { startOfToday, startOfYesterday, subHours, subDays, startOfDay } from 'date-fns'
 
 // Helper function to parse a natural-language date string into an ISO date
 export default (d, startDate) => {
@@ -22,7 +22,7 @@ export default (d, startDate) => {
     else if (/(days? ago)$/.test(d)) {
       // return the start of today - n days
       const [diff] = d.match(/\d+/)
-      return startOfToday(subDays(new Date(), diff))
+      return startOfDay(subDays(new Date(), diff))
     }
   } catch(e) {
     console.log(`Error converting ${d} into a date`)

--- a/packages/common/src/util/parse-date.js
+++ b/packages/common/src/util/parse-date.js
@@ -6,23 +6,23 @@ export default (d, startDate) => {
     if (d === 'start') {
       return startDate;
     } else if (d === 'now' || d === 'end') {
-      return new Date().toISOString()
+      return new Date()
     }
     else if (d === 'today') {
-      return startOfToday().toISOString()
+      return startOfToday()
     }
     else if (d === 'yesterday') {
-      return startOfYesterday().toISOString()
+      return startOfYesterday()
     }
     else if (/(hours? ago)$/.test(d)) {
       // return the same minute n hours ago
       const [diff] = d.match(/\d+/)
-      return subHours(new Date(), diff).toISOString()
+      return subHours(new Date(), diff)
     }
     else if (/(days? ago)$/.test(d)) {
       // return the start of today - n days
       const [diff] = d.match(/\d+/)
-      return startOfToday(subDays(new Date(), diff)).toISOString()
+      return startOfToday(subDays(new Date(), diff))
     }
   } catch(e) {
     console.log(`Error converting ${d} into a date`)

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -886,4 +886,33 @@ describe('cursor', () => {
     const result = cursor('today')(state)
     expect(result.cursor).to.eql(date);
   });
+
+  it('should clear the cursor', () => {
+    const state = {
+      cursor: new Date()
+    }
+    const result = cursor()(state)
+    expect(result.cursor).to.eql(undefined)
+  });
+
+  it('should use a default value', () => {
+    const state = {}
+    const result = cursor(state.cursor, { defaultValue: 33 })(state)
+    expect(result.cursor).to.eql(33)
+  });
+
+  it('should use a custom key', () => {
+    const state = {}
+    const result = cursor(44, { key: 'page' })(state)
+    expect(result.page).to.eql(44)
+  });
+
+  it('should re-use a custom key', () => {
+    const state = {}
+    const result1 = cursor(44, { key: 'page' })(state)
+    expect(result1.page).to.eql(44)
+
+    const result2 = cursor(55)(state)
+    expect(result2.page).to.eql(55)
+  });
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -887,6 +887,14 @@ describe('cursor', () => {
     expect(result.cursor).to.eql(date);
   });
 
+  it('should not blow up if an arbitrary string is passed', () => {
+    const state = {}
+
+    const str = 'rock the cashbah'
+    const result = cursor(str)(state)
+    expect(result.cursor).to.eql(str);
+  });
+
   it('should clear the cursor', () => {
     const state = {
       cursor: new Date()

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -7,6 +7,7 @@ import {
   arrayToString,
   chunk,
   combine,
+  cursor,
   dataPath,
   dataValue,
   each,
@@ -29,6 +30,7 @@ import {
   toArray,
   validate,
 } from '../src/Adaptor';
+import { startOfToday } from 'date-fns';
 
 const mockAgent = new MockAgent();
 setGlobalDispatcher(mockAgent);
@@ -859,5 +861,29 @@ describe('validate', () => {
     const result = await validate()(state);
 
     expect(result.validationErrors).to.eql([]);
+  });
+});
+
+describe('cursor', () => {
+  it('should set a cursor on state', () => {
+    const state = {}
+    const result = cursor(1234)(state)
+    expect(result.cursor).to.eql(1234);
+  });
+
+  it('should set a cursorStart on state', () => {
+    const state = {}
+    const date = new Date();
+    const result = cursor('start')(state)
+    const resultDate = new Date(result.cursor)
+    expect(resultDate.toDateString()).to.eql(date.toDateString())
+  });
+
+  it('should set a cursor on state with a natural language timestamp', () => {
+    const state = {}
+
+    const date = startOfToday().toISOString()
+    const result = cursor('today')(state)
+    expect(result.cursor).to.eql(date);
   });
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -864,7 +864,7 @@ describe('validate', () => {
   });
 });
 
-describe('cursor', () => {
+describe.only('cursor', () => {
   it('should set a cursor on state', () => {
     const state = {}
     const result = cursor(1234)(state)
@@ -923,4 +923,13 @@ describe('cursor', () => {
     const result2 = cursor(55)(state)
     expect(result2.page).to.eql(55)
   });
+
+  // testing the log output is hard here, I've only verified it manally
+  it('should use an object', () => {
+    const state = {}
+    const c = { page: 22, next: 23 }
+    const result = cursor(c, { key: 'cursor' })(state)
+    expect(result.cursor).to.eql(c)
+  });
+
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -864,7 +864,7 @@ describe('validate', () => {
   });
 });
 
-describe.only('cursor', () => {
+describe('cursor', () => {
   it('should set a cursor on state', () => {
     const state = {}
     const result = cursor(1234)(state)

--- a/packages/common/test/util/parse-date.test.js
+++ b/packages/common/test/util/parse-date.test.js
@@ -12,7 +12,7 @@ const approxEqual = (a, b) => {
   expect(a_ms).eql(b_ms)
 }
 
-describe('parse date', () => {
+describe.only('parse date', () => {
 
   it('should return now', () => {
     const today = new Date().toISOString()
@@ -77,11 +77,19 @@ describe('parse date', () => {
     approxEqual(result, target)
   })
 
+  it('should return 2 days ago', () => {
+    const target = startOfDay(subDays(new Date(), 2)).toLocaleString()
+    console.log(target)
+    const result = parseDate('2 days ago').toLocaleString()
+    console.log(result)
+    expect(result).eql(target)
+  })
+
   it('should return 9999 days ago', () => {
-    const target = subDays(new Date(), 9999).toISOString()
+    const target = startOfDay(subDays(new Date(), 9999)).toISOString()
     
     const result = parseDate('9999 days ago').toISOString()
-    approxEqual(result, target)
+    expect(result).eql(target)
   })
 
   it('should return start', () => {

--- a/packages/common/test/util/parse-date.test.js
+++ b/packages/common/test/util/parse-date.test.js
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import parseDate from '../../src/util/parse-date';
+import { startOfDay, subDays, subHours } from 'date-fns';
+
+// Check if two date are the same to ms resolution
+// Ie, cut off the nanoseconds of the date
+// there is a vanishingly small chance that dates could be 1ns apart
+// but cross an ms line - there's only so much we can do about this
+const approxEqual = (a, b) => {
+  const a_ms = a.substring(0, a.length - 5)
+  const b_ms = a.substring(0, a.length - 5)
+  expect(a_ms).eql(b_ms)
+}
+
+describe('parse date', () => {
+
+  it('should return now', () => {
+    const today = new Date().toISOString()
+    
+    const result = parseDate('now')
+    approxEqual(result, today)
+  })
+
+  it('should return start of today', () => {
+    const today = startOfDay(new Date()).toISOString()
+    
+    const result = parseDate('today')
+    expect(result).eql(today)
+  })
+
+  it('should return start of yesterday', () => {
+    const yesterday = startOfDay(subDays(new Date(), 1)).toISOString()
+    
+    const result = parseDate('yesterday')
+    expect(result).eql(yesterday)
+  })
+
+  it('should return 1 hour ago', () => {
+    const target = subHours(new Date(), 1).toISOString()
+    
+    const result = parseDate('1 hour ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 1 hours ago', () => {
+    const target = subHours(new Date(), 1).toISOString()
+    
+    const result = parseDate('1 hours ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 0001 hours ago', () => {
+    const target = subHours(new Date(), 1).toISOString()
+    
+    const result = parseDate('0001 hours ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 333 hours ago', () => {
+    const target = subHours(new Date(), 333).toISOString()
+    
+    const result = parseDate('333 hours ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 1 day ago', () => {
+    const target = subDays(new Date(), 1).toISOString()
+    
+    const result = parseDate('1 day ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 1 days ago', () => {
+    const target = subDays(new Date(), 1).toISOString()
+    
+    const result = parseDate('1 days ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 9999 days ago', () => {
+    const target = subDays(new Date(), 9999).toISOString()
+    
+    const result = parseDate('9999 days ago')
+    approxEqual(result, target)
+  })
+
+  it('should return start', () => {
+    const start = subHours(new Date(), 1).toISOString()
+    
+    const result = parseDate('start', start)
+    expect(result).eql(start)
+  })
+
+  it('should return a date', () => {
+    const date = subHours(new Date(), 3).toISOString()
+    
+    const result = parseDate(date)
+    expect(result).eql(date)
+  });
+})

--- a/packages/common/test/util/parse-date.test.js
+++ b/packages/common/test/util/parse-date.test.js
@@ -17,70 +17,70 @@ describe('parse date', () => {
   it('should return now', () => {
     const today = new Date().toISOString()
     
-    const result = parseDate('now')
+    const result = parseDate('now').toISOString()
     approxEqual(result, today)
   })
 
   it('should return start of today', () => {
     const today = startOfDay(new Date()).toISOString()
     
-    const result = parseDate('today')
+    const result = parseDate('today').toISOString()
     expect(result).eql(today)
   })
 
   it('should return start of yesterday', () => {
     const yesterday = startOfDay(subDays(new Date(), 1)).toISOString()
     
-    const result = parseDate('yesterday')
+    const result = parseDate('yesterday').toISOString()
     expect(result).eql(yesterday)
   })
 
   it('should return 1 hour ago', () => {
     const target = subHours(new Date(), 1).toISOString()
     
-    const result = parseDate('1 hour ago')
+    const result = parseDate('1 hour ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 1 hours ago', () => {
     const target = subHours(new Date(), 1).toISOString()
     
-    const result = parseDate('1 hours ago')
+    const result = parseDate('1 hours ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 0001 hours ago', () => {
     const target = subHours(new Date(), 1).toISOString()
     
-    const result = parseDate('0001 hours ago')
+    const result = parseDate('0001 hours ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 333 hours ago', () => {
     const target = subHours(new Date(), 333).toISOString()
     
-    const result = parseDate('333 hours ago')
+    const result = parseDate('333 hours ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 1 day ago', () => {
     const target = subDays(new Date(), 1).toISOString()
     
-    const result = parseDate('1 day ago')
+    const result = parseDate('1 day ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 1 days ago', () => {
     const target = subDays(new Date(), 1).toISOString()
     
-    const result = parseDate('1 days ago')
+    const result = parseDate('1 days ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 9999 days ago', () => {
     const target = subDays(new Date(), 9999).toISOString()
     
-    const result = parseDate('9999 days ago')
+    const result = parseDate('9999 days ago').toISOString()
     approxEqual(result, target)
   })
 


### PR DESCRIPTION
This PR adds a `cursor()` function designed to make the timestamp and pagination cursor pattern easier.

Closes #486

This approach leans heavily on input state and works best in v2.

See the docs PR at https://github.com/OpenFn/docs/pull/465

## General approach

Unlike v1, Lightning (and the CLI) give us good control of the input state. We need to use that.

So, if you want to run a job with the cursor in a specific place, just set the input to `{ cursor: '<date>' }` and that will be respected by the job.

To make date management easier, you pass human friendly strings `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start` (the time at which the run started). Note that these will parse relative to system time - which in lightning's case probably means UTC.

## Usage

Use the `cursor` function from common to set a cursor value on state.

```
cursor($.cursor, { defaultValue:  'today' })
```

This pattern will allow you to use the value on state if provided, but if no cursor is passed will default to "today".

You can update the cursor within the job by setting `state.cursor`. Or, if you want to use a natural language timestamp, use the `cursor` operation again.

```
cursor($.cursor, { defaultValue:  'today' })
fn(/* do something */)
cursor('now')
```

The value that gets written to `state.cursor` will be an actual ISO date, so when the next job runs, the cursor will be set to this start time.

Note that adaptors will need to be updated to export `cursor` from common.

## Options

The second argument accepts options:

* `options.defaultValue` is the value that will be used if the value argument is falsy
* `options.key` lets you change the state key used (ie, use `page` instead of `cursor`)

Later we might introduce a timezone and a flag to disable natural language date parsing.

## Usage examples

Basic usage: a cursor which starts from the start of the current day
```js
cursor('today')
fn(() => { /* do the thing using state.cursor */ })
```

Typical usage: use the input state if provided, or else default to 'now'. At the end of the job, set the cursor to the start time, ready for the next run.
```js
cursor($.cursor, { defaultValue: 'now' })
fn(() => { /* do the thing, use and set state.cursor */ })
cursor('start')
```

Pagination cursor which defaults to page 0
```js
cursor($.cursor, { defaultValue: 0, key: 'page' })
fn(() => { /* do the thing, use and set state.page */ })
```
