### PR TITLE
List common exports in all docs

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -35,12 +35,12 @@ rm tmp/tmp.json
 echo ] >>tmp/docs.json
 
 # commit new docs
-# git fetch origin docs
-# git switch docs
+git fetch origin docs
+git switch docs
 
 rsync -pr tmp/* docs/
 
-# git add docs --force
-# git status
-# git add -A && git commit -m"Update auto-generated documentation."
-# git push origin docs
+git add docs --force
+git status
+git add -A && git commit -m"Update auto-generated documentation."
+git push origin docs

--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -35,12 +35,12 @@ rm tmp/tmp.json
 echo ] >>tmp/docs.json
 
 # commit new docs
-git fetch origin docs
-git switch docs
+# git fetch origin docs
+# git switch docs
 
 rsync -pr tmp/* docs/
 
-git add docs --force
-git status
-git add -A && git commit -m"Update auto-generated documentation."
-git push origin docs
+# git add docs --force
+# git status
+# git add -A && git commit -m"Update auto-generated documentation."
+# git push origin docs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2029,6 +2029,9 @@ importers:
       '@types/node':
         specifier: 18.17.5
         version: 18.17.5
+      acorn:
+        specifier: ^8.11.3
+        version: 8.11.3
       esno:
         specifier: 0.16.3
         version: 0.16.3
@@ -3547,6 +3550,12 @@ packages:
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
+    dev: false
+
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
     dev: false
 
   /acorn@8.8.1:
@@ -12425,7 +12434,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.17.5
-      acorn: 8.8.1
+      acorn: 8.11.3
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2035,6 +2035,9 @@ importers:
       esno:
         specifier: 0.16.3
         version: 0.16.3
+      file-set:
+        specifier: ^5.1.3
+        version: 5.1.3
       jsdoc-to-markdown:
         specifier: 8.0.0
         version: 8.0.0
@@ -7090,6 +7093,14 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       array-back: 5.0.0
+      glob: 7.2.3
+    dev: false
+
+  /file-set@5.1.3:
+    resolution: {integrity: sha512-mQ6dqz+z59on3B50IGF3ujNGbZmY1TAeLHpNfhLEeNM6Lky31w3RUlbCyqZWQs0DuZJQU4R2qDuVd9ojyzadcg==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      array-back: 6.2.2
       glob: 7.2.3
     dev: false
 

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@openfn/simple-ast": "0.4.1",
     "@types/node": "18.17.5",
+    "acorn": "^8.11.3",
     "esno": "0.16.3",
     "jsdoc-to-markdown": "8.0.0",
     "ts-node": "10.9.1",

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -16,6 +16,7 @@
     "@types/node": "18.17.5",
     "acorn": "^8.11.3",
     "esno": "0.16.3",
+    "file-set": "^5.1.3",
     "jsdoc-to-markdown": "8.0.0",
     "ts-node": "10.9.1",
     "tsup": "6.3.0",

--- a/tools/build/src/commands/docs.ts
+++ b/tools/build/src/commands/docs.ts
@@ -41,7 +41,6 @@ export default async (lang: string) => {
   await fileSet.add([glob])
 
   // Extract exports from common and add them to the template data as externals
-  let exports = [];
   for (const f of fileSet.files) {
     const src = await fs.readFile(f, 'utf8')
     const exports = extractExports(src).map((e) => ({
@@ -115,15 +114,13 @@ export default async (lang: string) => {
     readme: `${JSON.stringify(readme)}`,
     changelog: `${JSON.stringify(changelog)}`,
     functions: functions.sort(),
-    'configuration-schema': configurationSchema,
-    commonExports: exports
+    'configuration-schema': configurationSchema
   };
 
   const destinationDir = `${root}/docs`;
   const destination = `${destinationDir}/index.md`;
   await mkdir(destinationDir, { recursive: true });
   await writeFile(destination, docs);
-  await writeFile(`${destinationDir}/templateData.json`, JSON.stringify(templateData, null, 2));
   await writeFile(`${destinationDir}/${lang}.json`, JSON.stringify(docsJson));
 
   console.log(`... done! `, destination);

--- a/tools/build/src/commands/docs.ts
+++ b/tools/build/src/commands/docs.ts
@@ -1,8 +1,8 @@
-import jsdoc2md from 'jsdoc-to-markdown';
-import fs from 'node:fs/promises';
+import fs, { writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { writeFile, mkdir } from 'node:fs/promises';
+import jsdoc2md from 'jsdoc-to-markdown';
+import FileSet from 'file-set'
 import resolvePath from '../util/resolve-path';
 import extractExports from '../util/extract-exports';
 
@@ -12,17 +12,14 @@ export default async (lang: string) => {
   console.log(`Building docs`);
   console.log();
 
-
-  // TODO proably need to do this for each file
-  const main = await fs.readFile(`${root}/src/Adaptor.js`, 'utf-8')
-  const exports = extractExports(main)
+  const glob = `${root}/src/**/*.js`;
 
   const template = await fs.readFile(
     '../../tools/build/src/util/docs-template.hbs'
   );
   /* get template data */
   const templateData = jsdoc2md.getTemplateDataSync({
-    files: `${root}/src/**/*.js`,
+    files: glob,
   });
 
   // sort template data
@@ -40,7 +37,22 @@ export default async (lang: string) => {
     return 0;
   });
 
-  templateData.push(...exports.map((e) => ({ id: e, common: true, name: e, scope: 'global', kind: "external" })))
+  const fileSet = new FileSet()
+  await fileSet.add([glob])
+
+  // Extract exports from common and add them to the template data as externals
+  let exports = [];
+  for (const f of fileSet.files) {
+    const src = await fs.readFile(f, 'utf8')
+    const exports = extractExports(src).map((e) => ({
+      id: e,
+      common: true,
+      name: e,
+      scope: 'global',
+      kind: "external"
+    }))
+    templateData.push(...exports)
+  }
 
   const helper = path.resolve('../../tools/build/src/util/hbs-helpers.js');
   const renderOpts = {
@@ -60,7 +72,8 @@ export default async (lang: string) => {
     'example-lang': 'js',
     'member-index-format': 'list',
   };
-  console.log(`rendering all that good stuff..`);
+  
+  console.log('rendering jsdocs...');
   const docs = jsdoc2md.renderSync(renderOpts);
 
   const readme = await fs.readFile(`${root}/README.md`, 'utf8', (err, data) =>
@@ -114,6 +127,7 @@ export default async (lang: string) => {
   await writeFile(`${destinationDir}/${lang}.json`, JSON.stringify(docsJson));
 
   console.log(`... done! `, destination);
+  console.log()
 
   return;
 };

--- a/tools/build/src/partials/members.hbs
+++ b/tools/build/src/partials/members.hbs
@@ -1,0 +1,3 @@
+{{#children inherited=undefined ~}}
+{{>docs~}}
+{{/children~}}

--- a/tools/build/src/util/docs-template.backup.hbs
+++ b/tools/build/src/util/docs-template.backup.hbs
@@ -1,6 +1,7 @@
 {{#if (showMainIndex)~}}
 
 {{#globals kind="function" ~}}
+{{name}}
 {{#if @first~}}{{>heading-indent}}Functions
 
 <dl>
@@ -20,6 +21,7 @@
 {{#if @last~}}</dl>{{/if~}}
 {{/globals~}}
 
+
 {{!-- {{>global-index-kinds kind="typedef" title="Typedefs" ~}} --}}
 
 {{/if~}}
@@ -27,15 +29,12 @@
 {{!-- this calls my common fns helper --}}
 {{!-- but why does it dump the array and not iterate? --}}
 {{#commonFns ~}}
-
 {{#if @first~}}{{>heading-indent}}Common
 
-The following functions are exported from the common adaptor:
 <dl>
+The following functions are exported from common:
 {{/if~}}
-<dt>
-    <a href="/adaptors/packages/common-docs#{{toLowerCase (anchorName)}}">{{name}}()</a>
-</dt>
+<dt>x</dt>
 {{#if @last~}}</dl>{{/if~}}
 {{/commonFns~}}
 

--- a/tools/build/src/util/docs-template.hbs
+++ b/tools/build/src/util/docs-template.hbs
@@ -25,8 +25,7 @@
 
 {{#commonFns}}
 
-{{#if @first~}}{{>heading-indent}}Common
-
+{{#if @first~}}
 The following functions are exported from the common adaptor:
 <dl>
 {{/if~}}

--- a/tools/build/src/util/docs-template.hbs
+++ b/tools/build/src/util/docs-template.hbs
@@ -17,16 +17,13 @@
 {{~/sig}}{{/if~}}
 </dt>
 {{!-- <dd>{{{md (inlineLinks description)}}}</dd> --}}
-{{#if @last~}}</dl>{{/if~}}
+{{#if @last~}}</dl>
+{{/if~}}
 {{/globals~}}
-
 {{!-- {{>global-index-kinds kind="typedef" title="Typedefs" ~}} --}}
-
 {{/if~}}
 
-{{!-- this calls my common fns helper --}}
-{{!-- but why does it dump the array and not iterate? --}}
-{{#commonFns ~}}
+{{#commonFns}}
 
 {{#if @first~}}{{>heading-indent}}Common
 
@@ -35,12 +32,12 @@ The following functions are exported from the common adaptor:
 {{/if~}}
 <dt>
     <a href="/adaptors/packages/common-docs#{{toLowerCase (anchorName)}}">{{name}}()</a>
-</dt>
-{{#if @last~}}</dl>{{/if~}}
-{{/commonFns~}}
-
+</dt>{{#if @last}}</dl>
+{{/if}}
+{{/commonFns}}
 
 {{#orphans ~}}
+
 {{>heading-indent}}{{anchorName}}
 
 {{>sig-name}}

--- a/tools/build/src/util/extract-exports.ts
+++ b/tools/build/src/util/extract-exports.ts
@@ -10,7 +10,7 @@ export default (source: string) => {
 
   const externalFunctions = ast.body
     .filter(i => i.type == 'ExportNamedDeclaration')
-    .filter((i: any) => i.specifiers.length > 0)
+    .filter((i: any) => i.specifiers.length > 0 && i.source?.value)
     .filter((i: any) => i.source.value == '@openfn/language-common')
     .map((i: any) =>
       i.specifiers.map(s => {

--- a/tools/build/src/util/extract-exports.ts
+++ b/tools/build/src/util/extract-exports.ts
@@ -1,19 +1,18 @@
 
 import * as acorn from 'acorn';
 
-
 export default (source: string) => {
   const ast = acorn.parse(source, {
     sourceType: 'module',
-    ecmaVersion: 10,
+    ecmaVersion: 'latest',
     locations: false,
   });
 
   const externalFunctions = ast.body
     .filter(i => i.type == 'ExportNamedDeclaration')
-    .filter(i => i.specifiers.length > 0)
-    .filter(i => i.source.value == '@openfn/language-common')
-    .map(i =>
+    .filter((i: any) => i.specifiers.length > 0)
+    .filter((i: any) => i.source.value == '@openfn/language-common')
+    .map((i: any) =>
       i.specifiers.map(s => {
         return s.exported.name;
       })

--- a/tools/build/src/util/extract-exports.ts
+++ b/tools/build/src/util/extract-exports.ts
@@ -1,0 +1,26 @@
+
+import * as acorn from 'acorn';
+
+
+export default (source: string) => {
+  const ast = acorn.parse(source, {
+    sourceType: 'module',
+    ecmaVersion: 10,
+    locations: false,
+  });
+
+  const externalFunctions = ast.body
+    .filter(i => i.type == 'ExportNamedDeclaration')
+    .filter(i => i.specifiers.length > 0)
+    .filter(i => i.source.value == '@openfn/language-common')
+    .map(i =>
+      i.specifiers.map(s => {
+        return s.exported.name;
+      })
+    )
+    .flat()
+    .sort()
+
+  return externalFunctions
+
+}

--- a/tools/build/src/util/hbs-helpers.js
+++ b/tools/build/src/util/hbs-helpers.js
@@ -4,18 +4,6 @@ exports.toLowerCase = function (str) {
   return str ? str.toLowerCase() : str;
 };
 
-// const common = () => {
-//   return options.data.root.filter(function (o) {
-//     console.log(o)
-//     return true;
-//   //   if (identifier.kind === 'external') {
-//   //     return identifier.description && identifier.description.length > 0
-//   //   } else {
-//   //     return true
-//   //   }
-//   // })
-// }
-
 exports.commonFns = function(options) {
   options.hash.scope = 'global'
   const common = () => handlebars.helpers._identifiers(options).filter((o) => {

--- a/tools/build/src/util/hbs-helpers.js
+++ b/tools/build/src/util/hbs-helpers.js
@@ -1,3 +1,27 @@
+const handlebars = require('handlebars');
+
 exports.toLowerCase = function (str) {
   return str ? str.toLowerCase() : str;
+};
+
+// const common = () => {
+//   return options.data.root.filter(function (o) {
+//     console.log(o)
+//     return true;
+//   //   if (identifier.kind === 'external') {
+//   //     return identifier.description && identifier.description.length > 0
+//   //   } else {
+//   //     return true
+//   //   }
+//   // })
+// }
+
+exports.commonFns = function(options) {
+  options.hash.scope = 'global'
+  const common = () => handlebars.helpers._identifiers(options).filter((o) => {
+    return o.common
+  }, options)
+
+  return handlebars.helpers.each(common, options)
+
 };


### PR DESCRIPTION
## Summary

This PR adds a list of common exports to the docs markdown generated by the build.

![image](https://github.com/OpenFn/adaptors/assets/7052509/9cb08ef8-a5cf-4b53-850e-7ba4610fbb94)


## Details

The task here is to get the list of exports from common for each adaptor and add them to the page somewhere.

jsdoc basically can't do it. It seems to have no means to list documentation for export aliases from another module. You can document the export statement and jsdoc will respect it. I considered adding build tooling to generate docs for each export.

But why? The result is a long list of funcitons and when looking at the actual docs, you can't tell the main adaptor functions from the common ones. I mean common mostly introduces a load of noise to the documentation - the most valuable docs are the ones native to this adaptor.

So I took a different approach. 
- Using `acorn`, parse the JS files for the adaptor
- Extract all the exported names from common
- List those exported values as hyperlinks at the top of the docs, but don't add any other documentation.

Now the common functionality is visible, but it's visibly a second-class citizen.

## Issues

Closes https://github.com/OpenFn/docs/issues/440
