### PR TITLE
remove buildtools as dev dependency

### DIFF
--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -34,7 +34,6 @@
     "@openfn/language-common": "^1.12.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/azure-storage/package.json
+++ b/packages/azure-storage/package.json
@@ -31,7 +31,6 @@
     "@azure/storage-blob": "^12.15.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/beyonic/package.json
+++ b/packages/beyonic/package.json
@@ -37,7 +37,6 @@
     "superagent": "^8.0.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -31,7 +31,6 @@
     "xml2js": "0.5.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/cartodb/package.json
+++ b/packages/cartodb/package.json
@@ -33,7 +33,6 @@
     "mocha": "^7.1.1",
     "superagent-mock": "^1.10.0",
     "esno": "^0.16.3",
-    "@openfn/buildtools": "workspace:^1.0.1",
     "@openfn/simple-ast": "0.4.1",
     "rimraf": "^3.0.2"
   },

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -35,7 +35,6 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "^0.4.1",
     "assertion-error": "^1.1.0",
     "chai": "^4.3.7",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -52,7 +52,6 @@
     "undici": "^5.23.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "chai": "4.3.6",
     "deep-eql": "4.1.1",

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -31,7 +31,6 @@
     "nock": "^8.0.0",
     "sinon": "^1.17.2",
     "esno": "^0.16.3",
-    "@openfn/buildtools": "workspace:^1.0.1",
     "@openfn/simple-ast": "0.4.1",
     "rimraf": "^3.0.2"
   },

--- a/packages/facebook/package.json
+++ b/packages/facebook/package.json
@@ -24,7 +24,6 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "chai": "^4.3.7",

--- a/packages/fhir/package.json
+++ b/packages/fhir/package.json
@@ -24,7 +24,6 @@
     "undici": "^5.22.1"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "^0.4.1",
     "assertion-error": "2.0.0",
     "chai": "^4.3.6",

--- a/packages/godata/package.json
+++ b/packages/godata/package.json
@@ -31,7 +31,6 @@
     "nock": "^12.0.3",
     "sinon": "^1.17.2",
     "esno": "^0.16.3",
-    "@openfn/buildtools": "workspace:^1.0.1",
     "@openfn/simple-ast": "0.4.1",
     "rimraf": "^3.0.2"
   },

--- a/packages/googlehealthcare/package.json
+++ b/packages/googlehealthcare/package.json
@@ -30,7 +30,6 @@
     "@openfn/language-common": "^1.12.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -35,7 +35,6 @@
     "googleapis": "100.0.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "1.1.0",
     "chai": "4.3.6",

--- a/packages/hive/package.json
+++ b/packages/hive/package.json
@@ -31,7 +31,6 @@
     "hive-driver": "0.2.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -38,7 +38,6 @@
     "cheerio-tableparser": "^1.0.1"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^",
     "@openfn/simple-ast": "0.4.1",
     "chai": "^4.3.10",
     "deep-eql": "4.1.1",

--- a/packages/khanacademy/package.json
+++ b/packages/khanacademy/package.json
@@ -25,7 +25,6 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "chai": "^4.3.7",

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -28,7 +28,6 @@
     "@openfn/language-common": "workspace:^1.12.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "assertion-error": "^1.0.1",
     "chai": "^3.4.0",
     "deep-eql": "^0.1.3",

--- a/packages/magpi/package.json
+++ b/packages/magpi/package.json
@@ -29,7 +29,6 @@
     "xml2js": "0.5.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "chai": "^4.3.7",

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -27,7 +27,6 @@
     "undici": "^5.22.1"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^1.1.0",
     "chai": "^4.3.6",

--- a/packages/mailgun/package.json
+++ b/packages/mailgun/package.json
@@ -26,7 +26,6 @@
     "sync-request": "^6.0.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.1",
     "@openfn/simple-ast": "^0.3.2",
     "assertion-error": "^1.0.1",
     "chai": "^3.4.0",

--- a/packages/maximo/package.json
+++ b/packages/maximo/package.json
@@ -26,7 +26,6 @@
     "utf8": "^2.1.2"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "babel-cli": "^6.26.0",

--- a/packages/medicmobile/package.json
+++ b/packages/medicmobile/package.json
@@ -26,7 +26,6 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "chai": "^4.3.7",

--- a/packages/mogli/package.json
+++ b/packages/mogli/package.json
@@ -29,7 +29,6 @@
     "yargs": "^3.32.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "chai": "^4.3.7",

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -24,7 +24,6 @@
     "mongodb": "^3.7.3"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^1.1.0",
     "chai": "^3.5.0",

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -32,7 +32,6 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -35,7 +35,6 @@
     "tedious": "15.1.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -40,7 +40,6 @@
     "nock": "^12.0.3",
     "sinon": "^1.17.2",
     "esno": "^0.16.3",
-    "@openfn/buildtools": "workspace:^1.0.1",
     "rimraf": "^3.0.2"
   },
   "type": "module",

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -24,7 +24,6 @@
     "nexmo": "2.9.1"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "chai": "^4.3.7",

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -23,7 +23,6 @@
     "@openfn/language-common": "1.12.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "^0.4.1",
     "assertion-error": "^1.0.1",
     "chai": "^4.3.6",

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -37,7 +37,6 @@
     "nock": "^12.0.3",
     "sinon": "^1.17.2",
     "esno": "^0.16.3",
-    "@openfn/buildtools": "workspace:^1.0.1",
     "rimraf": "^3.0.2"
   },
   "type": "module",

--- a/packages/openhim/package.json
+++ b/packages/openhim/package.json
@@ -37,7 +37,6 @@
     "sinon": "^1.17.2",
     "superagent-mock": "^1.10.0",
     "esno": "^0.16.3",
-    "@openfn/buildtools": "workspace:^1.0.1",
     "@openfn/simple-ast": "0.4.1",
     "rimraf": "^3.0.2"
   },

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -29,7 +29,6 @@
     "superagent": "^8.0.9"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.1",
     "@openfn/simple-ast": "^0.4.1",
     "assertion-error": "^1.0.1",
     "chai": "^3.4.0",

--- a/packages/openspp/package.json
+++ b/packages/openspp/package.json
@@ -31,7 +31,6 @@
     "odoo-await": "^3.4.1"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -36,7 +36,6 @@
     "pg-format": "^1.0.4"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -38,7 +38,6 @@
     "request": "^2.72.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/progres/package.json
+++ b/packages/progres/package.json
@@ -37,7 +37,6 @@
     "sinon": "^9.2.3",
     "esno": "^0.16.3",
     "rimraf": "^3.0.2",
-    "@openfn/buildtools": "workspace:^1.0.1",
     "@openfn/simple-ast": "0.4.1"
   },
   "type": "module",

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -31,7 +31,6 @@
     "nock": "^12.0.3",
     "sinon": "^1.17.2",
     "esno": "^0.16.3",
-    "@openfn/buildtools": "workspace:^1.0.1",
     "rimraf": "^3.0.2"
   },
   "repository": {

--- a/packages/resourcemap/package.json
+++ b/packages/resourcemap/package.json
@@ -24,7 +24,6 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "chai": "^4.3.7",

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -37,7 +37,6 @@
     "ssh2-sftp-client": "9.0.4"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "2.0.0",
     "chai": "4.3.6",

--- a/packages/smpp/package.json
+++ b/packages/smpp/package.json
@@ -24,7 +24,6 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^1.1.0",
     "chai": "^4.3.7",

--- a/packages/surveycto/package.json
+++ b/packages/surveycto/package.json
@@ -24,7 +24,6 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "chai": "^4.3.7",

--- a/packages/telerivet/package.json
+++ b/packages/telerivet/package.json
@@ -26,7 +26,6 @@
     "superagent": "^3.7.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^1.1.0",
     "chai": "^3.5.0",

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -24,7 +24,6 @@
     "twilio": "^3.83.2"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "^0.4.1",
     "assertion-error": "^1.1.0",
     "chai": "^3.5.0",

--- a/packages/vtiger/package.json
+++ b/packages/vtiger/package.json
@@ -26,7 +26,6 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^2.0.0",
     "chai": "^4.3.7",

--- a/packages/zoho/package.json
+++ b/packages/zoho/package.json
@@ -26,7 +26,6 @@
     "superagent": "^3.7.0"
   },
   "devDependencies": {
-    "@openfn/buildtools": "workspace:^1.0.2",
     "@openfn/simple-ast": "0.4.1",
     "assertion-error": "^1.1.0",
     "chai": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
         specifier: ^1.12.0
         version: link:../common
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -70,9 +67,6 @@ importers:
         specifier: ^1.12.0
         version: link:../common
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -113,9 +107,6 @@ importers:
         specifier: ^8.0.0
         version: 8.0.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -168,9 +159,6 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -217,9 +205,6 @@ importers:
         specifier: ^3.7.0
         version: 3.8.3
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -272,9 +257,6 @@ importers:
         specifier: https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz
         version: '@cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz'
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: ^0.4.1
         version: 0.4.1
@@ -333,9 +315,6 @@ importers:
         specifier: ^5.23.0
         version: 5.23.0
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -410,9 +389,6 @@ importers:
         specifier: ^2.72.0
         version: 2.88.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -450,9 +426,6 @@ importers:
         specifier: ^2.88.2
         version: 2.88.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -490,9 +463,6 @@ importers:
         specifier: ^5.22.1
         version: 5.22.1
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: ^0.4.1
         version: 0.4.1
@@ -524,9 +494,6 @@ importers:
         specifier: ^0.21.2
         version: 0.21.4
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -561,9 +528,6 @@ importers:
         specifier: ^1.12.0
         version: link:../common
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -598,9 +562,6 @@ importers:
         specifier: 100.0.0
         version: 100.0.0
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -635,9 +596,6 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -672,9 +630,6 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -709,9 +664,6 @@ importers:
         specifier: ^2.88.2
         version: 2.88.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -743,9 +695,6 @@ importers:
         specifier: workspace:^1.12.0
         version: link:../common
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -795,9 +744,6 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -841,9 +787,6 @@ importers:
         specifier: ^5.22.1
         version: 5.22.1
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -881,9 +824,6 @@ importers:
         specifier: ^6.0.0
         version: 6.1.0
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: ^0.3.2
         version: 0.3.2
@@ -927,9 +867,6 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -982,9 +919,6 @@ importers:
         specifier: ^2.88.2
         version: 2.88.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1034,9 +968,6 @@ importers:
         specifier: ^3.32.0
         version: 3.32.0
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1074,9 +1005,6 @@ importers:
         specifier: ^3.7.3
         version: 3.7.3
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1114,9 +1042,6 @@ importers:
         specifier: https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz
         version: '@cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz'
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1148,9 +1073,6 @@ importers:
         specifier: 15.1.0
         version: 15.1.0
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1191,9 +1113,6 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: ^0.4.1
         version: 0.4.1
@@ -1231,9 +1150,6 @@ importers:
         specifier: 2.9.1
         version: 2.9.1
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1265,9 +1181,6 @@ importers:
         specifier: 1.12.0
         version: link:../common
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: ^0.4.1
         version: 0.4.1
@@ -1302,9 +1215,6 @@ importers:
         specifier: ^0.21.1
         version: 0.21.4
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: ^0.4.1
         version: 0.4.1
@@ -1348,9 +1258,6 @@ importers:
         specifier: ^3.7.0
         version: 3.8.3
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1400,9 +1307,6 @@ importers:
         specifier: ^8.0.9
         version: 8.0.9
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: ^0.4.1
         version: 0.4.1
@@ -1440,9 +1344,6 @@ importers:
         specifier: ^3.4.1
         version: 3.4.1
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1480,9 +1381,6 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1526,9 +1424,6 @@ importers:
         specifier: ^2.72.0
         version: 2.88.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1575,9 +1470,6 @@ importers:
         specifier: ^0.21.2
         version: 0.21.4
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1615,9 +1507,6 @@ importers:
         specifier: ^0.21.2
         version: 0.21.4
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.1
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: ^0.3.0
         version: 0.3.2
@@ -1652,9 +1541,6 @@ importers:
         specifier: ^2.88.2
         version: 2.88.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1741,9 +1627,6 @@ importers:
         specifier: 9.0.4
         version: 9.0.4
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1787,9 +1670,6 @@ importers:
         specifier: ^2.88.2
         version: 2.88.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1824,9 +1704,6 @@ importers:
         specifier: ^2.88.2
         version: 2.88.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1867,9 +1744,6 @@ importers:
         specifier: ^3.7.0
         version: 3.8.3
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1904,9 +1778,6 @@ importers:
         specifier: ^3.83.2
         version: 3.83.3
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: ^0.4.1
         version: 0.4.1
@@ -1947,9 +1818,6 @@ importers:
         specifier: ^2.88.2
         version: 2.88.2
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1
@@ -1993,9 +1861,6 @@ importers:
         specifier: ^3.7.0
         version: 3.8.3
     devDependencies:
-      '@openfn/buildtools':
-        specifier: workspace:^1.0.2
-        version: link:../../tools/build
       '@openfn/simple-ast':
         specifier: 0.4.1
         version: 0.4.1


### PR DESCRIPTION
Remove buildtools as a dev dependency, which is breaking changesets

I am not registering a changeset for this because it's a pointless patch with no end-user benefit

Closes #498 