### PR TITLE
Release cursor

### DIFF
--- a/.changeset/odd-apples-wait.md
+++ b/.changeset/odd-apples-wait.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': minor
+---
+
+Added cursor() helper

--- a/.changeset/odd-apples-wait.md
+++ b/.changeset/odd-apples-wait.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-common': minor
----
-
-Added cursor() helper

--- a/.changeset/rude-pianos-play.md
+++ b/.changeset/rude-pianos-play.md
@@ -1,9 +1,0 @@
----
-'@openfn/language-asana': minor
-'@openfn/language-googlesheets': minor
-'@openfn/language-kobotoolbox': minor
-'@openfn/language-msgraph': minor
----
-
-Add the cursor() function from common. See the job writing guide for more
-information.

--- a/.changeset/rude-pianos-play.md
+++ b/.changeset/rude-pianos-play.md
@@ -1,0 +1,9 @@
+---
+'@openfn/language-asana': minor
+'@openfn/language-googlesheets': minor
+'@openfn/language-kobotoolbox': minor
+'@openfn/language-msgraph': minor
+---
+
+Add the cursor() function from common. See the job writing guide for more
+information.

--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @openfn/language-asana
 
+## 3.2.0
+
+### Minor Changes
+
+- bae5d3b6: Add the cursor() function from common. See the job writing guide for
+  more information.
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/asana/ast.json
+++ b/packages/asana/ast.json
@@ -724,6 +724,83 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "cursor",
+      "params": [
+        "value",
+        "options"
+      ],
+      "docs": {
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "cursor($.cursor, { defaultValue: 'today' })",
+            "caption": "Use a cursor from state if present, or else use the default value"
+          },
+          {
+            "title": "example",
+            "description": "cursor(22)",
+            "caption": "Use a pagination cursor"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "the cursor value. Usually an ISO date, natural language date, or page number",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "value"
+          },
+          {
+            "title": "param",
+            "description": "options to control the cursor.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "options"
+          },
+          {
+            "title": "param",
+            "description": "set the cursor key. Will persist through the whole run.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "options.key"
+          },
+          {
+            "title": "param",
+            "description": "the value to use if value is falsy",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "options.defaultValue"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
     }
   ]
 }

--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-asana",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "An adaptor to access objects in Asana",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "^1.12.0"
+    "@openfn/language-common": "^1.13.0"
   },
   "devDependencies": {
     "@openfn/simple-ast": "0.4.1",

--- a/packages/asana/src/Adaptor.js
+++ b/packages/asana/src/Adaptor.js
@@ -291,6 +291,7 @@ export function request(path, params, callback) {
 
 export {
   alterState,
+  cursor,
   dataPath,
   dataValue,
   dateFns,

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-bigquery
 
+## 2.0.5
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 2.0.4
 
 ### Patch Changes

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-bigquery",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A Google BigQuery language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@google-cloud/bigquery": "^5.12.0",
-    "@openfn/language-common": "workspace:1.12.0",
+    "@openfn/language-common": "workspace:1.13.0",
     "csv-parse": "^4.16.3",
     "import": "0.0.6",
     "json2csv": "^5.0.7",

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-commcare
 
+## 1.6.11
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 1.6.10
 
 ### Patch Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-commcare",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "Commcare Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:1.12.0",
+    "@openfn/language-common": "workspace:1.13.0",
     "@openfn/language-http": "workspace:^6.0.0",
     "JSONPath": "^0.10.0",
     "form-data": "^4.0.0",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 v0.4.0
 
+## 1.13.0
+
+### Minor Changes
+
+- 1ad86651: Added cursor() helper
+
 ## 1.12.0
 
 ### Minor Changes

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1313,6 +1313,83 @@
       "valid": true
     },
     {
+      "name": "cursor",
+      "params": [
+        "value",
+        "options"
+      ],
+      "docs": {
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "cursor($.cursor, { defaultValue: 'today' })",
+            "caption": "Use a cursor from state if present, or else use the default value"
+          },
+          {
+            "title": "example",
+            "description": "cursor(22)",
+            "caption": "Use a pagination cursor"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "the cursor value. Usually an ISO date, natural language date, or page number",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "value"
+          },
+          {
+            "title": "param",
+            "description": "options to control the cursor.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "options"
+          },
+          {
+            "title": "param",
+            "description": "set the cursor key. Will persist through the whole run.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "options.key"
+          },
+          {
+            "title": "param",
+            "description": "the value to use if value is falsy",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "options.defaultValue"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
+    },
+    {
       "name": "map",
       "params": [
         "path",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-common",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Common Expressions for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -827,7 +827,7 @@ export function cursor(value, options = {}) {
       }
     }
     state[cursorKey] = cursor;
-    console.log(`Setting cursor to ${cursor}`);
+    console.log('Setting cursor to:', cursor);
 
     return state;
   }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -778,26 +778,19 @@ export function validate(schema = 'schema', data = 'data') {
   };
 }
 
-// Note that we don't write cursorStart to state,
-// because it should not affect the next job
-
 let cursorStart = undefined;
 let cursorKey = 'cursor';
 
-// TODO timezones
-// All times should use UTC internally. But you can have strings parsed in a different time zone
-// Also,when we log a cursor time, we should log it in the timezone provided
 /**
- * Sets a cursor value on state (writes to `state.cursor`, or whatever value you set on options.key).
- * The first time this is called, a `cursorStart` key will be set on state,
- * which you can use to set the final state.cursor ready for the next run with `cursor('start')`
+ * Sets a cursor property on state.
  * Supports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,
  * which will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones 
  * are not yet supported.
+ * See the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}
  * @public
- * @example <caption>use a cursor from state if present, or else use the default value</caption>
+ * @example <caption>Use a cursor from state if present, or else use the default value</caption>
  * cursor($.cursor, { defaultValue: 'today' })
- * @example <caption>cursor for pagination</caption>
+ * @example <caption>Use a pagination cursor</caption>
  * cursor(22)
  * @function
  * @param {any} value - the cursor value. Usually an ISO date, natural language date, or page number

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -813,17 +813,18 @@ export function cursor(value, options = {}) {
     }
 
     if (!cursorStart) {
-      cursorStart = new Date().toISOString()
+      cursorStart = new Date().toISOString();
     }
 
     const cursor = resolvedValue ?? defaultValue;
 
     if (typeof cursor === 'string') {
-      state[cursorKey] = parseDate(cursor, cursorStart)
-      console.log(`Setting cursor "${cursor}" to ${new Date(state.cursor).toLocaleString()}`)
+      state[cursorKey] = parseDate(cursor, cursorStart);
+      const humanLocaleDate = state[cursorKey].toLocaleString(undefined, { timeZoneName: 'short' });
+      console.log(`Setting cursor "${cursor}" to ${humanLocaleDate}`);
     } else {
       state[cursorKey] = cursor;
-      console.log(`Setting cursor to ${cursor}`)
+      console.log(`Setting cursor to ${cursor}`);
     }
 
     return state;

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -813,19 +813,21 @@ export function cursor(value, options = {}) {
     }
 
     if (!cursorStart) {
-      cursorStart = new Date().toISOString();
+      cursorStart = new Date();
     }
 
     const cursor = resolvedValue ?? defaultValue;
-
     if (typeof cursor === 'string') {
-      state[cursorKey] = parseDate(cursor, cursorStart);
-      const humanLocaleDate = state[cursorKey].toLocaleString(undefined, { timeZoneName: 'short' });
-      console.log(`Setting cursor "${cursor}" to ${humanLocaleDate}`);
-    } else {
-      state[cursorKey] = cursor;
-      console.log(`Setting cursor to ${cursor}`);
+      const date = parseDate(cursor, cursorStart)
+      if (date instanceof Date && date.toString !== "Invalid Date") {
+        state[cursorKey] = date.toISOString();
+        const humanLocaleDate = date.toLocaleString(undefined, { timeZoneName: 'short' });
+        console.log(`Setting cursor "${cursor}" to: ${humanLocaleDate}`);
+        return state;
+      }
     }
+    state[cursorKey] = cursor;
+    console.log(`Setting cursor to ${cursor}`);
 
     return state;
   }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -801,7 +801,7 @@ let cursorStart = undefined;
  * @param {any} options - options to control the cursor. Options will persist after the first call.
  * @returns {Operation}
  */
-export function cursor(value, options) {
+export function cursor(value, options = {}) {
   return (state) => {
     const [resolvedValue] = newExpandReferences(state, value);
 
@@ -813,15 +813,14 @@ export function cursor(value, options) {
     } = options;
 
     if (!cursorStart) {
-      cursorStart = converter(new Date().toISOString())
+      cursorStart = new Date().toISOString()
     }
 
     const cursor = resolvedValue ?? defaultValue;
 
     if (typeof cursor === 'string') {
       state[key] = parseDate(cursor, cursorStart)
-      // TODO we should format the output more nicely
-      console.log(`Setting cursor "${cursor}" to ${new Date(state.cursor).toUTCString()}`)
+      console.log(`Setting cursor "${cursor}" to ${new Date(state.cursor).toLocaleString()}`)
     } else {
       state[key] = cursor;
       console.log(`Setting cursor to ${cursor}`)

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -782,6 +782,7 @@ export function validate(schema = 'schema', data = 'data') {
 // because it should not affect the next job
 
 let cursorStart = undefined;
+let cursorKey = 'cursor';
 
 // TODO timezones
 // All times should use UTC internally. But you can have strings parsed in a different time zone
@@ -798,7 +799,9 @@ let cursorStart = undefined;
  * cursor(22)
  * @function
  * @param {any} value - the cursor value. Usually an ISO date, natural language date, or page number
- * @param {any} options - options to control the cursor. Options will persist after the first call.
+ * @param {object} options - options to control the cursor.
+ * @param {string} options.key - set the cursor key. Will persist through the whole run.
+ * @param {any} options.defaultValue - the value to use if value is falsy
  * @returns {Operation}
  */
 export function cursor(value, options = {}) {
@@ -807,10 +810,12 @@ export function cursor(value, options = {}) {
 
     const {
       defaultValue, // if there is no cursor on state, this will be used
-      key = 'cursor', // the key to use on state. idk why you want to change this, but sure
-      
-      // timezone, // time zone as in UTC, GMT, PST? Or locale?
+      key, // the key to use on state
     } = options;
+
+    if (key) {
+      cursorKey = key;
+    }
 
     if (!cursorStart) {
       cursorStart = new Date().toISOString()
@@ -819,10 +824,10 @@ export function cursor(value, options = {}) {
     const cursor = resolvedValue ?? defaultValue;
 
     if (typeof cursor === 'string') {
-      state[key] = parseDate(cursor, cursorStart)
+      state[cursorKey] = parseDate(cursor, cursorStart)
       console.log(`Setting cursor "${cursor}" to ${new Date(state.cursor).toLocaleString()}`)
     } else {
-      state[key] = cursor;
+      state[cursorKey] = cursor;
       console.log(`Setting cursor to ${cursor}`)
     }
 

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -801,12 +801,12 @@ let cursorKey = 'cursor';
  */
 export function cursor(value, options = {}) {
   return (state) => {
-    const [resolvedValue] = newExpandReferences(state, value);
+    const [resolvedValue, resolvedOptions] = newExpandReferences(state, value, options);
 
     const {
       defaultValue, // if there is no cursor on state, this will be used
       key, // the key to use on state
-    } = options;
+    } = resolvedOptions;
 
     if (key) {
       cursorKey = key;

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -792,7 +792,7 @@ let cursorKey = 'cursor';
  * The first time this is called, a `cursorStart` key will be set on state,
  * which you can use to set the final state.cursor ready for the next run with `cursor('start')`
  * Supports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,
- * which will be converted into a UTC time relative to the current UTC time. Relative timezones 
+ * which will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones 
  * are not yet supported.
  * @public
  * @example <caption>use a cursor from state if present, or else use the default value</caption>

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -791,7 +791,9 @@ let cursorKey = 'cursor';
  * Sets a cursor value on state (writes to `state.cursor`, or whatever value you set on options.key).
  * The first time this is called, a `cursorStart` key will be set on state,
  * which you can use to set the final state.cursor ready for the next run with `cursor('start')`
- * Supports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`
+ * Supports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,
+ * which will be converted into a UTC time relative to the current UTC time. Relative timezones 
+ * are not yet supported.
  * @public
  * @example <caption>use a cursor from state if present, or else use the default value</caption>
  * cursor($.cursor, { defaultValue: 'today' })

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -803,6 +803,7 @@ let cursorStart = undefined;
  */
 export function cursor(value, options) {
   return (state) => {
+    const [resolvedValue] = newExpandReferences(state, value);
 
     const {
       defaultValue, // if there is no cursor on state, this will be used
@@ -815,7 +816,7 @@ export function cursor(value, options) {
       cursorStart = converter(new Date().toISOString())
     }
 
-    const cursor = value ?? defaultValue;
+    const cursor = resolvedValue ?? defaultValue;
 
     if (typeof cursor === 'string') {
       state[key] = parseDate(cursor, cursorStart)

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -6,6 +6,7 @@ import { parse } from 'csv-parse';
 import { Readable } from 'node:stream';
 
 import { request } from 'undici';
+import { format } from 'date-fns';
 
 import { expandReferences as newExpandReferences, parseDate } from './util';
 
@@ -821,8 +822,10 @@ export function cursor(value, options = {}) {
       const date = parseDate(cursor, cursorStart)
       if (date instanceof Date && date.toString !== "Invalid Date") {
         state[cursorKey] = date.toISOString();
-        const humanLocaleDate = date.toLocaleString(undefined, { timeZoneName: 'short' });
-        console.log(`Setting cursor "${cursor}" to: ${humanLocaleDate}`);
+        // Log the converted date in a very international, human-friendly format
+        // See https://date-fns.org/v3.6.0/docs/format
+        const formatted = format(date, 'HH:MM d MMM yyyy (OOO)')
+        console.log(`Setting cursor "${cursor}" to: ${formatted}`);
         return state;
       }
     }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -781,7 +781,7 @@ export function validate(schema = 'schema', data = 'data') {
 // Note that we don't write cursorStart to state,
 // because it should not affect the next job
 
-let cursorStart;
+let cursorStart = undefined;
 
 /**
  * Sets a cursor value on state (writes to `state.cursor`).

--- a/packages/common/src/http.deprecated.js
+++ b/packages/common/src/http.deprecated.js
@@ -17,7 +17,7 @@ export { axios };
 const printDeprecationNotice = name => {
   if (process.env.NODE_ENV !== 'production') {
     console.warn(
-      `The common.http.¬${name} function has been deprecated. This adaptor should migrate to use common.util.http instead.`
+      `The common.http.${name} function has been deprecated. This adaptor should migrate to use common.util.http instead.`
     );
   }
 };

--- a/packages/common/src/util/index.js
+++ b/packages/common/src/util/index.js
@@ -1,2 +1,5 @@
 export * from './http';
 export * from './references';
+import parseDate from './parse-date';
+
+export  { parseDate }

--- a/packages/common/src/util/parse-date.js
+++ b/packages/common/src/util/parse-date.js
@@ -1,0 +1,34 @@
+import { startOfToday, startOfYesterday, subHours, subDays } from 'date-fns'
+
+// Helper function to parse a natural-langauge date string into an ISO date
+export default (d, startDate) => {
+  try {
+    if (d === 'start') {
+      return startDate;
+    } else if (d === 'now' || d === 'end') {
+      return new Date().toISOString()
+    }
+    else if (d === 'today') {
+      return startOfToday().toISOString()
+    }
+    else if (d === 'yesterday') {
+      return startOfYesterday().toISOString()
+    }
+    else if (/(hours? ago)$/.test(d)) {
+      // return the same minute n hours ago
+      const [diff] = d.match(/\d+/)
+      return subHours(new Date(), diff).toISOString()
+    }
+    else if (/(days? ago)$/.test(d)) {
+      // return the start of today - n days
+      const [diff] = d.match(/\d+/)
+      return startOfToday(subDays(new Date(), diff)).toISOString()
+    }
+  } catch(e) {
+    console.log(`Error converting ${d} into a date`)
+    console.log(e)
+  }
+
+  // Just return the value if we couldn't parse it
+  return d;
+}

--- a/packages/common/src/util/parse-date.js
+++ b/packages/common/src/util/parse-date.js
@@ -1,6 +1,6 @@
 import { startOfToday, startOfYesterday, subHours, subDays } from 'date-fns'
 
-// Helper function to parse a natural-langauge date string into an ISO date
+// Helper function to parse a natural-language date string into an ISO date
 export default (d, startDate) => {
   try {
     if (d === 'start') {

--- a/packages/common/src/util/parse-date.js
+++ b/packages/common/src/util/parse-date.js
@@ -1,4 +1,4 @@
-import { startOfToday, startOfYesterday, subHours, subDays } from 'date-fns'
+import { startOfToday, startOfYesterday, subHours, subDays, startOfDay } from 'date-fns'
 
 // Helper function to parse a natural-language date string into an ISO date
 export default (d, startDate) => {
@@ -22,7 +22,7 @@ export default (d, startDate) => {
     else if (/(days? ago)$/.test(d)) {
       // return the start of today - n days
       const [diff] = d.match(/\d+/)
-      return startOfToday(subDays(new Date(), diff))
+      return startOfDay(subDays(new Date(), diff))
     }
   } catch(e) {
     console.log(`Error converting ${d} into a date`)

--- a/packages/common/src/util/parse-date.js
+++ b/packages/common/src/util/parse-date.js
@@ -6,23 +6,23 @@ export default (d, startDate) => {
     if (d === 'start') {
       return startDate;
     } else if (d === 'now' || d === 'end') {
-      return new Date().toISOString()
+      return new Date()
     }
     else if (d === 'today') {
-      return startOfToday().toISOString()
+      return startOfToday()
     }
     else if (d === 'yesterday') {
-      return startOfYesterday().toISOString()
+      return startOfYesterday()
     }
     else if (/(hours? ago)$/.test(d)) {
       // return the same minute n hours ago
       const [diff] = d.match(/\d+/)
-      return subHours(new Date(), diff).toISOString()
+      return subHours(new Date(), diff)
     }
     else if (/(days? ago)$/.test(d)) {
       // return the start of today - n days
       const [diff] = d.match(/\d+/)
-      return startOfToday(subDays(new Date(), diff)).toISOString()
+      return startOfToday(subDays(new Date(), diff))
     }
   } catch(e) {
     console.log(`Error converting ${d} into a date`)

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -886,4 +886,33 @@ describe('cursor', () => {
     const result = cursor('today')(state)
     expect(result.cursor).to.eql(date);
   });
+
+  it('should clear the cursor', () => {
+    const state = {
+      cursor: new Date()
+    }
+    const result = cursor()(state)
+    expect(result.cursor).to.eql(undefined)
+  });
+
+  it('should use a default value', () => {
+    const state = {}
+    const result = cursor(state.cursor, { defaultValue: 33 })(state)
+    expect(result.cursor).to.eql(33)
+  });
+
+  it('should use a custom key', () => {
+    const state = {}
+    const result = cursor(44, { key: 'page' })(state)
+    expect(result.page).to.eql(44)
+  });
+
+  it('should re-use a custom key', () => {
+    const state = {}
+    const result1 = cursor(44, { key: 'page' })(state)
+    expect(result1.page).to.eql(44)
+
+    const result2 = cursor(55)(state)
+    expect(result2.page).to.eql(55)
+  });
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -887,6 +887,14 @@ describe('cursor', () => {
     expect(result.cursor).to.eql(date);
   });
 
+  it('should not blow up if an arbitrary string is passed', () => {
+    const state = {}
+
+    const str = 'rock the cashbah'
+    const result = cursor(str)(state)
+    expect(result.cursor).to.eql(str);
+  });
+
   it('should clear the cursor', () => {
     const state = {
       cursor: new Date()

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -7,6 +7,7 @@ import {
   arrayToString,
   chunk,
   combine,
+  cursor,
   dataPath,
   dataValue,
   each,
@@ -29,6 +30,7 @@ import {
   toArray,
   validate,
 } from '../src/Adaptor';
+import { startOfToday } from 'date-fns';
 
 const mockAgent = new MockAgent();
 setGlobalDispatcher(mockAgent);
@@ -859,5 +861,29 @@ describe('validate', () => {
     const result = await validate()(state);
 
     expect(result.validationErrors).to.eql([]);
+  });
+});
+
+describe('cursor', () => {
+  it('should set a cursor on state', () => {
+    const state = {}
+    const result = cursor(1234)(state)
+    expect(result.cursor).to.eql(1234);
+  });
+
+  it('should set a cursorStart on state', () => {
+    const state = {}
+    const date = new Date();
+    const result = cursor('start')(state)
+    const resultDate = new Date(result.cursor)
+    expect(resultDate.toDateString()).to.eql(date.toDateString())
+  });
+
+  it('should set a cursor on state with a natural language timestamp', () => {
+    const state = {}
+
+    const date = startOfToday().toISOString()
+    const result = cursor('today')(state)
+    expect(result.cursor).to.eql(date);
   });
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -864,7 +864,7 @@ describe('validate', () => {
   });
 });
 
-describe('cursor', () => {
+describe.only('cursor', () => {
   it('should set a cursor on state', () => {
     const state = {}
     const result = cursor(1234)(state)
@@ -923,4 +923,13 @@ describe('cursor', () => {
     const result2 = cursor(55)(state)
     expect(result2.page).to.eql(55)
   });
+
+  // testing the log output is hard here, I've only verified it manally
+  it('should use an object', () => {
+    const state = {}
+    const c = { page: 22, next: 23 }
+    const result = cursor(c, { key: 'cursor' })(state)
+    expect(result.cursor).to.eql(c)
+  });
+
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -864,7 +864,7 @@ describe('validate', () => {
   });
 });
 
-describe.only('cursor', () => {
+describe('cursor', () => {
   it('should set a cursor on state', () => {
     const state = {}
     const result = cursor(1234)(state)

--- a/packages/common/test/util/parse-date.test.js
+++ b/packages/common/test/util/parse-date.test.js
@@ -12,7 +12,7 @@ const approxEqual = (a, b) => {
   expect(a_ms).eql(b_ms)
 }
 
-describe('parse date', () => {
+describe.only('parse date', () => {
 
   it('should return now', () => {
     const today = new Date().toISOString()
@@ -77,11 +77,19 @@ describe('parse date', () => {
     approxEqual(result, target)
   })
 
+  it('should return 2 days ago', () => {
+    const target = startOfDay(subDays(new Date(), 2)).toLocaleString()
+    console.log(target)
+    const result = parseDate('2 days ago').toLocaleString()
+    console.log(result)
+    expect(result).eql(target)
+  })
+
   it('should return 9999 days ago', () => {
-    const target = subDays(new Date(), 9999).toISOString()
+    const target = startOfDay(subDays(new Date(), 9999)).toISOString()
     
     const result = parseDate('9999 days ago').toISOString()
-    approxEqual(result, target)
+    expect(result).eql(target)
   })
 
   it('should return start', () => {

--- a/packages/common/test/util/parse-date.test.js
+++ b/packages/common/test/util/parse-date.test.js
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import parseDate from '../../src/util/parse-date';
+import { startOfDay, subDays, subHours } from 'date-fns';
+
+// Check if two date are the same to ms resolution
+// Ie, cut off the nanoseconds of the date
+// there is a vanishingly small chance that dates could be 1ns apart
+// but cross an ms line - there's only so much we can do about this
+const approxEqual = (a, b) => {
+  const a_ms = a.substring(0, a.length - 5)
+  const b_ms = a.substring(0, a.length - 5)
+  expect(a_ms).eql(b_ms)
+}
+
+describe('parse date', () => {
+
+  it('should return now', () => {
+    const today = new Date().toISOString()
+    
+    const result = parseDate('now')
+    approxEqual(result, today)
+  })
+
+  it('should return start of today', () => {
+    const today = startOfDay(new Date()).toISOString()
+    
+    const result = parseDate('today')
+    expect(result).eql(today)
+  })
+
+  it('should return start of yesterday', () => {
+    const yesterday = startOfDay(subDays(new Date(), 1)).toISOString()
+    
+    const result = parseDate('yesterday')
+    expect(result).eql(yesterday)
+  })
+
+  it('should return 1 hour ago', () => {
+    const target = subHours(new Date(), 1).toISOString()
+    
+    const result = parseDate('1 hour ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 1 hours ago', () => {
+    const target = subHours(new Date(), 1).toISOString()
+    
+    const result = parseDate('1 hours ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 0001 hours ago', () => {
+    const target = subHours(new Date(), 1).toISOString()
+    
+    const result = parseDate('0001 hours ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 333 hours ago', () => {
+    const target = subHours(new Date(), 333).toISOString()
+    
+    const result = parseDate('333 hours ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 1 day ago', () => {
+    const target = subDays(new Date(), 1).toISOString()
+    
+    const result = parseDate('1 day ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 1 days ago', () => {
+    const target = subDays(new Date(), 1).toISOString()
+    
+    const result = parseDate('1 days ago')
+    approxEqual(result, target)
+  })
+
+  it('should return 9999 days ago', () => {
+    const target = subDays(new Date(), 9999).toISOString()
+    
+    const result = parseDate('9999 days ago')
+    approxEqual(result, target)
+  })
+
+  it('should return start', () => {
+    const start = subHours(new Date(), 1).toISOString()
+    
+    const result = parseDate('start', start)
+    expect(result).eql(start)
+  })
+
+  it('should return a date', () => {
+    const date = subHours(new Date(), 3).toISOString()
+    
+    const result = parseDate(date)
+    expect(result).eql(date)
+  });
+})

--- a/packages/common/test/util/parse-date.test.js
+++ b/packages/common/test/util/parse-date.test.js
@@ -17,70 +17,70 @@ describe('parse date', () => {
   it('should return now', () => {
     const today = new Date().toISOString()
     
-    const result = parseDate('now')
+    const result = parseDate('now').toISOString()
     approxEqual(result, today)
   })
 
   it('should return start of today', () => {
     const today = startOfDay(new Date()).toISOString()
     
-    const result = parseDate('today')
+    const result = parseDate('today').toISOString()
     expect(result).eql(today)
   })
 
   it('should return start of yesterday', () => {
     const yesterday = startOfDay(subDays(new Date(), 1)).toISOString()
     
-    const result = parseDate('yesterday')
+    const result = parseDate('yesterday').toISOString()
     expect(result).eql(yesterday)
   })
 
   it('should return 1 hour ago', () => {
     const target = subHours(new Date(), 1).toISOString()
     
-    const result = parseDate('1 hour ago')
+    const result = parseDate('1 hour ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 1 hours ago', () => {
     const target = subHours(new Date(), 1).toISOString()
     
-    const result = parseDate('1 hours ago')
+    const result = parseDate('1 hours ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 0001 hours ago', () => {
     const target = subHours(new Date(), 1).toISOString()
     
-    const result = parseDate('0001 hours ago')
+    const result = parseDate('0001 hours ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 333 hours ago', () => {
     const target = subHours(new Date(), 333).toISOString()
     
-    const result = parseDate('333 hours ago')
+    const result = parseDate('333 hours ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 1 day ago', () => {
     const target = subDays(new Date(), 1).toISOString()
     
-    const result = parseDate('1 day ago')
+    const result = parseDate('1 day ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 1 days ago', () => {
     const target = subDays(new Date(), 1).toISOString()
     
-    const result = parseDate('1 days ago')
+    const result = parseDate('1 days ago').toISOString()
     approxEqual(result, target)
   })
 
   it('should return 9999 days ago', () => {
     const target = subDays(new Date(), 9999).toISOString()
     
-    const result = parseDate('9999 days ago')
+    const result = parseDate('9999 days ago').toISOString()
     approxEqual(result, target)
   })
 

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dynamics
 
+## 0.4.9
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 0.4.8
 
 ### Patch Changes

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dynamics",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "A Microsoft Dynamics Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0",
+    "@openfn/language-common": "1.13.0",
     "request": "^2.72.0"
   },
   "devDependencies": {

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @openfn/language-googlesheets
 
+## 2.4.0
+
+### Minor Changes
+
+- bae5d3b6: Add the cursor() function from common. See the job writing guide for
+  more information.
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/googlesheets/ast.json
+++ b/packages/googlesheets/ast.json
@@ -614,6 +614,83 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "cursor",
+      "params": [
+        "value",
+        "options"
+      ],
+      "docs": {
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "cursor($.cursor, { defaultValue: 'today' })",
+            "caption": "Use a cursor from state if present, or else use the default value"
+          },
+          {
+            "title": "example",
+            "description": "cursor(22)",
+            "caption": "Use a pagination cursor"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "the cursor value. Usually an ISO date, natural language date, or page number",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "value"
+          },
+          {
+            "title": "param",
+            "description": "options to control the cursor.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "options"
+          },
+          {
+            "title": "param",
+            "description": "set the cursor key. Will persist through the whole run.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "options.key"
+          },
+          {
+            "title": "param",
+            "description": "the value to use if value is falsy",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "options.defaultValue"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
     }
   ]
 }

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@openfn/language-googlesheets",
+<<<<<<< HEAD
   "version": "2.3.1",
+=======
+  "version": "2.4.0",
+>>>>>>> fd5916c1 (version bumps)
   "description": "A Google Sheets Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -31,7 +35,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:^1.12.0",
+    "@openfn/language-common": "workspace:^1.13.0",
     "googleapis": "100.0.0"
   },
   "devDependencies": {

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@openfn/language-googlesheets",
-<<<<<<< HEAD
-  "version": "2.3.1",
-=======
   "version": "2.4.0",
->>>>>>> fd5916c1 (version bumps)
   "description": "A Google Sheets Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -39,7 +39,7 @@ function logError(err) {
   }
 }
 /**
- * Execute a sequence of operations.
+ * Execute a sequence of oper.
  * Wraps `language-common/execute`, and prepends initial state for http.
  * @example
  * execute(
@@ -225,6 +225,7 @@ export function getValues(spreadsheetId, range, callback = s => s) {
 export {
   alterState,
   combine,
+  cursor,
   dataPath,
   dataValue,
   each,

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @openfn/language-kobotoolbox
 
+## 2.2.0
+
+### Minor Changes
+
+- bae5d3b6: Add the cursor() function from common. See the job writing guide for
+  more information.
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/kobotoolbox/ast.json
+++ b/packages/kobotoolbox/ast.json
@@ -472,6 +472,83 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "cursor",
+      "params": [
+        "value",
+        "options"
+      ],
+      "docs": {
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "cursor($.cursor, { defaultValue: 'today' })",
+            "caption": "Use a cursor from state if present, or else use the default value"
+          },
+          {
+            "title": "example",
+            "description": "cursor(22)",
+            "caption": "Use a pagination cursor"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "the cursor value. Usually an ISO date, natural language date, or page number",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "value"
+          },
+          {
+            "title": "param",
+            "description": "options to control the cursor.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "options"
+          },
+          {
+            "title": "param",
+            "description": "set the cursor key. Will persist through the whole run.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "options.key"
+          },
+          {
+            "title": "param",
+            "description": "the value to use if value is falsy",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "options.defaultValue"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
     }
   ]
 }

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-kobotoolbox",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A Kobo Toolbox Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:^1.12.0"
+    "@openfn/language-common": "workspace:^1.13.0"
   },
   "devDependencies": {
     "assertion-error": "^1.0.1",

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -151,13 +151,14 @@ export function getDeploymentInfo(params, callback) {
 }
 
 export {
-  fn,
   alterState,
+  cursor,
   dataPath,
   dataValue,
   each,
   field,
   fields,
+  fn,
   http,
   lastReferenceValue,
   merge,

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @openfn/language-msgraph
 
+## 0.5.0
+
+### Minor Changes
+
+- bae5d3b6: Add the cursor() function from common. See the job writing guide for
+  more information.
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/msgraph/ast.json
+++ b/packages/msgraph/ast.json
@@ -949,6 +949,83 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "cursor",
+      "params": [
+        "value",
+        "options"
+      ],
+      "docs": {
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "cursor($.cursor, { defaultValue: 'today' })",
+            "caption": "Use a cursor from state if present, or else use the default value"
+          },
+          {
+            "title": "example",
+            "description": "cursor(22)",
+            "caption": "Use a pagination cursor"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "the cursor value. Usually an ISO date, natural language date, or page number",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "value"
+          },
+          {
+            "title": "param",
+            "description": "options to control the cursor.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "options"
+          },
+          {
+            "title": "param",
+            "description": "set the cursor key. Will persist through the whole run.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "options.key"
+          },
+          {
+            "title": "param",
+            "description": "the value to use if value is falsy",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "options.defaultValue"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
     }
   ]
 }

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-msgraph",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Microsoft Graph Language Pack for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/msgraph/src/Adaptor.js
+++ b/packages/msgraph/src/Adaptor.js
@@ -370,6 +370,7 @@ export function uploadFile(resource, data, callback) {
 export { request, sheetToBuffer } from './Utils';
 
 export {
+  cursor,
   dataPath,
   dataValue,
   dateFns,

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mssql
 
+## 4.1.9
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 4.1.8
 
 ### Patch Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mssql",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:1.12.0",
+    "@openfn/language-common": "workspace:1.13.0",
     "tedious": "15.1.0"
   },
   "devDependencies": {

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mysql
 
+## 1.4.9
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 1.4.8
 
 ### Patch Changes

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mysql",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "A MySQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "main": "dist/index.cjs",
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0",
+    "@openfn/language-common": "1.13.0",
     "json-sql": "^0.3.10",
     "mysql": "^2.13.0",
     "squel": "^5.8.0",

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-nexmo
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-nexmo",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "An Language Package for Nexmo",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ocl
 
+## 1.1.8
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 1.1.7
 
 ### Patch Changes

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ocl",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "An OCL language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0"
+    "@openfn/language-common": "1.13.0"
   },
   "devDependencies": {
     "@openfn/simple-ast": "^0.4.1",

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openfn
 
+## 1.3.9
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 1.3.8
 
 ### Patch Changes

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openfn",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "An (experimental) adaptor for accessing the OpenFn web API",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0",
+    "@openfn/language-common": "1.13.0",
     "axios": "^0.21.1"
   },
   "devDependencies": {

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openmrs
 
+## 3.0.1
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openmrs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "OpenMRS Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0"
+    "@openfn/language-common": "1.13.0"
   },
   "devDependencies": {
     "@openfn/simple-ast": "^0.4.1",

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-postgresql
 
+## 4.1.9
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 4.1.8
 
 ### Patch Changes

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-postgresql",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "A PostgreSQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0",
+    "@openfn/language-common": "1.13.0",
     "pg": "^8.3.2",
     "pg-format": "^1.0.4"
   },

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-primero
 
+## 2.11.9
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 2.11.8
 
 ### Patch Changes

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-primero",
-  "version": "2.11.8",
+  "version": "2.11.9",
   "description": "A UNICEF Primero language package for use with Open Function",
   "exports": {
     ".": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0",
+    "@openfn/language-common": "1.13.0",
     "cheerio": "^1.0.0-rc.10",
     "cheerio-tableparser": "1.0.1",
     "csv-parse": "^4.8.3",

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-progres
 
+## 1.3.9
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 1.3.8
 
 ### Patch Changes

--- a/packages/progres/package.json
+++ b/packages/progres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-progres",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "An OpenFn adaptor to work with UNHCR's ProGres case management system",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0",
+    "@openfn/language-common": "1.13.0",
     "axios": "^0.21.2"
   },
   "devDependencies": {

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-rapidpro
 
+## 1.0.9
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 1.0.8
 
 ### Patch Changes

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-rapidpro",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A RapidPro adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0",
+    "@openfn/language-common": "1.13.0",
     "axios": "^0.21.2"
   },
   "devDependencies": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-salesforce
 
+## 4.6.1
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 4.6.0
 
 ### Minor Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-sftp
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [1ad86651]
+  - @openfn/language-common@1.13.0
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-sftp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An SFTP language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -32,7 +32,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.12.0",
+    "@openfn/language-common": "1.13.0",
     "lodash": "^4.17.19",
     "ssh2-sftp-client": "9.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
   packages/asana:
     dependencies:
       '@openfn/language-common':
-        specifier: ^1.12.0
+        specifier: ^1.13.0
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -135,7 +135,7 @@ importers:
         specifier: ^5.12.0
         version: 5.12.0
       '@openfn/language-common':
-        specifier: workspace:1.12.0
+        specifier: workspace:1.13.0
         version: link:../common
       csv-parse:
         specifier: ^4.16.3
@@ -233,7 +233,7 @@ importers:
   packages/commcare:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:1.12.0
+        specifier: workspace:1.13.0
         version: link:../common
       '@openfn/language-http':
         specifier: workspace:^6.0.0
@@ -383,7 +383,7 @@ importers:
   packages/dynamics:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
       request:
         specifier: ^2.72.0
@@ -556,7 +556,7 @@ importers:
   packages/googlesheets:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^1.12.0
+        specifier: workspace:^1.13.0
         version: link:../common
       googleapis:
         specifier: 100.0.0
@@ -692,7 +692,7 @@ importers:
   packages/kobotoolbox:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^1.12.0
+        specifier: workspace:^1.13.0
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -1067,7 +1067,7 @@ importers:
   packages/mssql:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:1.12.0
+        specifier: workspace:1.13.0
         version: link:../common
       tedious:
         specifier: 15.1.0
@@ -1098,7 +1098,7 @@ importers:
   packages/mysql:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
       json-sql:
         specifier: ^0.3.10
@@ -1178,7 +1178,7 @@ importers:
   packages/ocl:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -1209,7 +1209,7 @@ importers:
   packages/openfn:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
       axios:
         specifier: ^0.21.1
@@ -1301,7 +1301,7 @@ importers:
   packages/openmrs:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -1369,7 +1369,7 @@ importers:
   packages/postgresql:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
       pg:
         specifier: ^8.3.2
@@ -1406,7 +1406,7 @@ importers:
   packages/primero:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
       cheerio:
         specifier: ^1.0.0-rc.10
@@ -1461,7 +1461,7 @@ importers:
   packages/progres:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
       axios:
         specifier: ^0.21.2
@@ -1498,7 +1498,7 @@ importers:
   packages/rapidpro:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
       axios:
         specifier: ^0.21.2
@@ -1615,7 +1615,7 @@ importers:
   packages/sftp:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../common
       lodash:
         specifier: ^4.17.19
@@ -1946,7 +1946,7 @@ importers:
   tools/import-tests:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^1.7.4
+        specifier: workspace:^1.13.0
         version: link:../../packages/common
       mocha:
         specifier: ^10.1.0

--- a/tools/import-tests/package.json
+++ b/tools/import-tests/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@openfn/language-common": "workspace:^1.7.4",
+    "@openfn/language-common": "workspace:^1.13.0",
     "mocha": "^10.1.0"
   }
 }


### PR DESCRIPTION
Release branch for the new cursor function

Must be released in tandem with the docs at  https://github.com/OpenFn/docs/pull/465

This branch will include minor releases for:
- common
- msgraph
- asana
- kobotoolbox
- googlesheet

There are patch releases for basically every other adaptor, since they depend on common. These are not terribly helpful but it's quite hard to ignore them - something I think changesets doesn't handle terribly well.