### PR TITLE
Add `callback` in `gsheets` docs 

### DIFF
--- a/.changeset/green-lions-pump.md
+++ b/.changeset/green-lions-pump.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-googlesheets': patch
+---
+
+add callback jsdocs

--- a/.changeset/green-lions-pump.md
+++ b/.changeset/green-lions-pump.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-googlesheets': patch
----
-
-add callback jsdocs

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-googlesheets
 
+## 2.3.1
+
+### Patch Changes
+
+- 4594a324: add callback jsdocs
+
 ## 2.3.0
 
 ### Minor Changes

--- a/packages/googlesheets/ast.json
+++ b/packages/googlesheets/ast.json
@@ -69,6 +69,15 @@
             "name": "params.values"
           },
           {
+            "title": "param",
+            "description": "(Optional) Callback function",
+            "type": {
+              "type": "NameExpression",
+              "name": "function"
+            },
+            "name": "callback"
+          },
+          {
             "title": "returns",
             "description": null,
             "type": {
@@ -123,6 +132,15 @@
             "name": "range"
           },
           {
+            "title": "param",
+            "description": "(Optional) callback function",
+            "type": {
+              "type": "NameExpression",
+              "name": "function"
+            },
+            "name": "callback"
+          },
+          {
             "title": "returns",
             "description": "spreadsheet information",
             "type": {
@@ -132,7 +150,7 @@
           }
         ]
       },
-      "valid": false
+      "valid": true
     }
   ],
   "exports": [],

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-googlesheets",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A Google Sheets Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -91,6 +91,7 @@ export function execute(...operations) {
  * @param {string} [params.spreadsheetId] The spreadsheet ID.
  * @param {string} [params.range] The range of values to update.
  * @param {array} [params.values] A 2d array of values to update.
+ * @param {function} callback - (Optional) Callback function
  * @returns {Operation}
  */
 export function appendValues(params, callback = s => s) {
@@ -147,6 +148,7 @@ export function appendValues(params, callback = s => s) {
  * @param {string} [params.range] The range of values to update.
  * @param {string} [params.valueInputOption] (Optional) Value update options. Defaults to 'USER_ENTERED'
  * @param {array} [params.values] A 2d array of values to update.
+ * @param {function} callback - (Optional) callback function
  * @returns {Operation} spreadsheet information
  */
 export function batchUpdateValues(params, callback = s => s) {
@@ -191,6 +193,7 @@ export function batchUpdateValues(params, callback = s => s) {
  * @function
  * @param {string} spreadsheetId The spreadsheet ID.
  * @param {string} range The sheet range.
+ * @param {function} callback - (Optional) callback function
  * @returns {Operation} spreadsheet information
  */
 export function getValues(spreadsheetId, range, callback = s => s) {


### PR DESCRIPTION
## Summary

#495 PR added support for callback in googlesheets functions. But i forgotten to add the jsdoc for callback option. This PR amend those changes for each function that supports callback in googlesheets  

## Review Checklist

- [x] Does the PR do what it claims to do?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
