### PR TITLE
http: expose cursor

### DIFF
--- a/packages/asana/ast.json
+++ b/packages/asana/ast.json
@@ -732,7 +732,7 @@
         "options"
       ],
       "docs": {
-        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at {@link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
         "tags": [
           {
             "title": "public",

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-bigquery
 
+## 2.0.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 2.0.5
 
 ### Patch Changes

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-bigquery",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A Google BigQuery language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@google-cloud/bigquery": "^5.12.0",
-    "@openfn/language-common": "workspace:1.13.0",
+    "@openfn/language-common": "workspace:1.13.1",
     "csv-parse": "^4.16.3",
     "import": "0.0.6",
     "json2csv": "^5.0.7",

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-commcare
 
+## 1.6.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 1.6.11
 
 ### Patch Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-commcare",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "description": "Commcare Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:1.13.0",
+    "@openfn/language-common": "workspace:1.13.1",
     "@openfn/language-http": "workspace:^6.0.0",
     "JSONPath": "^0.10.0",
     "form-data": "^4.0.0",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 v0.4.0
 
+## 1.13.1
+
+### Patch Changes
+
+- Fix jsdoc link
+
 ## 1.13.0
 
 ### Minor Changes

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1319,7 +1319,7 @@
         "options"
       ],
       "docs": {
-        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at {@link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
         "tags": [
           {
             "title": "public",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-common",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Common Expressions for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -787,7 +787,7 @@ let cursorKey = 'cursor';
  * Supports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,
  * which will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones 
  * are not yet supported.
- * See the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}
+ * See the usage guide at {@link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}
  * @public
  * @example <caption>Use a cursor from state if present, or else use the default value</caption>
  * cursor($.cursor, { defaultValue: 'today' })

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dynamics
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 0.4.9
 
 ### Patch Changes

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dynamics",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "A Microsoft Dynamics Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0",
+    "@openfn/language-common": "1.13.1",
     "request": "^2.72.0"
   },
   "devDependencies": {

--- a/packages/googlesheets/ast.json
+++ b/packages/googlesheets/ast.json
@@ -622,7 +622,7 @@
         "options"
       ],
       "docs": {
-        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at {@link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
         "tags": [
           {
             "title": "public",

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-http
 
+## 6.2.0
+
+### Minor Changes
+
+- Add cursor() function
+
 ## 6.1.0
 
 ### Minor Changes

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -1304,6 +1304,83 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "cursor",
+      "params": [
+        "value",
+        "options"
+      ],
+      "docs": {
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at {@link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "cursor($.cursor, { defaultValue: 'today' })",
+            "caption": "Use a cursor from state if present, or else use the default value"
+          },
+          {
+            "title": "example",
+            "description": "cursor(22)",
+            "caption": "Use a pagination cursor"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "the cursor value. Usually an ISO date, natural language date, or page number",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "value"
+          },
+          {
+            "title": "param",
+            "description": "options to control the cursor.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "options"
+          },
+          {
+            "title": "param",
+            "description": "set the cursor key. Will persist through the whole run.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "options.key"
+          },
+          {
+            "title": "param",
+            "description": "the value to use if value is falsy",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "options.defaultValue"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
     }
   ]
 }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-http",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -182,6 +182,7 @@ export {
   alterState,
   arrayToString,
   combine,
+  cursor,
   dataPath,
   dataValue,
   dateFns,

--- a/packages/kobotoolbox/ast.json
+++ b/packages/kobotoolbox/ast.json
@@ -480,7 +480,7 @@
         "options"
       ],
       "docs": {
-        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at {@link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
         "tags": [
           {
             "title": "public",

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msgraph
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/msgraph/ast.json
+++ b/packages/msgraph/ast.json
@@ -957,7 +957,7 @@
         "options"
       ],
       "docs": {
-        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at @{link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at {@link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
         "tags": [
           {
             "title": "public",

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-msgraph",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Microsoft Graph Language Pack for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mssql
 
+## 4.1.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 4.1.9
 
 ### Patch Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mssql",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:1.13.0",
+    "@openfn/language-common": "workspace:1.13.1",
     "tedious": "15.1.0"
   },
   "devDependencies": {

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mysql
 
+## 1.4.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 1.4.9
 
 ### Patch Changes

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mysql",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "A MySQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "main": "dist/index.cjs",
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0",
+    "@openfn/language-common": "1.13.1",
     "json-sql": "^0.3.10",
     "mysql": "^2.13.0",
     "squel": "^5.8.0",

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-nexmo
 
+## 0.4.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 0.4.4
 
 ### Patch Changes

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-nexmo",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "An Language Package for Nexmo",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ocl
 
+## 1.1.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 1.1.8
 
 ### Patch Changes

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ocl",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "An OCL language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0"
+    "@openfn/language-common": "1.13.1"
   },
   "devDependencies": {
     "@openfn/simple-ast": "^0.4.1",

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openfn
 
+## 1.3.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 1.3.9
 
 ### Patch Changes

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openfn",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "An (experimental) adaptor for accessing the OpenFn web API",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0",
+    "@openfn/language-common": "1.13.1",
     "axios": "^0.21.1"
   },
   "devDependencies": {

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openmrs
 
+## 3.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 3.0.1
 
 ### Patch Changes

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openmrs",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "OpenMRS Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0"
+    "@openfn/language-common": "1.13.1"
   },
   "devDependencies": {
     "@openfn/simple-ast": "^0.4.1",

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-postgresql
 
+## 4.1.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 4.1.9
 
 ### Patch Changes

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-postgresql",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "A PostgreSQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0",
+    "@openfn/language-common": "1.13.1",
     "pg": "^8.3.2",
     "pg-format": "^1.0.4"
   },

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-primero
 
+## 2.11.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 2.11.9
 
 ### Patch Changes

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-primero",
-  "version": "2.11.9",
+  "version": "2.11.10",
   "description": "A UNICEF Primero language package for use with Open Function",
   "exports": {
     ".": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0",
+    "@openfn/language-common": "1.13.1",
     "cheerio": "^1.0.0-rc.10",
     "cheerio-tableparser": "1.0.1",
     "csv-parse": "^4.8.3",

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-progres
 
+## 1.3.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 1.3.9
 
 ### Patch Changes

--- a/packages/progres/package.json
+++ b/packages/progres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-progres",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "An OpenFn adaptor to work with UNHCR's ProGres case management system",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0",
+    "@openfn/language-common": "1.13.1",
     "axios": "^0.21.2"
   },
   "devDependencies": {

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-rapidpro
 
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 1.0.9
 
 ### Patch Changes

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-rapidpro",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A RapidPro adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0",
+    "@openfn/language-common": "1.13.1",
     "axios": "^0.21.2"
   },
   "devDependencies": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-salesforce
 
+## 4.6.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 4.6.1
 
 ### Patch Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-sftp
 
+## 1.0.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.1
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-sftp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "An SFTP language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -32,7 +32,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.0",
+    "@openfn/language-common": "1.13.1",
     "lodash": "^4.17.19",
     "ssh2-sftp-client": "9.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         specifier: ^5.12.0
         version: 5.12.0
       '@openfn/language-common':
-        specifier: workspace:1.13.0
+        specifier: workspace:1.13.1
         version: link:../common
       csv-parse:
         specifier: ^4.16.3
@@ -233,7 +233,7 @@ importers:
   packages/commcare:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:1.13.0
+        specifier: workspace:1.13.1
         version: link:../common
       '@openfn/language-http':
         specifier: workspace:^6.0.0
@@ -383,7 +383,7 @@ importers:
   packages/dynamics:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
       request:
         specifier: ^2.72.0
@@ -1067,7 +1067,7 @@ importers:
   packages/mssql:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:1.13.0
+        specifier: workspace:1.13.1
         version: link:../common
       tedious:
         specifier: 15.1.0
@@ -1098,7 +1098,7 @@ importers:
   packages/mysql:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
       json-sql:
         specifier: ^0.3.10
@@ -1178,7 +1178,7 @@ importers:
   packages/ocl:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -1209,7 +1209,7 @@ importers:
   packages/openfn:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
       axios:
         specifier: ^0.21.1
@@ -1301,7 +1301,7 @@ importers:
   packages/openmrs:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -1369,7 +1369,7 @@ importers:
   packages/postgresql:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
       pg:
         specifier: ^8.3.2
@@ -1406,7 +1406,7 @@ importers:
   packages/primero:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
       cheerio:
         specifier: ^1.0.0-rc.10
@@ -1461,7 +1461,7 @@ importers:
   packages/progres:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
       axios:
         specifier: ^0.21.2
@@ -1498,7 +1498,7 @@ importers:
   packages/rapidpro:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
       axios:
         specifier: ^0.21.2
@@ -1615,7 +1615,7 @@ importers:
   packages/sftp:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.0
+        specifier: 1.13.1
         version: link:../common
       lodash:
         specifier: ^4.17.19
@@ -1946,7 +1946,7 @@ importers:
   tools/import-tests:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^1.13.0
+        specifier: workspace:^1.13.1
         version: link:../../packages/common
       mocha:
         specifier: ^10.1.0

--- a/tools/import-tests/package.json
+++ b/tools/import-tests/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@openfn/language-common": "workspace:^1.13.0",
+    "@openfn/language-common": "workspace:^1.13.1",
     "mocha": "^10.1.0"
   }
 }


### PR DESCRIPTION
Expose the `cursor` function to http.

Also patches common (annoyingly) to fix a broken link in the jsdocs.