### PR TITLE
`mssql` update schema and expose cursor

### DIFF
--- a/.changeset/poor-elephants-serve.md
+++ b/.changeset/poor-elephants-serve.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-mssql': minor
+---
+
+- Add `cursor()` function
+- Update `configuration-schema.json`

--- a/.changeset/poor-elephants-serve.md
+++ b/.changeset/poor-elephants-serve.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-mssql': minor
----
-
-- Add `cursor()` function
-- Update `configuration-schema.json`

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mssql
 
+## 4.2.0
+
+### Minor Changes
+
+- 2964fc8d: - Add `cursor()` function
+  - Update `configuration-schema.json`
+
 ## 4.1.10
 
 ### Patch Changes

--- a/packages/mssql/ast.json
+++ b/packages/mssql/ast.json
@@ -1082,6 +1082,83 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "cursor",
+      "params": [
+        "value",
+        "options"
+      ],
+      "docs": {
+        "description": "Sets a cursor property on state.\nSupports natural language dates like `now`, `today`, `yesterday`, `n hours ago`, `n days ago`, and `start`,\nwhich will be converted relative to the environment (ie, the Lightning or CLI locale). Custom timezones \nare not yet supported.\nSee the usage guide at {@link https://docs.openfn.org/documentation/jobs/job-writing-guide#using-cursors}",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "cursor($.cursor, { defaultValue: 'today' })",
+            "caption": "Use a cursor from state if present, or else use the default value"
+          },
+          {
+            "title": "example",
+            "description": "cursor(22)",
+            "caption": "Use a pagination cursor"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "the cursor value. Usually an ISO date, natural language date, or page number",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "value"
+          },
+          {
+            "title": "param",
+            "description": "options to control the cursor.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "options"
+          },
+          {
+            "title": "param",
+            "description": "set the cursor key. Will persist through the whole run.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "options.key"
+          },
+          {
+            "title": "param",
+            "description": "the value to use if value is falsy",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "options.defaultValue"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
     }
   ]
 }

--- a/packages/mssql/configuration-schema.json
+++ b/packages/mssql/configuration-schema.json
@@ -1,14 +1,27 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "properties": {
     "server": {
       "title": "Server URL",
-      "type": "string",
       "description": "The database instance server URL or IP address",
-      "format": "uri",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "hostname"
+        },
+        {
+          "type": "string",
+          "format": "ipv4"
+        },
+        {
+          "type": "string",
+          "format": "uri"
+        }
+      ],
       "minLength": 1,
       "examples": [
-        "something.database.windows.net"
+        "something.database.windows.net",
+        "192.168.12.10"
       ]
     },
     "database": {
@@ -38,9 +51,42 @@
       "examples": [
         "@super(!)Password"
       ]
+    },
+    "port": {
+      "type": "integer",
+      "default": 1433,
+      "examples": [
+        1432
+      ]
+    },
+    "encrypt": {
+      "type": "boolean",
+      "default": true,
+      "examples": [
+        false
+      ]
+    },
+    "rowCollectionOnRequestCompletion": {
+      "type": "boolean",
+      "default": true,
+      "examples": [
+        false
+      ]
+    },
+    "trustServerCertificate": {
+      "type": "boolean",
+      "default": true,
+      "examples": [
+        false
+      ]
     }
   },
   "type": "object",
   "additionalProperties": true,
-  "required": ["server", "database"]
+  "required": [
+    "server",
+    "database",
+    "userName",
+    "password"
+  ]
 }

--- a/packages/mssql/configuration-schema.json
+++ b/packages/mssql/configuration-schema.json
@@ -4,20 +4,7 @@
     "server": {
       "title": "Server URL",
       "description": "The database instance server URL or IP address",
-      "oneOf": [
-        {
-          "type": "string",
-          "format": "hostname"
-        },
-        {
-          "type": "string",
-          "format": "ipv4"
-        },
-        {
-          "type": "string",
-          "format": "uri"
-        }
-      ],
+      "type": "string",
       "minLength": 1,
       "examples": [
         "something.database.windows.net",

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mssql",
-  "version": "4.1.10",
+  "version": "4.2.0",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -30,6 +30,7 @@ function createConnection(state) {
       database,
       encrypt: true,
       rowCollectionOnRequestCompletion: true,
+      trustServerCertificate: true,
     },
   };
 

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -2,7 +2,6 @@ import {
   execute as commonExecute,
   expandReferences,
 } from '@openfn/language-common';
-import { resolve as resolveUrl } from 'url';
 import { Connection, Request } from 'tedious';
 
 /**
@@ -14,7 +13,16 @@ import { Connection, Request } from 'tedious';
  * @returns {State}
  */
 function createConnection(state) {
-  const { server, userName, password, database } = state.configuration;
+  const {
+    server,
+    userName,
+    password,
+    database,
+    port = 1433,
+    encrypt = true,
+    rowCollectionOnRequestCompletion = true,
+    trustServerCertificate = true,
+  } = state.configuration;
 
   if (!server) {
     throw new Error('server missing from configuration.');
@@ -27,14 +35,15 @@ function createConnection(state) {
     },
     server,
     options: {
+      port,
       database,
-      encrypt: true,
-      rowCollectionOnRequestCompletion: true,
-      trustServerCertificate: true,
+      encrypt,
+      rowCollectionOnRequestCompletion,
+      trustServerCertificate,
     },
   };
 
-  var connection = new Connection(config);
+  const connection = new Connection(config);
 
   // Attempt to connect and execute queries if connection goes through
   return new Promise((resolve, reject) => {
@@ -791,6 +800,7 @@ export {
   fn,
   http,
   lastReferenceValue,
+  cursor,
   merge,
   sourceValue,
 } from '@openfn/language-common';


### PR DESCRIPTION
## Summary

Improved the `configuration-schema` to support extra properties. All properties have default values and can be change if need when setting up a credential for `mssql`

## Details
- Set the following options in configuration-schema with default values 
```
- encrypt = true
- rowCollectionOnRequestCompletion = true
- trustServerCertificate = true
- port = 1433
```

- I have also remove un-used import of `url`
- I have update the configuration-schema for `server` to use one of `hostname, uri, on ipv4` #511 
- Import `cursor()` from `language-common`


## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
