### PR TITLE
http: don't override the auth header

### DIFF
--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Fixed an issue where the Authorization header could be overwritten if username
   and password are set on config
+- Configuration schema: demoted `username` and `password` to optional
+- Configuration schema: Added `token`. This is not automated and must be
+  manually add to the HTTP headers.
 
 ## 6.2.0
 

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-http
 
+## 6.2.1
+
+### Patch Changes
+
+- Fixed an issue where the Authorization header could be overwritten if username
+  and password are set on config
+
 ## 6.2.0
 
 ### Minor Changes

--- a/packages/http/configuration-schema.json
+++ b/packages/http/configuration-schema.json
@@ -18,6 +18,15 @@
         "@some(!)Password"
       ]
     },
+    "token": {
+      "title": "Token",
+      "type": "string",
+      "description": "Bearer token or API key. This should be added manually to the Authorization header.",
+      "writeOnly": true,
+      "examples": [
+        "00QCjAl4MlV-WPX"
+      ]
+    },
     "baseUrl": {
       "title": "Base URL",
       "anyOf": [
@@ -37,6 +46,5 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
-  "required": ["password", "username"]
+  "additionalProperties": true
 }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-http",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -11,7 +11,7 @@ import cheerioTableparser from 'cheerio-tableparser';
 
 export function addBasicAuth(configuration = {}, headers) {
   const { username, password } = configuration;
-  if (username && password && !('Authorization' in headers)) {
+  if (username && password && !headers.Authorization) {
     Object.assign(headers, makeBasicAuthHeader(username, password));
   }
 }

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -11,7 +11,7 @@ import cheerioTableparser from 'cheerio-tableparser';
 
 export function addBasicAuth(configuration = {}, headers) {
   const { username, password } = configuration;
-  if (username && password) {
+  if (username && password && !('Authorization' in headers)) {
     Object.assign(headers, makeBasicAuthHeader(username, password));
   }
 }

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -254,6 +254,29 @@ describe('get()', () => {
     expect(data.Authorization).to.eql('Basic aGVsbG86dGhlcmU=');
   });
 
+  it('does not override the Authorization header', async () => {
+    testServer
+      .intercept({
+        path: '/api/auth',
+        method: 'GET',
+      })
+      .reply(200, req => req.headers, { headers: jsonHeaders });
+
+    const state = {
+      configuration: {
+        baseUrl: 'https://www.example.com',
+        username: 'hello',
+        password: 'there',
+      },
+    };
+
+    const { data } = await execute(
+      get('/api/auth', { headers: { Authorization: 'Bearer abc' } })
+    )(state);
+
+    expect(data.Authorization).to.eql('Bearer abc');
+  });
+
   it('allows query strings to be set', async () => {
     testServer
       .intercept({


### PR DESCRIPTION
We may have stumbled on an issue where if state.configuration has a username and password,  AND the user passes their own Authorization header, we overwrite their header with own own basic auth.

This feels wrong: if the user has defined their own authorization header, we should use it regardless of what exists on state.

Fixes #539 