### PR TITLE
Commcare: replace superagent with common http helpers

### DIFF
--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:1.13.1",
+    "@openfn/language-common": "workspace*",
     "@openfn/language-http": "workspace:^6.0.0",
     "JSONPath": "^0.10.0",
     "form-data": "^4.0.0",

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -26,12 +26,10 @@
   ],
   "dependencies": {
     "@openfn/language-common": "workspace*",
-    "@openfn/language-http": "workspace:^6.0.0",
     "JSONPath": "^0.10.0",
     "form-data": "^4.0.0",
     "js2xmlparser": "^1.0.0",
     "lodash-fp": "^0.10.4",
-    "superagent": "^8.0.9",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"
   },
   "devDependencies": {

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -42,7 +42,7 @@ async function clientPost({ state, path, body }) {
     method: 'POST',
     path: path,
     data: body,
-    contentType: 'text/html',
+    contentType: 'text/xml',
     parseAs: 'text',
   });
 

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -71,14 +71,12 @@ async function clientPost({ state, path, body }) {
  */
 export function submitXls(formData, params) {
   return async state => {
-    const { applicationName, username, apiKey, hostUrl } = state.configuration;
+    const { applicationName, username, apiKey } = state.configuration;
 
     const [json] = expandReferences(state, formData);
     const { case_type, search_field, create_new_cases } = params;
 
     const path = `/a/${applicationName}/importer/excel/bulk_upload_api/`;
-
-    const url = (hostUrl || 'https://www.commcarehq.org').concat(path);
 
     const workbook = xlsx.utils.book_new();
     const worksheet = xlsx.utils.json_to_sheet(json);
@@ -96,8 +94,6 @@ export function submitXls(formData, params) {
     data.append('case_type', case_type);
     data.append('search_field', search_field);
     data.append('create_new_cases', create_new_cases);
-
-    console.log('Posting to url: '.concat(url));
 
     const response = await request({
       state,
@@ -144,14 +140,10 @@ export function submit(formData) {
       // it is what lives after www.commcarehq.org/a/...
       applicationName,
       appId,
-      hostUrl,
     } = state.configuration;
 
     const path = `/a/${applicationName}/receiver/${appId}/`;
 
-    const url = (hostUrl || 'https://www.commcarehq.org').concat(path);
-
-    console.log('Posting to url: '.concat(url));
     console.log('Raw JSON body: '.concat(JSON.stringify(jsonBody)));
     console.log('X-form submission: '.concat(body));
 
@@ -175,13 +167,7 @@ export function fetchReportData(reportId, params, postUrl) {
   return async state => {
     const path = `/a/${state.configuration.applicationName}/api/v0.5/configurablereportdata/${reportId}/`;
 
-    console.log(
-      'getting from url: '.concat(
-        state.configuration.hostUrl,
-        `/a/${state.configuration.applicationName}/api/v0.5/configurablereportdata/${reportId}/`
-      )
-    );
-    console.log('with params: '.concat(params));
+    console.log('with params: '.concat(JSON.stringify(params)));
 
     return await request({
       state,

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -164,7 +164,7 @@ export function submit(formData) {
  * @returns {Operation}
  */
 export function fetchReportData(reportId, params, postUrl) {
-  return async state => {
+  return state => {
     const path = `/a/${state.configuration.applicationName}/api/v0.5/configurablereportdata/${reportId}/`;
 
     console.log('with params: '.concat(JSON.stringify(params)));

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -1,11 +1,5 @@
-import {
-  execute as commonExecute,
-  http,
-  expandReferences,
-} from '@openfn/language-common';
-import pkg from '@openfn/language-http';
-const { get, post } = pkg;
-// import request from 'superagent';
+import { execute as commonExecute } from '@openfn/language-common';
+import { expandReferences } from '@openfn/language-common/util';
 import FormData from 'form-data';
 import js2xmlparser from 'js2xmlparser';
 import xlsx from 'xlsx';
@@ -30,10 +24,6 @@ export function execute(...operations) {
   };
 
   return state => {
-    // state.configuration.authType = 'basic';
-    // state.configuration.baseUrl = 'https://www.commcarehq.org/a/'.concat(
-    //   state.configuration.applicationName
-    // );
     return commonExecute(...operations)({ ...initialState, ...state });
   };
 }
@@ -43,23 +33,21 @@ export function execute(...operations) {
  * @example
  *  clientPost(formData)
  * @function
- * @param {Object} formData - Form Data with auth params and body
+ * @param {Object} formData - Form Data with path and body
  * @returns {State}
  */
-function clientPost({ url, body, username, password }) {
-  return new Promise((resolve, reject) => {
-    request
-      .post(url)
-      .auth(username, password)
-      .set('Content-Type', 'application/xml')
-      .send(body)
-      .end((error, res) => {
-        if (!!error || !res.ok) {
-          reject(error);
-        }
-        resolve(res);
-      });
+async function clientPost({ state, path, body }) {
+  const response = await request({
+    state,
+    method: 'POST',
+    path: path,
+    data: body,
+    authType: 'basic',
+    contentType: 'text/html',
+    parseAs: 'text',
   });
+
+  return prepareNextState(state, response, s => s);
 }
 
 /**
@@ -82,17 +70,15 @@ function clientPost({ url, body, username, password }) {
  * @returns {Operation}
  */
 export function submitXls(formData, params) {
-  return state => {
-    const { applicationName, username, apiKey } = state.configuration;
+  return async state => {
+    const { applicationName, username, apiKey, hostUrl } = state.configuration;
 
-    const json = expandReferences(formData)(state);
+    const [json] = expandReferences(state, formData);
     const { case_type, search_field, create_new_cases } = params;
 
-    // const url = (hostUrl || 'https://www.commcarehq.org').concat(
-    //   '/a/',
-    //   applicationName,
-    //   '/importer/excel/bulk_upload_api/'
-    // );
+    const path = `/a/${applicationName}/importer/excel/bulk_upload_api/`;
+
+    const url = (hostUrl || 'https://www.commcarehq.org').concat(path);
 
     const workbook = xlsx.utils.book_new();
     const worksheet = xlsx.utils.json_to_sheet(json);
@@ -111,39 +97,21 @@ export function submitXls(formData, params) {
     data.append('search_field', search_field);
     data.append('create_new_cases', create_new_cases);
 
-    // console.log('Posting to url: '.concat(url));
+    console.log('Posting to url: '.concat(url));
 
-    return async state => {
-      const response = await request(
-        state,
-        'POST',
-        `/a/${applicationName}/importer/excel/bulk_upload_api/`,
-        data,
-        '',
-        {
-          ...data.getHeaders(),
-          Authorization: `ApiKey ${username}:${apiKey}`,
-        },
-        'AUTH_TYPE_APIKEY'
-      );
+    const response = await request({
+      state,
+      method: 'POST',
+      path: path,
+      data,
+      header: {
+        ...data.getHeaders(),
+        Authorization: `ApiKey ${username}:${apiKey}`,
+      },
+      authType: 'APIKEY',
+    });
 
-      return prepareNextState(state, response, s => s)
-    };
-    // return http
-    //   .post({
-    //     url,
-    //     data,
-    //     headers: {
-    //       ...data.getHeaders(),
-    //       Authorization: `ApiKey ${username}:${apiKey}`,
-    //     },
-    //   })(state)
-    //   .then(response => {
-    //     return { ...state, data: { body: response.data } };
-    //   })
-    //   .catch(err => {
-    //     throw { ...err, config: {}, request: {} };
-    //   });
+    return prepareNextState(state, response, s => s);
   };
 }
 
@@ -167,42 +135,27 @@ export function submitXls(formData, params) {
  * @returns {Operation}
  */
 export function submit(formData) {
-  return state => {
-    const jsonBody = expandReferences(formData)(state);
+  return async state => {
+    const [jsonBody] = expandReferences(state, formData);
     const body = js2xmlparser('data', jsonBody);
 
     const {
       // this should be called project URL.
       // it is what lives after www.commcarehq.org/a/...
       applicationName,
-      username,
-      password,
       appId,
       hostUrl,
     } = state.configuration;
 
-    const url = (hostUrl || 'https://www.commcarehq.org').concat(
-      '/a/',
-      applicationName,
-      '/receiver/',
-      appId,
-      '/'
-    );
+    const path = `/a/${applicationName}/receiver/${appId}/`;
+
+    const url = (hostUrl || 'https://www.commcarehq.org').concat(path);
 
     console.log('Posting to url: '.concat(url));
     console.log('Raw JSON body: '.concat(JSON.stringify(jsonBody)));
     console.log('X-form submission: '.concat(body));
 
-    return clientPost({
-      url,
-      body,
-      username,
-      password,
-    }).then(response => {
-      console.log(`Server repsonded with a ${response.status}:`);
-      console.log(response);
-      return { ...state, references: [response, ...state.references] };
-    });
+    return clientPost({ state, path, body });
   };
 }
 
@@ -219,29 +172,41 @@ export function submit(formData) {
  * @returns {Operation}
  */
 export function fetchReportData(reportId, params, postUrl) {
-  return http.get(`api/v0.5/configurablereportdata/${reportId}/`, {
-    query: function (state) {
-      console.log(
-        'getting from url: '.concat(
-          state.configuration.baseUrl,
-          `/api/v0.5/configurablereportdata/${reportId}/`
-        )
-      );
-      console.log('with params: '.concat(params));
-      return params;
-    },
-    callback: function (state) {
-      var reportData = state.response.body;
-      return post(postUrl, {
-        body: reportData,
-      })(state).then(function (state) {
-        delete state.response;
+  return async state => {
+    const path = `/a/${state.configuration.applicationName}/api/v0.5/configurablereportdata/${reportId}/`;
+
+    console.log(
+      'getting from url: '.concat(
+        state.configuration.hostUrl,
+        `/a/${state.configuration.applicationName}/api/v0.5/configurablereportdata/${reportId}/`
+      )
+    );
+    console.log('with params: '.concat(params));
+
+    return await request({
+      state,
+      method: 'GET',
+      path,
+      authType: 'basic',
+    })
+      .then(response => {
+        const reportData = response.body;
+        return request({
+          state,
+          method: 'POST',
+          path: postUrl,
+          params,
+          data: reportData,
+          authType: 'basic',
+        });
+      })
+      .then(result => {
+        delete result.response;
         console.log('fetchReportData succeeded.');
         console.log('Posted to: '.concat(postUrl));
-        return state;
+        return prepareNextState(state, {}, s => s);
       });
-    },
-  });
+  };
 }
 
 export {

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -169,7 +169,7 @@ export function fetchReportData(reportId, params, postUrl) {
 
     console.log('with params: '.concat(JSON.stringify(params)));
 
-    return await request({
+    return request({
       state,
       method: 'GET',
       path,

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -4,8 +4,6 @@ import FormData from 'form-data';
 import js2xmlparser from 'js2xmlparser';
 import xlsx from 'xlsx';
 import { request, prepareNextState } from './Utils';
-import pkg from '@openfn/language-http';
-const { get, post } = pkg;
 
 /**
  * Execute a sequence of operations.

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -47,7 +47,7 @@ async function clientPost({ state, path, body }) {
     parseAs: 'text',
   });
 
-  return prepareNextState(state, response, s => s);
+  return prepareNextState(state, response);
 }
 
 /**
@@ -111,7 +111,7 @@ export function submitXls(formData, params) {
       authType: 'APIKEY',
     });
 
-    return prepareNextState(state, response, s => s);
+    return prepareNextState(state, response);
   };
 }
 
@@ -204,7 +204,7 @@ export function fetchReportData(reportId, params, postUrl) {
         delete result.response;
         console.log('fetchReportData succeeded.');
         console.log('Posted to: '.concat(postUrl));
-        return prepareNextState(state, {}, s => s);
+        return prepareNextState(state, {});
       });
   };
 }

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -42,7 +42,6 @@ async function clientPost({ state, path, body }) {
     method: 'POST',
     path: path,
     data: body,
-    authType: 'basic',
     contentType: 'text/html',
     parseAs: 'text',
   });
@@ -104,7 +103,6 @@ export function submitXls(formData, params) {
         ...data.getHeaders(),
         Authorization: `ApiKey ${username}:${apiKey}`,
       },
-      authType: 'APIKEY',
     });
 
     return prepareNextState(state, response);

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -29,27 +29,6 @@ export function execute(...operations) {
 }
 
 /**
- * Performs a post request
- * @example
- *  clientPost(formData)
- * @function
- * @param {Object} formData - Form Data with path and body
- * @returns {State}
- */
-async function clientPost({ state, path, body }) {
-  const response = await request({
-    state,
-    method: 'POST',
-    path: path,
-    data: body,
-    contentType: 'text/xml',
-    parseAs: 'text',
-  });
-
-  return prepareNextState(state, response);
-}
-
-/**
  * Convert form data to xls then submit.
  * @public
  * @example
@@ -145,7 +124,16 @@ export function submit(formData) {
     console.log('Raw JSON body: '.concat(JSON.stringify(jsonBody)));
     console.log('X-form submission: '.concat(body));
 
-    return clientPost({ state, path, body });
+    const response = await request({
+      state,
+      method: 'POST',
+      path: path,
+      data: body,
+      contentType: 'text/xml',
+      parseAs: 'text',
+    });
+
+    return prepareNextState(state, response);
   };
 }
 

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -5,7 +5,7 @@ import {
   logResponse,
 } from '@openfn/language-common/util';
 
-export const prepareNextState = (state, response, callback) => {
+export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
   const nextState = {
     ...composeNextState(state, response.body),

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -22,7 +22,7 @@ export function request({
   data,
   params = {},
   header = {},
-  authType,
+  authType = 'basic',
   contentType = 'application/json',
   parseAs = 'json',
 }) {

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -15,29 +15,39 @@ export const prepareNextState = (state, response, callback) => {
   return callback(nextState);
 };
 
-export function request(state, method, path, data, params, header, authType) {
+export function request({
+  state,
+  method,
+  path,
+  data,
+  params = {},
+  header = {},
+  authType,
+  contentType = 'application/json',
+  parseAs = 'json',
+}) {
   const { hostUrl, username, password } = state.configuration;
 
-  const headers = authType === 'basic'
-  ? {
-      ...makeBasicAuthHeader(username, password),
-      'content-type': 'application/json'
-    }
-  : {
-      ...header,
-
-    };
+  const headers =
+    authType === 'basic'
+      ? {
+          ...makeBasicAuthHeader(username, password),
+          'content-type': contentType,
+        }
+      : {
+          ...header,
+        };
 
   const options = {
     body: data,
     headers: headers,
     query: params,
-    parseAs: 'json',
+    parseAs: parseAs,
   };
 
   const url = `${hostUrl}${path}`;
 
-  return commonRequest(method, url, options).then(response =>
-    logResponse(response)
-  );
+  return commonRequest(method, url, options).then(response => {
+    return logResponse(response);
+  });
 }

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -5,32 +5,6 @@ import {
   logResponse,
 } from '@openfn/language-common/util';
 
-/**
- * @private
- *  * @function
- * @param {string} path - Path to resource
- * @param {object} data - Object which defines data that will be used to create a given instance of resource
- * @param {string} contentType- Optional field for the header content-type
- * @param {string} parseAs- Optional for data response parse i.e json
- */
-export const post = async ({
-  path,
-  data,
-  contentType = 'application/json',
-  parseAs = 'json',
-}) => {
-  return async state => {
-    const response = await request({
-      method: 'POST',
-      path,
-      data,
-      contentType,
-      parseAs,
-    });
-    return prepareNextState(state, response);
-  };
-};
-
 export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
   const nextState = {

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -47,7 +47,5 @@ export function request({
 
   const url = `${hostUrl}${path}`;
 
-  return commonRequest(method, url, options).then(response => {
-    return logResponse(response);
-  });
+  return commonRequest(method, url, options).then(logResponse);
 }

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -1,0 +1,43 @@
+import { composeNextState } from '@openfn/language-common';
+import {
+  request as commonRequest,
+  makeBasicAuthHeader,
+  logResponse,
+} from '@openfn/language-common/util';
+
+export const prepareNextState = (state, response, callback) => {
+  const { body, ...responseWithoutBody } = response;
+  const nextState = {
+    ...composeNextState(state, response.body),
+    response: responseWithoutBody,
+  };
+
+  return callback(nextState);
+};
+
+export function request(state, method, path, data, params, header, authType) {
+  const { hostUrl, username, password } = state.configuration;
+
+  const headers = authType === 'basic'
+  ? {
+      ...makeBasicAuthHeader(username, password),
+      'content-type': 'application/json'
+    }
+  : {
+      ...header,
+
+    };
+
+  const options = {
+    body: data,
+    headers: headers,
+    query: params,
+    parseAs: 'json',
+  };
+
+  const url = `${hostUrl}${path}`;
+
+  return commonRequest(method, url, options).then(response =>
+    logResponse(response)
+  );
+}

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -5,6 +5,32 @@ import {
   logResponse,
 } from '@openfn/language-common/util';
 
+/**
+ * @private
+ *  * @function
+ * @param {string} path - Path to resource
+ * @param {object} data - Object which defines data that will be used to create a given instance of resource
+ * @param {string} contentType- Optional field for the header content-type
+ * @param {string} parseAs- Optional for data response parse i.e json
+ */
+export const post = async ({
+  path,
+  data,
+  contentType = 'application/json',
+  parseAs = 'json',
+}) => {
+  return async state => {
+    const response = await request({
+      method: 'POST',
+      path,
+      data,
+      contentType,
+      parseAs,
+    });
+    return prepareNextState(state, response);
+  };
+};
+
 export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
   const nextState = {

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -3,9 +3,7 @@ import { expect } from 'chai';
 import Adaptor from '../src';
 const { execute, submit } = Adaptor;
 
-import request from 'superagent';
-import superagentMock from 'superagent-mock';
-import Fixtures, { fixtures } from './Fixtures'
+
 
 describe("execute", () => {
 
@@ -47,17 +45,4 @@ describe("execute", () => {
   })
 })
 
-describe("submit", () => {
-  let mockRequest
 
-  before(() => {
-    mockRequest = superagentMock(request, Fixtures)
-  })
-
-  it("submits a form and returns state")
-
-  after(() => {
-    mockRequest.unset()
-  })
-
-})

--- a/packages/commcare/test/integrations/JobExample.js
+++ b/packages/commcare/test/integrations/JobExample.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-undef */
+
+// Create a state.json for credentials to the demo environment. Docs "https://docs.openfn.org/adaptors/packages/commcare-configuration-schema"
+submit(
+  fields(
+    field('@', function () {
+      return {
+        xmlns: 'http://openrosa.org/formdesigner/form-id-here',
+      };
+    }),
+    field('question1', dataValue('answer1')),
+    field('question2', 'Write some answer here.')
+  )
+);
+fn(state => {
+  console.log(state);
+});
+
+submitXls([{ name: 'Mamadou', phone: '000000' }], {
+  case_type: 'student',
+  search_field: 'external_id',
+  create_new_cases: 'on',
+});
+fn(state => {
+  console.log(state);
+});
+
+fetchReportData(
+  'report-id-here',
+  {
+    offset: 20,
+    limit: 10,
+  },
+  '/a/your-domain/api/v0.5/form/'
+);
+fn(state => {
+  console.log(state);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,7 +233,7 @@ importers:
   packages/commcare:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:1.13.1
+        specifier: workspace*
         version: link:../common
       '@openfn/language-http':
         specifier: workspace:^6.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,9 +235,6 @@ importers:
       '@openfn/language-common':
         specifier: workspace*
         version: link:../common
-      '@openfn/language-http':
-        specifier: workspace:^6.0.0
-        version: link:../http
       JSONPath:
         specifier: ^0.10.0
         version: 0.10.0
@@ -250,9 +247,6 @@ importers:
       lodash-fp:
         specifier: ^0.10.4
         version: 0.10.4
-      superagent:
-        specifier: ^8.0.9
-        version: 8.0.9
       xlsx:
         specifier: https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz
         version: '@cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz'


### PR DESCRIPTION
## Summary

Switch `commcare` adaptor implementation to use `fetch` for all http calls

## Implementation Details

Currently the `commcare` module utilizes superagent and `language-http` to handle its requests.  Our aim was to switch the implementation with normal fetch.


## How to Test

- [x] Uses the standard format for http requests defined in https://github.com/OpenFn/adaptors/blob/main/packages/template/src/Utils.js
- [x] Have no reference to  superagent or `language-http` . 


## Issues

Fixes #414

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.

