### PR TITLE
dhis2: fix attribute metadata

### DIFF
--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-dhis2
 
+## 4.0.5
+
+### Patch Changes
+
+- Fix attribute metadata
+
 ## 4.0.4
 
 ### Patch Changes

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dhis2",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "DHIS2 Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/dhis2/src/meta/config.js
+++ b/packages/dhis2/src/meta/config.js
@@ -1,7 +1,7 @@
 // Config for dhis2 sandbox
 export default {
   configuration: {
-    hostUrl: 'https://play.dhis2.org/2.39.0.1',
+    hostUrl: 'https://play.dhis2.org/40.3.0',
     username: process.env.OPENFN_DHIS2_USER,
     password: process.env.OPENFN_DHIS2_PW,
   },

--- a/packages/dhis2/src/meta/helper.js
+++ b/packages/dhis2/src/meta/helper.js
@@ -53,9 +53,8 @@ const createHelper = (configuration = {}) => {
     return response.data;
   };
 
-  // get all the attriobutes for a trackedEntityInstanceType
   const getAttributes = async () => {
-    const url = generateUrl(configuration, {}, 'attributes');
+    const url = generateUrl(configuration, {}, 'trackedEntityAttributes');
 
     const response = await get(url);
 

--- a/packages/dhis2/src/meta/metadata.js
+++ b/packages/dhis2/src/meta/metadata.js
@@ -30,7 +30,7 @@ const metadata = async (configuration = {}, helper) => {
 
   const attributes = (await helper.getAttributes()) ?? [];
   children.attributes =
-    attributes.attributes?.map(attr =>
+    attributes.trackedEntityAttributes?.map(attr =>
       createEntity(attr.id, 'attribute', {
         datatype: 'string',
         label: attr.displayName,

--- a/packages/dhis2/test/fixtures/getAttributes.json
+++ b/packages/dhis2/test/fixtures/getAttributes.json
@@ -1,1 +1,5 @@
-{ "attributes": [{ "displayName": "Alternative name", "id": "DnrLSdo4hMl" }] }
+{
+  "trackedEntityAttributes": [
+    { "displayName": "Alternative name", "id": "DnrLSdo4hMl" }
+  ]
+}

--- a/tools/metadata/package.json
+++ b/tools/metadata/package.json
@@ -7,8 +7,7 @@
   "main": "src/index.js",
   "license": "ISC",
   "bin": {
-    "metadata": "src/cli.js",
-    "jam": "src/cli.js"
+    "metadata": "src/cli.js"
   },
   "scripts": {
     "cli": "node src/cli.js"


### PR DESCRIPTION
dhis2 metadata is loading attributes from the wrong endpoint.

We should be loading trackedEntityAttributes, not attributes.

Maybe one day we need both but for now, this just provides more useful metadata.

Closes #557 
