### PR TITLE
Commcare: standardize auth

### DIFF
--- a/.changeset/small-pots-wave.md
+++ b/.changeset/small-pots-wave.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-commcare': major
+---
+
+Standardize auth to use either basic or APIKey. This is a minor change that will not affect the functionality of the function but only allow for one type of auth to be used at a time

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -75,10 +75,8 @@ export function submitXls(formData, params) {
     data.append('search_field', search_field);
     data.append('create_new_cases', create_new_cases);
 
-    const response = await request({
-      state,
+    const response = await request(state.configuration, path, {
       method: 'POST',
-      path: path,
       data,
       headers: {
         ...data.getHeaders(),
@@ -125,10 +123,8 @@ export function submit(formData) {
     console.log('Raw JSON body: '.concat(JSON.stringify(jsonBody)));
     console.log('X-form submission: '.concat(body));
 
-    const response = await request({
-      state,
+    const response = await request(state.configuration, path, {
       method: 'POST',
-      path: path,
       data: body,
       contentType: 'text/xml',
       parseAs: 'text',
@@ -156,17 +152,13 @@ export function fetchReportData(reportId, params, postUrl) {
 
     console.log('with params: '.concat(JSON.stringify(params)));
 
-    const { body: reportData } = await request({
-      state,
+    const { body: reportData } = await request(state.configuration, path, {
       method: 'GET',
-      path,
       authType: 'basic',
     });
 
-    const result = await request({
-      state,
+    const result = await request(state.configuration, postUrl, {
       method: 'POST',
-      path: postUrl,
       params,
       data: reportData,
       authType: 'basic',

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -69,7 +69,6 @@ export function submitXls(formData, params) {
 
     data.append('file', buffer, {
       filename: 'output.xls',
-      contentType: 'application/vnd.ms-excel',
     });
     // data.append('file', fs.createReadStream('./out.xls'));
     data.append('case_type', case_type);

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -49,7 +49,7 @@ export function execute(...operations) {
  */
 export function submitXls(formData, params) {
   return async state => {
-    const { applicationName, username, apiKey } = state.configuration;
+    const { applicationName } = state.configuration;
 
     const [json] = expandReferences(state, formData);
     const { case_type, search_field, create_new_cases } = params;
@@ -67,7 +67,10 @@ export function submitXls(formData, params) {
 
     const data = new FormData();
 
-    data.append('file', buffer, { filename: 'output.xls' });
+    data.append('file', buffer, {
+      filename: 'output.xls',
+      contentType: 'application/vnd.ms-excel',
+    });
     // data.append('file', fs.createReadStream('./out.xls'));
     data.append('case_type', case_type);
     data.append('search_field', search_field);
@@ -78,9 +81,8 @@ export function submitXls(formData, params) {
       method: 'POST',
       path: path,
       data,
-      header: {
+      headers: {
         ...data.getHeaders(),
-        Authorization: `ApiKey ${username}:${apiKey}`,
       },
     });
 

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { composeNextState } from '@openfn/language-common';
 import {
   request as commonRequest,


### PR DESCRIPTION
## Summary

Creating a single auth systems that will check the `config` and authorize depending on the availability of an api key or password

## Details

The current implementation of auth is to allow for both basic and API key at the same time and we needed to make it better by only allowing one type of auth depending on the `config`. 

## Issues

#554 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
