### PR TITLE
Commcare: fix xlsx

### DIFF
--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@openfn/language-common": "workspace*",
     "JSONPath": "^0.10.0",
-    "form-data": "^4.0.0",
     "js2xmlparser": "^1.0.0",
     "lodash-fp": "^0.10.4",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -1,11 +1,10 @@
 import { execute as commonExecute } from '@openfn/language-common';
 import { expandReferences } from '@openfn/language-common/util';
-// import FormData from 'form-data';
+import { Blob } from 'node:buffer';
 import js2xmlparser from 'js2xmlparser';
 import xlsx from 'xlsx';
-import { request, prepareNextState } from './Utils';
 
-import { Blob } from 'node:buffer';
+import { request, prepareNextState } from './Utils';
 
 /**
  * Execute a sequence of operations.
@@ -69,8 +68,8 @@ export function submitXls(formData, params) {
 
     const data = new FormData();
 
-    data.append('file', new Blob(buffer), 'output.xls');
-    // data.append('file', fs.createReadStream('./out.xls'));
+    data.append('file', new Blob([buffer]), 'output.xls');
+    // data.append('file', fs.createReadStream('out.xls'));
     data.append('case_type', case_type);
     data.append('search_field', search_field);
     data.append('create_new_cases', create_new_cases);

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -1,9 +1,11 @@
 import { execute as commonExecute } from '@openfn/language-common';
 import { expandReferences } from '@openfn/language-common/util';
-import FormData from 'form-data';
+// import FormData from 'form-data';
 import js2xmlparser from 'js2xmlparser';
 import xlsx from 'xlsx';
 import { request, prepareNextState } from './Utils';
+
+import { Blob } from 'node:buffer';
 
 /**
  * Execute a sequence of operations.
@@ -67,9 +69,7 @@ export function submitXls(formData, params) {
 
     const data = new FormData();
 
-    data.append('file', buffer, {
-      filename: 'output.xls',
-    });
+    data.append('file', new Blob(buffer), 'output.xls');
     // data.append('file', fs.createReadStream('./out.xls'));
     data.append('case_type', case_type);
     data.append('search_field', search_field);
@@ -79,9 +79,6 @@ export function submitXls(formData, params) {
       const response = await request(state.configuration, path, {
         method: 'POST',
         data,
-        headers: {
-          ...data.getHeaders(),
-        },
       });
 
       return prepareNextState(state, response);
@@ -165,7 +162,7 @@ export function fetchReportData(reportId, params, postUrl) {
       method: 'POST',
       params,
       data: reportData,
-      authType: 'basic',
+      contentType: 'application/json',
     });
 
     delete result.response;

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -38,20 +38,21 @@ export function request(configuration, path, opts) {
     method,
     data,
     params = {},
-    headers = {},
-    contentType = 'application/json',
+    headers: customHeaders = {},
+    contentType,
     parseAs = 'json',
   } = opts;
 
+  const headers = configureAuth(configuration, customHeaders);
+  if (contentType) {
+    headers['content-type'] = contentType;
+  }
+
   const options = {
     body: data,
-    headers: {
-      ...configureAuth(configuration),
-      'content-type': contentType,
-      ...headers,
-    },
+    headers,
     query: params,
-    parseAs: parseAs,
+    parseAs,
   };
 
   const url = `${hostUrl}${path}`;

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -56,6 +56,5 @@ export function request(configuration, path, opts) {
   };
 
   const url = `${hostUrl}${path}`;
-
   return commonRequest(method, url, options).then(logResponse);
 }

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -1,48 +1,99 @@
 import { expect } from 'chai';
+import { enableMockClient } from '@openfn/language-common/util';
+import { execute, submitXls } from '../src';
 
-import Adaptor from '../src';
-const { execute, submit } = Adaptor;
+const hostUrl = 'http://example.commcare.com';
+const testServer = enableMockClient(hostUrl);
 
-
-
-describe("execute", () => {
-
-  it("executes each operation in sequence", (done) => {
+describe('execute', () => {
+  it('executes each operation in sequence', done => {
     let state = {
       data: {},
-      configuration: {}
-    }
+      configuration: {},
+    };
     let operations = [
-      (state) => { return {counter: 1} },
-      (state) => { return {counter: 2} },
-      (state) => { return {counter: 3} }
-    ]
+      state => {
+        return { counter: 1 };
+      },
+      state => {
+        return { counter: 2 };
+      },
+      state => {
+        return { counter: 3 };
+      },
+    ];
 
     execute(...operations)(state)
-    .then((finalState) => {
-      expect(finalState).to.eql({ counter: 3 })
-    })
-    .then(done).catch(done)
+      .then(finalState => {
+        expect(finalState).to.eql({ counter: 3 });
+      })
+      .then(done)
+      .catch(done);
+  });
 
-  })
-
-  it("assigns references, data to the initialState", () => {
+  it('assigns references, data to the initialState', () => {
     let state = {
       data: {},
-      configuration: {}
-    }
+      configuration: {},
+    };
 
-    let finalState = execute()(state)
+    let finalState = execute()(state);
 
-    execute()(state)
-    .then((finalState) => {
+    execute()(state).then(finalState => {
       expect(finalState).to.eql({
         references: [],
-        data: null
+        data: null,
+      });
+    });
+  });
+});
+
+describe('SubmitXls', () => {
+  it('should submit JSON as an xls file', async () => {
+    const domain = 'my-domain';
+    const app = 'my-app';
+
+    let formdata;
+
+    testServer
+      .intercept({
+        path: `/a/${domain}/importer/excel/bulk_upload_api/`,
+        method: 'POST',
       })
-    })
+      .reply(200, req => {
+        // save out the form data that was upladed
+        formdata = req.body;
 
-  })
-})
+        // simulate a return from commcare
+        return { code: 200, message: 'success' };
+      });
 
+    const state = {
+      configuration: {
+        hostUrl,
+        applicationName: domain,
+        appId: app,
+        username: 'user',
+        password: 'password',
+      },
+    };
 
+    const { data } = await execute(
+      submitXls([{ name: 'Mamadou', phone: '000000' }], {
+        case_type: 'student',
+        search_field: 'external_id',
+        create_new_cases: 'on',
+      })
+    )(state);
+
+    // The response  should be on state.data
+    expect(data.code).to.equal(200);
+    expect(data.message).to.equal('success');
+
+    // And the adaptor should have uploaded a reasonable looking formdata object
+    expect(formdata.get('case_type')).to.not.be.undefined;
+    expect(formdata.get('case_type')).to.equal('student');
+    expect(formdata.get('search_field')).to.equal('external_id');
+    expect(formdata.get('create_new_cases')).to.equal('on');
+  });
+});

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -35,6 +35,7 @@ const getClient = (baseUrl, options) => {
 
 export const enableMockClient = baseUrl => {
   const mockAgent = new MockAgent({ connections: 1 });
+  mockAgent.disableNetConnect();
   const client = mockAgent.get(baseUrl);
   if (!clients.has(baseUrl)) {
     clients.set(baseUrl, client);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,9 +238,6 @@ importers:
       JSONPath:
         specifier: ^0.10.0
         version: 0.10.0
-      form-data:
-        specifier: ^4.0.0
-        version: 4.0.0
       js2xmlparser:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2321,7 +2318,7 @@ packages:
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2548,7 +2545,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.0
       '@babel/types': 7.23.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4943,7 +4940,6 @@ packages:
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       set-function-length: 1.2.2
-    dev: false
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -5721,6 +5717,17 @@ packages:
       supports-color: 8.1.1
     dev: true
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -5827,7 +5834,6 @@ packages:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
-    dev: false
 
   /define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
@@ -6198,12 +6204,10 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.2.4
-    dev: false
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-    dev: false
 
   /es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
@@ -7303,7 +7307,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: false
 
   /function.prototype.name@1.1.5:
     resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
@@ -7387,7 +7390,6 @@ packages:
       has-proto: 1.0.1
       has-symbols: 1.0.3
       hasown: 2.0.2
-    dev: false
 
   /get-port@3.2.0:
     resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
@@ -7601,7 +7603,7 @@ packages:
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.4
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -7690,7 +7692,6 @@ packages:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
     dependencies:
       es-define-property: 1.0.0
-    dev: false
 
   /has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
@@ -7756,7 +7757,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: false
 
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
@@ -9761,7 +9761,7 @@ packages:
     resolution: {integrity: sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==}
     engines: {node: '>= 10.13'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       propagate: 2.0.1
@@ -11309,7 +11309,6 @@ packages:
       get-intrinsic: 1.2.4
       gopd: 1.0.1
       has-property-descriptors: 1.0.2
-    dev: false
 
   /set-value@2.0.1:
     resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==}
@@ -11361,8 +11360,8 @@ packages:
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
       object-inspect: 1.12.3
 
   /signal-exit@3.0.7:
@@ -11991,10 +11990,11 @@ packages:
   /superagent@8.0.9:
     resolution: {integrity: sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==}
     engines: {node: '>=6.4.0 <13 || >=14'}
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
     dependencies:
       component-emitter: 1.3.0
       cookiejar: 2.1.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 2.1.2


### PR DESCRIPTION
Fixes to the `submitXls` function

Since switching from axios to undici, the submitXls function has failed. There are many reasons for this:

* commcare uses `form-data`, but it shouldn't. Using the `form-data` object made the common helper not recognise the form data and encode the payload into a string
* It turns out that when sending form data, we explicitly must not pass a header value. Unidici will work it out with the boundary encoding. So there's some fixes around this

I've also added a unit test for submitxls. It's not very good coverage but it's a start!

There is a tiny change to common because the test agent was calling out to the internet and hitting actual commcare servers. I thought we'd disabled that - but I've done it now.

No changesets are required for this PR