### PR TITLE
Commcare: Get function handler

### DIFF
--- a/.changeset/strong-items-lay.md
+++ b/.changeset/strong-items-lay.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-commcare': major
+---
+
+Implemented a get function for all get requests in commcare

--- a/.changeset/young-bees-wait.md
+++ b/.changeset/young-bees-wait.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': major
+---
+
+Ensure redirects append base url

--- a/packages/commcare/ast.json
+++ b/packages/commcare/ast.json
@@ -1,6 +1,112 @@
 {
   "operations": [
     {
+      "name": "get",
+      "params": [
+        "path",
+        "params"
+      ],
+      "docs": {
+        "description": "Make a get request to any commcare endpoint",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "get(\n   \"case\"\n   {\n     limit: 1,\n     offset:0,\n   }\n)"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Path to resource",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "path"
+          },
+          {
+            "title": "param",
+            "description": "Optional request params such as limit and offset.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "params"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
+      "name": "getCases",
+      "params": [
+        "path",
+        "params"
+      ],
+      "docs": {
+        "description": "Make a get request to any commcare endpoint",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "getCases(\n   \"case\"\n   {\n     limit: 1,\n     offset:0,\n   }\n)"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Path to resource",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "path"
+          },
+          {
+            "title": "param",
+            "description": "Optional request params such as limit and offset.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "params"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "submitXls",
       "params": [
         "formData",

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -29,6 +29,7 @@
     "JSONPath": "^0.10.0",
     "js2xmlparser": "^1.0.0",
     "lodash-fp": "^0.10.4",
+    "sinon": "^18.0.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"
   },
   "devDependencies": {

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -54,16 +54,21 @@ export function get(path, params = {}) {
       params
     );
 
-    const response = await request(
-      state.configuration,
-      `/a/${applicationName}/api/v0.5/${resolvedPath}`,
-      {
-        method: 'GET',
-        params: resolvedParams,
-      }
-    );
+    try {
+      const response = await request(
+        state.configuration,
+        `/a/${applicationName}/api/v0.5/${resolvedPath}`,
+        {
+          method: 'GET',
+          params: resolvedParams,
+          contentType: 'application/json',
+        }
+      );
 
-    return prepareNextState(state, response);
+      return prepareNextState(state, response);
+    } catch (e) {
+      throw e.body ?? e;
+    }
   };
 }
 
@@ -192,6 +197,7 @@ export function fetchReportData(reportId, params, postUrl) {
 
     const { body: reportData } = await request(state.configuration, path, {
       method: 'GET',
+      contentType: 'application/json',
     });
 
     const result = await request(state.configuration, postUrl, {

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -74,6 +74,7 @@ export function get(path, params = {}, callback = s => s) {
           contentType: 'application/json',
         }
       );
+      console.log({response});
 
       return prepareNextState(state, response, callback);
     } catch (e) {

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -74,7 +74,6 @@ export function get(path, params = {}, callback = s => s) {
           contentType: 'application/json',
         }
       );
-      console.log({response});
 
       return prepareNextState(state, response, callback);
     } catch (e) {

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -40,6 +40,9 @@ export function execute(...operations) {
  *      offset:0,
  *    }
  * )
+ * // The returned objects will be written into state.data,
+ * // and the meta object will be written to state.response
+ * // along with the status code and returned headers.
  * @function
  * @param {string} path - Path to resource
  * @param {Object} params - Optional request params such as limit and offset.

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -29,6 +29,44 @@ export function execute(...operations) {
 }
 
 /**
+ * Make a get request to any commcare endpoint
+ * @public
+ * @example
+ * get(
+ *    "case"
+ *    {
+ *      limit: 1,
+ *      offset:0,
+ *    }
+ * )
+ * @function
+ * @param {string} path - Path to resource
+ * @param {Object} params - Optional request params such as limit and offset.
+ * @returns {Operation}
+ */
+export function get(path, params = {}) {
+  return async state => {
+    const { applicationName } = state.configuration;
+    const [resolvedPath, resolvedParams] = expandReferences(
+      state,
+      path,
+      params
+    );
+
+    const response = await request(
+      state.configuration,
+      `/a/${applicationName}/api/v0.5/${resolvedPath}`,
+      {
+        method: 'GET',
+        params: resolvedParams,
+      }
+    );
+
+    return prepareNextState(state, response);
+  };
+}
+
+/**
  * Convert form data to xls then submit.
  * @public
  * @example
@@ -158,14 +196,12 @@ export function fetchReportData(reportId, params, postUrl) {
 
     const { body: reportData } = await request(state.configuration, path, {
       method: 'GET',
-      authType: 'basic',
     });
 
     const result = await request(state.configuration, postUrl, {
       method: 'POST',
       params,
       data: reportData,
-      authType: 'basic',
     });
 
     delete result.response;

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -52,9 +52,10 @@ export function execute(...operations) {
  * @function
  * @param {string} path - Path to resource
  * @param {Object} params - Optional request params such as limit and offset.
+ * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
-export function get(path, params = {}) {
+export function get(path, params = {}, callback = s => s) {
   return async state => {
     const { applicationName } = state.configuration;
     const [resolvedPath, resolvedParams] = expandReferences(
@@ -74,7 +75,7 @@ export function get(path, params = {}) {
         }
       );
 
-      return prepareNextState(state, response);
+      return prepareNextState(state, response, callback);
     } catch (e) {
       throw e.body ?? e;
     }

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -31,8 +31,9 @@ export function execute(...operations) {
 
 /**
  * Make a get request to any commcare endpoint
+ * - The response returned is {meta:{}, objects:[]}. These are destructured where objects will be written into state.data and meta into state.response along with the status code and returned headers.
  * @public
- * @example
+ * @example <caption>Get a list of cases</caption>
  * get(
  *    "case"
  *    {
@@ -40,9 +41,14 @@ export function execute(...operations) {
  *      offset:0,
  *    }
  * )
- * // The returned objects will be written into state.data,
- * // and the meta object will be written to state.response
- * // along with the status code and returned headers.
+ *  * @example <caption>Get a specific case </caption>
+ * get(
+ *    "case/12345"
+ *    {
+ *      limit: 1,
+ *      offset:0,
+ *    }
+ * )
  * @function
  * @param {string} path - Path to resource
  * @param {Object} params - Optional request params such as limit and offset.

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -31,19 +31,18 @@ export const prepareNextState = (state, response, callback = s => s) => {
   return callback(nextState);
 };
 
-export function request(configuration, path, opts) {
+export async function request(configuration, path, opts) {
   const { hostUrl } = configuration;
 
   const {
     method,
-    data = {},
+    data,
     params = {},
     headers: customHeaders = {},
     contentType,
     parseAs = 'json',
   } = opts;
 
-  console.log({opts});
   const headers = configureAuth(configuration, customHeaders);
   if (contentType) {
     headers['content-type'] = contentType;
@@ -54,10 +53,9 @@ export function request(configuration, path, opts) {
     headers,
     query: params,
     parseAs,
+    maxRedirections: 100,
+    baseUrl: hostUrl,
   };
 
-  console.log({options});
-
-  const url = `${hostUrl}${path}`;
-  return commonRequest(method, url, options).then(logResponse);
+  return commonRequest(method, path, options).then(logResponse);
 }

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -36,13 +36,14 @@ export function request(configuration, path, opts) {
 
   const {
     method,
-    data,
+    data = {},
     params = {},
     headers = {},
     contentType = 'application/json',
     parseAs = 'json',
   } = opts;
 
+  console.log({opts});
   const options = {
     body: data,
     headers: {
@@ -51,8 +52,10 @@ export function request(configuration, path, opts) {
       ...headers,
     },
     query: params,
-    parseAs: parseAs,
+    parseAs,
   };
+
+  console.log({options});
 
   const url = `${hostUrl}${path}`;
 

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -24,7 +24,7 @@ export const configureAuth = (auth, headers = {}) => {
 export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
   const nextState = {
-    ...composeNextState(state, body.objects ? body.objects : response.body),
+    ...composeNextState(state, body.objects ?? body),
     response: {...responseWithoutBody, ...{meta:body.meta}},
   };
 

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -25,8 +25,7 @@ export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
   const nextState = {
     ...composeNextState(state, body.objects ? body.objects : response.body),
-    response: responseWithoutBody,
-    references: [body.meta || {}],
+    response: {...responseWithoutBody, ...{meta:body.meta}},
   };
 
   return callback(nextState);

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -53,7 +53,7 @@ export async function request(configuration, path, opts) {
     headers,
     query: params,
     parseAs,
-    maxRedirections: 100,
+    maxRedirections: 1,
     baseUrl: hostUrl,
   };
 

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -24,8 +24,9 @@ export const configureAuth = (auth, headers = {}) => {
 export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
   const nextState = {
-    ...composeNextState(state, response.body),
+    ...composeNextState(state, body.objects ? body.objects : response.body),
     response: responseWithoutBody,
+    references: [body.meta || {}],
   };
 
   return callback(nextState);

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -132,4 +132,38 @@ describe('getCases', () => {
 
     expect(data.data[0]).to.haveOwnProperty('case_id');
   });
+
+  it('should fetch a single case', async () => {
+    testServer
+      .intercept({
+        path: `/a/${domain}/api/v0.5/case/12345`,
+        method: 'GET',
+      })
+      .reply(200, () => {
+        // simulate a return from commcare
+        return {
+          data: {
+            case_id: '12345',
+            properties: { case_type: 'pregnancy', case_name: 'Jane' },
+          },
+        };
+      });
+
+    const state = {
+      configuration: {
+        hostUrl,
+        applicationName: domain,
+        appId: app,
+        username: 'user',
+        password: 'password',
+      },
+    };
+
+    const { data } = await execute(get('case/12345'))(state);
+
+    // The response  should be on state.data
+
+    expect(data.data.case_id).to.equal('12345');
+    expect(data.data.properties.case_type).to.equal('pregnancy');
+  });
 });

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -130,6 +130,7 @@ describe('getCases', () => {
     const { data, response } = await execute(get('case'))(state);
 
     expect(data[0]).to.haveOwnProperty('case_id');
+    expect(data.length).to.equal(1);
     expect(response.meta.limit).to.equal(1);
   });
 
@@ -142,13 +143,8 @@ describe('getCases', () => {
       .reply(200, () => {
         // simulate a return from commcare
         return {
-          meta: { limit: 5 },
-          objects: [
-            {
-              case_id: '12345',
-              properties: { case_type: 'pregnancy', case_name: 'Jane' },
-            },
-          ],
+          case_id: '12345',
+          properties: { case_type: 'pregnancy', case_name: 'Jane' },
         };
       });
 
@@ -162,10 +158,9 @@ describe('getCases', () => {
       },
     };
 
-    const { data, response } = await execute(get('case/12345'))(state);
+    const { data } = await execute(get('case/12345'))(state);
 
-    expect(data[0].case_id).to.equal('12345');
-    expect(data[0].properties.case_type).to.equal('pregnancy');
-    expect(response.meta.limit).to.equal(5);
+    expect(data.case_id).to.equal('12345');
+    expect(data.properties.case_type).to.equal('pregnancy');
   });
 });

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -108,12 +108,22 @@ describe('getCases', () => {
         method: 'GET',
       })
       .reply(200, req => {
-        // save out the form data that was upladed
         method = req.method;
         path = req.path;
 
         // simulate a return from commcare
-        return { code: 200, message: 'success' };
+        return {
+          code: 200,
+          message: 'success',
+          meta: { limit: 2 },
+          objects: [
+            {
+              case_id: '12345',
+              properties: { case_type: 'pregnancy', case_name: 'Jane' },
+            },
+          ],
+         
+        };
       });
 
     const state = {
@@ -131,6 +141,9 @@ describe('getCases', () => {
     // The response  should be on state.data
     expect(data.code).to.equal(200);
     expect(data.message).to.equal('success');
+    expect(data.meta.limit).to.equal(2)
+    expect(data.objects[0]).to.haveOwnProperty('case_id');
+
 
     // And the adaptor should have uploaded a reasonable looking formdata object
     expect(method).to.equal('GET');

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -99,22 +99,14 @@ describe('SubmitXls', () => {
 
 describe('getCases', () => {
   it('should fetch cases', async () => {
-    let method;
-    let path;
-
     testServer
       .intercept({
         path: `/a/${domain}/api/v0.5/case`,
         method: 'GET',
       })
-      .reply(200, req => {
-        method = req.method;
-        path = req.path;
-
+      .reply(200, () => {
         // simulate a return from commcare
         return {
-          code: 200,
-          message: 'success',
           data: [
             {
               case_id: '12345',
@@ -137,12 +129,7 @@ describe('getCases', () => {
     const { data } = await execute(get('case'))(state);
 
     // The response  should be on state.data
-    expect(data.code).to.equal(200);
-    expect(data.message).to.equal('success');
-    expect(data.data[0]).to.haveOwnProperty('case_id');
 
-    // And the adaptor should have uploaded a reasonable looking formdata object
-    expect(method).to.equal('GET');
-    expect(path).to.equal('/a/my-domain/api/v0.5/case');
+    expect(data.data[0]).to.haveOwnProperty('case_id');
   });
 });

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -107,7 +107,8 @@ describe('getCases', () => {
       .reply(200, () => {
         // simulate a return from commcare
         return {
-          data: [
+          meta: { limit: 1 },
+          objects: [
             {
               case_id: '12345',
               properties: { case_type: 'pregnancy', case_name: 'Jane' },
@@ -126,11 +127,10 @@ describe('getCases', () => {
       },
     };
 
-    const { data } = await execute(get('case'))(state);
+    const { data, response } = await execute(get('case'))(state);
 
-    // The response  should be on state.data
-
-    expect(data.data[0]).to.haveOwnProperty('case_id');
+    expect(data[0]).to.haveOwnProperty('case_id');
+    expect(response.meta.limit).to.equal(1);
   });
 
   it('should fetch a single case', async () => {
@@ -142,10 +142,13 @@ describe('getCases', () => {
       .reply(200, () => {
         // simulate a return from commcare
         return {
-          data: {
-            case_id: '12345',
-            properties: { case_type: 'pregnancy', case_name: 'Jane' },
-          },
+          meta: { limit: 5 },
+          objects: [
+            {
+              case_id: '12345',
+              properties: { case_type: 'pregnancy', case_name: 'Jane' },
+            },
+          ],
         };
       });
 
@@ -159,11 +162,10 @@ describe('getCases', () => {
       },
     };
 
-    const { data } = await execute(get('case/12345'))(state);
+    const { data, response } = await execute(get('case/12345'))(state);
 
-    // The response  should be on state.data
-
-    expect(data.data.case_id).to.equal('12345');
-    expect(data.data.properties.case_type).to.equal('pregnancy');
+    expect(data[0].case_id).to.equal('12345');
+    expect(data[0].properties.case_type).to.equal('pregnancy');
+    expect(response.meta.limit).to.equal(5);
   });
 });

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -115,14 +115,12 @@ describe('getCases', () => {
         return {
           code: 200,
           message: 'success',
-          meta: { limit: 2 },
-          objects: [
+          data: [
             {
               case_id: '12345',
               properties: { case_type: 'pregnancy', case_name: 'Jane' },
             },
           ],
-         
         };
       });
 
@@ -141,9 +139,7 @@ describe('getCases', () => {
     // The response  should be on state.data
     expect(data.code).to.equal(200);
     expect(data.message).to.equal('success');
-    expect(data.meta.limit).to.equal(2)
-    expect(data.objects[0]).to.haveOwnProperty('case_id');
-
+    expect(data.data[0]).to.haveOwnProperty('case_id');
 
     // And the adaptor should have uploaded a reasonable looking formdata object
     expect(method).to.equal('GET');

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -4,6 +4,8 @@ import { execute, submitXls, get } from '../src';
 
 const hostUrl = 'http://example.commcare.com';
 const testServer = enableMockClient(hostUrl);
+const domain = 'my-domain';
+const app = 'my-app';
 
 describe('execute', () => {
   it('executes each operation in sequence', done => {
@@ -50,9 +52,6 @@ describe('execute', () => {
 
 describe('SubmitXls', () => {
   it('should submit JSON as an xls file', async () => {
-    const domain = 'my-domain';
-    const app = 'my-app';
-
     let formdata;
 
     testServer
@@ -100,9 +99,6 @@ describe('SubmitXls', () => {
 
 describe('getCases', () => {
   it('should fetch cases', async () => {
-    const domain = 'my-domain';
-    const app = 'my-app';
-
     let method;
     let path;
 
@@ -114,7 +110,7 @@ describe('getCases', () => {
       .reply(200, req => {
         // save out the form data that was upladed
         method = req.method;
-        path=req.path;
+        path = req.path;
 
         // simulate a return from commcare
         return { code: 200, message: 'success' };
@@ -130,9 +126,7 @@ describe('getCases', () => {
       },
     };
 
-    const { data } = await execute(
-      get("case")
-    )(state);
+    const { data } = await execute(get('case'))(state);
 
     // The response  should be on state.data
     expect(data.code).to.equal(200);
@@ -141,6 +135,5 @@ describe('getCases', () => {
     // And the adaptor should have uploaded a reasonable looking formdata object
     expect(method).to.equal('GET');
     expect(path).to.equal('/a/my-domain/api/v0.5/case');
-
   });
 });

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -108,11 +108,42 @@ describe('getCases', () => {
       .reply(200, () => {
         // simulate a return from commcare
         return {
-          meta: { limit: 1 },
+          meta: {
+            limit: 1,
+            next: null,
+            offset: 0,
+            previous: null,
+            total_count: 2,
+          },
           objects: [
             {
               case_id: '12345',
-              properties: { case_type: 'pregnancy', case_name: 'Jane' },
+              closed: false,
+              closed_by: null,
+              date_closed: null,
+              date_modified: 'xxxxx',
+              domain: `${domain}`,
+              id: '12345',
+              indexed_on: 'xxxxx',
+              indices: {},
+              opened_by: 'xxxxx',
+              properties: {
+                Children_alive: 'no',
+                Last_menstrual_period: 'xxxx',
+                Total_children: '',
+                case_name: 'Jane',
+                case_type: 'pregnancy',
+                date_opened: 'xxxxx',
+                external_id: null,
+                feeling_sick: 'No',
+                owner_id: 'xxxxxx',
+                village_name: 'Somewhere',
+              },
+              resource_uri: '',
+              server_date_modified: 'xxxxx',
+              server_date_opened: 'xxxxx',
+              user_id: 'xxxxx',
+              xform_ids: ['xxxx'],
             },
           ],
         };
@@ -130,8 +161,8 @@ describe('getCases', () => {
 
     const { data, response } = await execute(get('case'))(state);
 
-    expect(data[0]).to.haveOwnProperty('case_id');
     expect(data.length).to.equal(1);
+    expect(data[0]).to.haveOwnProperty('case_id');
     expect(response.meta.limit).to.equal(1);
   });
 
@@ -145,7 +176,32 @@ describe('getCases', () => {
         // simulate a return from commcare
         return {
           case_id: '12345',
-          properties: { case_type: 'pregnancy', case_name: 'Jane' },
+          closed: false,
+          closed_by: null,
+          date_closed: null,
+          date_modified: 'xxxxx',
+          domain: `${domain}`,
+          id: '12345',
+          indexed_on: 'xxxxx',
+          indices: {},
+          opened_by: 'xxxxx',
+          properties: {
+            Children_alive: 'no',
+            Last_menstrual_period: 'xxxx',
+            Total_children: '',
+            case_name: 'Jane',
+            case_type: 'pregnancy',
+            date_opened: 'xxxxx',
+            external_id: null,
+            feeling_sick: 'No',
+            owner_id: 'xxxxxx',
+            village_name: 'Somewhere',
+          },
+          resource_uri: '',
+          server_date_modified: 'xxxxx',
+          server_date_opened: 'xxxxx',
+          user_id: 'xxxxx',
+          xform_ids: ['xxxx'],
         };
       });
 
@@ -174,11 +230,42 @@ describe('getCases', () => {
       .reply(200, () => {
         // simulate a return from commcare
         return {
-          meta: { limit: 1 },
+          meta: {
+            limit: 1,
+            next: null,
+            offset: 0,
+            previous: null,
+            total_count: 2,
+          },
           objects: [
             {
               case_id: '12345',
-              properties: { case_type: 'pregnancy', case_name: 'Jane' },
+              closed: false,
+              closed_by: null,
+              date_closed: null,
+              date_modified: 'xxxxx',
+              domain: `${domain}`,
+              id: '12345',
+              indexed_on: 'xxxxx',
+              indices: {},
+              opened_by: 'xxxxx',
+              properties: {
+                Children_alive: 'no',
+                Last_menstrual_period: 'xxxx',
+                Total_children: '',
+                case_name: 'Jane',
+                case_type: 'pregnancy',
+                date_opened: 'xxxxx',
+                external_id: null,
+                feeling_sick: 'No',
+                owner_id: 'xxxxxx',
+                village_name: 'Somewhere',
+              },
+              resource_uri: '',
+              server_date_modified: 'xxxxx',
+              server_date_opened: 'xxxxx',
+              user_id: 'xxxxx',
+              xform_ids: ['xxxx'],
             },
           ],
         };
@@ -203,7 +290,32 @@ describe('getCases', () => {
     expect(callbackArg.data).to.deep.equal([
       {
         case_id: '12345',
-        properties: { case_type: 'pregnancy', case_name: 'Jane' },
+        closed: false,
+        closed_by: null,
+        date_closed: null,
+        date_modified: 'xxxxx',
+        domain: `${domain}`,
+        id: '12345',
+        indexed_on: 'xxxxx',
+        indices: {},
+        opened_by: 'xxxxx',
+        properties: {
+          Children_alive: 'no',
+          Last_menstrual_period: 'xxxx',
+          Total_children: '',
+          case_name: 'Jane',
+          case_type: 'pregnancy',
+          date_opened: 'xxxxx',
+          external_id: null,
+          feeling_sick: 'No',
+          owner_id: 'xxxxxx',
+          village_name: 'Somewhere',
+        },
+        resource_uri: '',
+        server_date_modified: 'xxxxx',
+        server_date_opened: 'xxxxx',
+        user_id: 'xxxxx',
+        xform_ids: ['xxxx'],
       },
     ]);
   });

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -146,6 +146,7 @@ export async function request(method, fullUrlOrPath, options = {}) {
     maxRedirections,
     bodyTimeout: timeout,
     headersTimeout: timeout,
+    // If the request is redirected, undici requires the origin to be set (this affects commcare)
     origin: baseUrl,
   });
 

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -146,6 +146,7 @@ export async function request(method, fullUrlOrPath, options = {}) {
     maxRedirections,
     bodyTimeout: timeout,
     headersTimeout: timeout,
+    origin: baseUrl,
   });
 
   const statusText = getReasonPhrase(response.statusCode);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       lodash-fp:
         specifier: ^0.10.4
         version: 0.10.4
+      sinon:
+        specifier: ^18.0.0
+        version: 18.0.0
       xlsx:
         specifier: https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz
         version: '@cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz'
@@ -2318,7 +2321,7 @@ packages:
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2545,7 +2548,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.0
       '@babel/types': 7.23.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3193,7 +3196,6 @@ packages:
     resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
     dependencies:
       type-detect: 4.0.8
-    dev: true
 
   /@sinonjs/commons@3.0.0:
     resolution: {integrity: sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==}
@@ -3201,11 +3203,23 @@ packages:
       type-detect: 4.0.8
     dev: true
 
+  /@sinonjs/commons@3.0.1:
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+    dependencies:
+      type-detect: 4.0.8
+    dev: false
+
   /@sinonjs/fake-timers@10.3.0:
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
     dependencies:
       '@sinonjs/commons': 3.0.0
     dev: true
+
+  /@sinonjs/fake-timers@11.2.2:
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+    dev: false
 
   /@sinonjs/fake-timers@6.0.1:
     resolution: {integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==}
@@ -3235,9 +3249,16 @@ packages:
       type-detect: 4.0.8
     dev: true
 
+  /@sinonjs/samsam@8.0.0:
+    resolution: {integrity: sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==}
+    dependencies:
+      '@sinonjs/commons': 2.0.0
+      lodash.get: 4.4.2
+      type-detect: 4.0.8
+    dev: false
+
   /@sinonjs/text-encoding@0.7.2:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
-    dev: true
 
   /@slack/logger@3.0.0:
     resolution: {integrity: sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==}
@@ -5717,17 +5738,6 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -5948,6 +5958,11 @@ packages:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
     dev: true
+
+  /diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+    dev: false
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -8788,6 +8803,10 @@ packages:
     resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
     dev: true
 
+  /just-extend@6.2.0:
+    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
+    dev: false
+
   /jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
     dependencies:
@@ -9733,6 +9752,16 @@ packages:
       path-to-regexp: 1.8.0
     dev: true
 
+  /nise@6.0.0:
+    resolution: {integrity: sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/text-encoding': 0.7.2
+      just-extend: 6.2.0
+      path-to-regexp: 6.2.2
+    dev: false
+
   /nock@12.0.3:
     resolution: {integrity: sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==}
     engines: {node: '>= 10.13'}
@@ -9761,7 +9790,7 @@ packages:
     resolution: {integrity: sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==}
     engines: {node: '>= 10.13'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       propagate: 2.0.1
@@ -10370,6 +10399,10 @@ packages:
     dependencies:
       isarray: 0.0.1
     dev: true
+
+  /path-to-regexp@6.2.2:
+    resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
+    dev: false
 
   /path-type@2.0.0:
     resolution: {integrity: sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ==}
@@ -11379,6 +11412,7 @@ packages:
 
   /sinon@14.0.2:
     resolution: {integrity: sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==}
+    deprecated: 16.1.1
     dependencies:
       '@sinonjs/commons': 2.0.0
       '@sinonjs/fake-timers': 9.1.2
@@ -11387,6 +11421,17 @@ packages:
       nise: 5.1.4
       supports-color: 7.2.0
     dev: true
+
+  /sinon@18.0.0:
+    resolution: {integrity: sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.0
+      diff: 5.2.0
+      nise: 6.0.0
+      supports-color: 7.2.0
+    dev: false
 
   /sinon@9.2.4:
     resolution: {integrity: sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==}
@@ -11994,7 +12039,7 @@ packages:
     dependencies:
       component-emitter: 1.3.0
       cookiejar: 2.1.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 2.1.2
@@ -12476,7 +12521,6 @@ packages:
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
-    dev: true
 
   /type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}


### PR DESCRIPTION
## Summary

Creating a `get` function to be used to fetch data from `commcare`

## Details

Commcare does not have a get handler that can be used to fetch various data. The `get` function will be used to fetch data such as `case, forms`.

## Issues

#528 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
