### PR TITLE
`fhir` Update configuratio-schema

### DIFF
--- a/.changeset/rare-toys-clap.md
+++ b/.changeset/rare-toys-clap.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-fhir': patch
+---
+
+- Update `create()` example
+- Update required properties in configuration schema

--- a/.changeset/rare-toys-clap.md
+++ b/.changeset/rare-toys-clap.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-fhir': patch
----
-
-- Update `create()` example
-- Update required properties in configuration schema

--- a/packages/fhir/CHANGELOG.md
+++ b/packages/fhir/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir
 
+## 3.1.2
+
+### Patch Changes
+
+- 2b283549: - Update `create()` example
+  - Update required properties in configuration schema
+
 ## 3.1.1
 
 ### Patch Changes

--- a/packages/fhir/ast.json
+++ b/packages/fhir/ast.json
@@ -17,7 +17,7 @@
           },
           {
             "title": "example",
-            "description": "create(\"Bundle\", {...state.data: type: \"collection\"})"
+            "description": "create(\"Bundle\", {\n  entry: [\n    {\n      fullUrl: \"\", // Eg: Patient URL\n      resource: {}, // Resource data\n      search: {\n        mode: \"match\",\n      },\n    },\n  ],\n  type: \"collection\",\n});"
           },
           {
             "title": "function",

--- a/packages/fhir/configuration-schema.json
+++ b/packages/fhir/configuration-schema.json
@@ -7,7 +7,7 @@
             "type": "string",
             "description": "The baseUrl",
             "examples": [
-                "https://hapi.fhir.org/baseR4"
+                "https://hapi.fhir.org"
             ]
         },
         "apiPath": {
@@ -47,8 +47,7 @@
         }
     },
     "required": [
-        "resource",
-        "authType",
-        "token"
+        "baseUrl",
+        "apiPath"
     ]
 }

--- a/packages/fhir/package.json
+++ b/packages/fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-fhir",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A FHIR adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/fhir/src/Adaptor.js
+++ b/packages/fhir/src/Adaptor.js
@@ -33,7 +33,18 @@ export function execute(...operations) {
  * Creates a resource in a destination system using a POST request
  * @public
  * @example
- * create("Bundle", {...state.data: type: "collection"})
+ * create("Bundle", {
+ *   entry: [
+ *     {
+ *       fullUrl: "", // Eg: Patient URL
+ *       resource: {}, // Resource data
+ *       search: {
+ *         mode: "match",
+ *       },
+ *     },
+ *   ],
+ *   type: "collection",
+ * });
  * @function
  * @param {string} path - Path to resource
  * @param {object} params - data to create the new resource


### PR DESCRIPTION
## Summary

Update required properties in configuration schema and improved the `create()` example

## Details

The required properties for `fhir` adaptor were wrong, `resource` property doesn't exist and the other properties were not required. This PR update the required properties list to contain only the required items


## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
