### PR TITLE
Feature/562 update commcare configuration

### DIFF
--- a/.changeset/tall-pianos-happen.md
+++ b/.changeset/tall-pianos-happen.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-commcare': major
+---
+
+Change applicationName to domain to match commcare's configuration. The change has been applied to the configuration schema and the code. Add apiKey to the config schema. Ensure username and appId are optional configuration fields

--- a/packages/commcare/ast.json
+++ b/packages/commcare/ast.json
@@ -4,10 +4,11 @@
       "name": "get",
       "params": [
         "path",
-        "params"
+        "params",
+        "callback"
       ],
       "docs": {
-        "description": "Make a get request to any commcare endpoint",
+        "description": "Make a get request to any commcare endpoint\n- The response returned is {meta:{}, objects:[]}. These are destructured where objects will be written into state.data and meta into state.response along with the status code and returned headers.",
         "tags": [
           {
             "title": "public",
@@ -16,7 +17,8 @@
           },
           {
             "title": "example",
-            "description": "get(\n   \"case\"\n   {\n     limit: 1,\n     offset:0,\n   }\n)"
+            "description": "get(\n   \"case\"\n   {\n     limit: 1,\n     offset:0,\n   }\n)\n * @example <caption>Get a specific case </caption>\nget(\n   \"case/12345\"\n   {\n     limit: 1,\n     offset:0,\n   }\n)",
+            "caption": "Get a list of cases"
           },
           {
             "title": "function",
@@ -42,57 +44,16 @@
             "name": "params"
           },
           {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "Operation"
-            }
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
-      "name": "getCases",
-      "params": [
-        "path",
-        "params"
-      ],
-      "docs": {
-        "description": "Make a get request to any commcare endpoint",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "example",
-            "description": "getCases(\n   \"case\"\n   {\n     limit: 1,\n     offset:0,\n   }\n)"
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Optional callback to handle the response",
             "type": {
-              "type": "NameExpression",
-              "name": "string"
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "function"
+              }
             },
-            "name": "path"
-          },
-          {
-            "title": "param",
-            "description": "Optional request params such as limit and offset.",
-            "type": {
-              "type": "NameExpression",
-              "name": "Object"
-            },
-            "name": "params"
+            "name": "callback"
           },
           {
             "title": "returns",

--- a/packages/commcare/configuration-schema.json
+++ b/packages/commcare/configuration-schema.json
@@ -11,13 +11,22 @@
                 "https://www.commcarehq.org"
             ]
         },
-        "applicationName": {
-            "title": "Application Name",
+        "domain": {
+            "title": "Domain",
             "type": "string",
-            "description": "The CommCare application name",
+            "description": "The CommCare domain name",
             "minLength": 1,
             "examples": [
                 "some-proof-of-concept"
+            ]
+        },
+        "apiKey": {
+            "title": "API Key",
+            "type": "string",
+            "description": "The CommCare API Key",
+            "minLength": 1,
+            "examples": [
+                "the-long-uuid-provided-by-commcare-that-authenticates-requests"
             ]
         },
         "appId": {
@@ -53,7 +62,6 @@
     "additionalProperties": true,
     "required": [
         "hostUrl",
-        "applicationName",
-        "appId"
+        "domain"
     ]
 }

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -57,7 +57,7 @@ export function execute(...operations) {
  */
 export function get(path, params = {}, callback = s => s) {
   return async state => {
-    const { applicationName } = state.configuration;
+    const { domain } = state.configuration;
     const [resolvedPath, resolvedParams] = expandReferences(
       state,
       path,
@@ -67,7 +67,7 @@ export function get(path, params = {}, callback = s => s) {
     try {
       const response = await request(
         state.configuration,
-        `/a/${applicationName}/api/v0.5/${resolvedPath}`,
+        `/a/${domain}/api/v0.5/${resolvedPath}`,
         {
           method: 'GET',
           params: resolvedParams,
@@ -103,12 +103,12 @@ export function get(path, params = {}, callback = s => s) {
  */
 export function submitXls(formData, params) {
   return async state => {
-    const { applicationName } = state.configuration;
+    const { domain } = state.configuration;
 
     const [json] = expandReferences(state, formData);
     const { case_type, search_field, create_new_cases } = params;
 
-    const path = `/a/${applicationName}/importer/excel/bulk_upload_api/`;
+    const path = `/a/${domain}/importer/excel/bulk_upload_api/`;
 
     const workbook = xlsx.utils.book_new();
     const worksheet = xlsx.utils.json_to_sheet(json);
@@ -167,11 +167,11 @@ export function submit(formData) {
     const {
       // this should be called project URL.
       // it is what lives after www.commcarehq.org/a/...
-      applicationName,
+      domain,
       appId,
     } = state.configuration;
 
-    const path = `/a/${applicationName}/receiver/${appId}/`;
+    const path = `/a/${domain}/receiver/${appId}/`;
 
     console.log('Raw JSON body: '.concat(JSON.stringify(jsonBody)));
     console.log('X-form submission: '.concat(body));
@@ -201,7 +201,7 @@ export function submit(formData) {
  */
 export function fetchReportData(reportId, params, postUrl) {
   return async state => {
-    const path = `/a/${state.configuration.applicationName}/api/v0.5/configurablereportdata/${reportId}/`;
+    const path = `/a/${state.configuration.domain}/api/v0.5/configurablereportdata/${reportId}/`;
 
     console.log('with params: '.concat(JSON.stringify(params)));
 

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -165,8 +165,6 @@ export function submit(formData) {
     const body = js2xmlparser('data', jsonBody);
 
     const {
-      // this should be called project URL.
-      // it is what lives after www.commcarehq.org/a/...
       domain,
       appId,
     } = state.configuration;

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -71,7 +71,7 @@ describe('SubmitXls', () => {
     const state = {
       configuration: {
         hostUrl,
-        applicationName: domain,
+        domain,
         appId: app,
         username: 'user',
         password: 'password',
@@ -152,7 +152,7 @@ describe('getCases', () => {
     const state = {
       configuration: {
         hostUrl,
-        applicationName: domain,
+        domain,
         appId: app,
         username: 'user',
         password: 'password',
@@ -208,7 +208,7 @@ describe('getCases', () => {
     const state = {
       configuration: {
         hostUrl,
-        applicationName: domain,
+        domain,
         appId: app,
         username: 'user',
         password: 'password',
@@ -274,7 +274,7 @@ describe('getCases', () => {
     const state = {
       configuration: {
         hostUrl,
-        applicationName: domain,
+        domain,
         appId: app,
         username: 'user',
         password: 'password',


### PR DESCRIPTION
## Summary

Add apiKey and change applicationname to domain in commcare configuration schema

## Details

The adaptor currently uses `applicationName` as the `domain` name. to avoid conflicts, we are renaming `applicationName` to match commcare's definition: `domain`.
`apiKey` is also being added to the configuration schema as an optional field together with `username` and `appId` which have been made optional.

## Issues

#562 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
