### PR TITLE
Commcare: Implement generic `post` function

### DIFF
--- a/.changeset/proud-impalas-act.md
+++ b/.changeset/proud-impalas-act.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-commcare': major
+---
+
+Create a generic post fucntion that allows for posting JSON data

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -86,8 +86,10 @@ export function get(path, params = {}, callback = s => s) {
  * Make a post request to commcare
  * @example
  * post(
- *   "idgen/identifiersource/8549f706-7e85-4c1d-9424-217d50a2988b/identifier",
- *   {}
+ *   "user",
+ *  {"username":"test",
+ *  "password":"somepassword"},
+ *   (state) =< state.data
  * );
  * @function
  * @param {string} path - Path to resource

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -83,6 +83,49 @@ export function get(path, params = {}, callback = s => s) {
 }
 
 /**
+ * Make a post request to commcare
+ * @example
+ * post(
+ *   "idgen/identifiersource/8549f706-7e85-4c1d-9424-217d50a2988b/identifier",
+ *   {}
+ * );
+ * @function
+ * @param {string} path - Path to resource
+ * @param {object} data - Object or JSON which defines data that will be used to create a given instance of resource
+ * @param {Object} params - Optional request params.
+ * @param {function} [callback] - Optional callback to handle the response
+ * @returns {Operation}
+ */
+export function post(path, data, params = {}, callback = s => s) {
+  return async state => {
+    const { domain } = state.configuration;
+    const [resolvedPath, resolvedData, resolvedParams] = expandReferences(
+      state,
+      path,
+      data,
+      params
+    );
+
+    try {
+      const response = await request(
+        state.configuration,
+        `/a/${domain}/api/v0.5/${resolvedPath}`,
+        {
+          method: 'POST',
+          data: resolvedData,
+          params: resolvedParams,
+          contentType: 'application/json',
+        }
+      );
+
+      return prepareNextState(state, response, callback);
+    } catch (e) {
+      throw e.body.error ?? e;
+    }
+  };
+}
+
+/**
  * Convert form data to xls then submit.
  * @public
  * @example
@@ -164,10 +207,7 @@ export function submit(formData) {
     const [jsonBody] = expandReferences(state, formData);
     const body = js2xmlparser('data', jsonBody);
 
-    const {
-      domain,
-      appId,
-    } = state.configuration;
+    const { domain, appId } = state.configuration;
 
     const path = `/a/${domain}/receiver/${appId}/`;
 

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -88,8 +88,7 @@ export function get(path, params = {}, callback = s => s) {
  * post(
  *   "user",
  *  {"username":"test",
- *  "password":"somepassword"},
- *   (state) =< state.data
+ *  "password":"somepassword"}
  * );
  * @function
  * @param {string} path - Path to resource

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -25,7 +25,7 @@ export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
   const nextState = {
     ...composeNextState(state, body.objects ?? body),
-    response: {...responseWithoutBody, ...{meta:body.meta}},
+    response: { ...responseWithoutBody, ...{ meta: body.meta } },
   };
 
   return callback(nextState);

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -321,7 +321,7 @@ describe('getCases', () => {
   });
 });
 
-describe('createUser', ()=>{
+describe('createUser', () => {
   it('should create a user', async () => {
     testServer
       .intercept({
@@ -331,8 +331,7 @@ describe('createUser', ()=>{
       .reply(201, () => {
         // simulate a return from commcare
         return {
-       
-        id:'123456'
+          id: '123456',
         };
       });
 
@@ -346,18 +345,18 @@ describe('createUser', ()=>{
       },
     };
 
-    const { data, response } = await execute(post('user',{
-      username: 'person',
-      password: 'per1234',
-      first_name: 'Per',
-      last_name: 'Son',
-      default_phone_number: '+50253311399',
-      email: 'person@example.org',
-    }))(state);
+    const { data, response } = await execute(
+      post('user', {
+        username: 'person',
+        password: 'per1234',
+        first_name: 'Per',
+        last_name: 'Son',
+        default_phone_number: '+50253311399',
+        email: 'person@example.org',
+      })
+    )(state);
 
     expect(data).to.haveOwnProperty('id');
     expect(response.statusCode).to.equal(201);
-
-
-  })
-})
+  });
+});

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { enableMockClient } from '@openfn/language-common/util';
-import { execute, submitXls, get } from '../src';
+import { execute, submitXls, get, post } from '../src';
 import sinon from 'sinon';
 
 const hostUrl = 'http://example.commcare.com';
@@ -320,3 +320,44 @@ describe('getCases', () => {
     ]);
   });
 });
+
+describe('createUser', ()=>{
+  it('should create a user', async () => {
+    testServer
+      .intercept({
+        path: `/a/${domain}/api/v0.5/user`,
+        method: 'POST',
+      })
+      .reply(201, () => {
+        // simulate a return from commcare
+        return {
+       
+        id:'123456'
+        };
+      });
+
+    const state = {
+      configuration: {
+        hostUrl,
+        domain,
+        appId: app,
+        username: 'user',
+        password: 'password',
+      },
+    };
+
+    const { data, response } = await execute(post('user',{
+      username: 'person',
+      password: 'per1234',
+      first_name: 'Per',
+      last_name: 'Son',
+      default_phone_number: '+50253311399',
+      email: 'person@example.org',
+    }))(state);
+
+    expect(data).to.haveOwnProperty('id');
+    expect(response.statusCode).to.equal(201);
+
+
+  })
+})


### PR DESCRIPTION
## Summary

Creating a generic `post` function for commcare

## Details

We currently have `submit` and `submitxls` which cater to submitting form-data and xls data. However, we do not have a generic post that can allow to send JSON data. 

## Issues

#570 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
