### PR TITLE
`salesforce` Update default `apiVersion`

### DIFF
--- a/.changeset/mighty-eyes-guess.md
+++ b/.changeset/mighty-eyes-guess.md
@@ -1,7 +1,0 @@
----
-'@openfn/language-salesforce': patch
----
-
-- Set default API version to `47.0`
-- In `bulkQuery` throw errors if API version is less than `47.0`
-- Update `bulkQuery` jsdocs with a link to `Bulk API 2.0 Query`

--- a/.changeset/mighty-eyes-guess.md
+++ b/.changeset/mighty-eyes-guess.md
@@ -1,0 +1,7 @@
+---
+'@openfn/language-salesforce': patch
+---
+
+- Set default API version to `47.0`
+- In `bulkQuery` throw errors if API version is less than `47.0`
+- Update `bulkQuery` jsdocs with a link to `Bulk API 2.0 Query`

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-salesforce
 
+## 4.6.7
+
+### Patch Changes
+
+- 332225ec: - Set default API version to `47.0`
+  - In `bulkQuery` throw errors if API version is less than `47.0`
+  - Update `bulkQuery` jsdocs with a link to `Bulk API 2.0 Query`
+
 ## 4.6.6
 
 ### Patch Changes

--- a/packages/salesforce/ast.json
+++ b/packages/salesforce/ast.json
@@ -290,7 +290,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Execute an SOQL Bulk Query.\nThis function uses bulk query to efficiently query large data sets and reduce the number of API requests.\n`bulkQuery()` uses {@link https://sforce.co/3y9phlc Bulk API v.2.0} which is available in API version 41.0 and later.\nThis API is subject to {@link https://sforce.co/4b6kn6z rate limits}.",
+        "description": "Execute an SOQL Bulk Query.\nThis function uses bulk query to efficiently query large data sets and reduce the number of API requests.\n`bulkQuery()` uses {@link https://sforce.co/4azgczz Bulk API v.2.0 Query} which is available in API version 47.0 and later.\nThis API is subject to {@link https://sforce.co/4b6kn6z rate limits}.",
         "tags": [
           {
             "title": "public",

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -317,7 +317,9 @@ export function bulkQuery(qs, options, callback) {
       qs,
       options
     );
-    const apiVersion = connection.version;
+
+    if (connection.version < 47.0)
+      throw new Error('bulkQuery requires API version 47.0 and later');
 
     const { pollTimeout, pollInterval } = {
       ...defaultOptions,
@@ -328,7 +330,7 @@ export function bulkQuery(qs, options, callback) {
 
     const queryJob = await connection.request({
       method: 'POST',
-      url: `/services/data/v${apiVersion}/jobs/query`,
+      url: `/services/data/v${connection.version}/jobs/query`,
       body: JSON.stringify({
         operation: 'query',
         query: resolvedQs,

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -318,7 +318,7 @@ export function bulkQuery(qs, options, callback) {
       options
     );
 
-    if (connection.version < '47.0')
+    if (parseFloat(connection.version) < 47.0)
       throw new Error('bulkQuery requires API version 47.0 and later');
 
     const { pollTimeout, pollInterval } = {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -318,7 +318,7 @@ export function bulkQuery(qs, options, callback) {
       options
     );
 
-    if (connection.version < 47.0)
+    if (connection.version < '47.0')
       throw new Error('bulkQuery requires API version 47.0 and later');
 
     const { pollTimeout, pollInterval } = {
@@ -711,12 +711,11 @@ function getConnection(state, options) {
   const apiVersionRegex = /^\d{2}\.\d$/;
 
   if (apiVersion && apiVersionRegex.test(apiVersion)) {
-    console.log('Using Salesforce API version:', apiVersion);
     options.version = apiVersion;
   } else {
     options.version = '47.0';
-    console.log('Using Salesforce API version:', options.version);
   }
+  console.log('Using Salesforce API version:', options.version);
 
   return new jsforce.Connection(options);
 }

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -289,7 +289,7 @@ const defaultOptions = {
 /**
  * Execute an SOQL Bulk Query.
  * This function uses bulk query to efficiently query large data sets and reduce the number of API requests.
- * `bulkQuery()` uses {@link https://sforce.co/3y9phlc Bulk API v.2.0} which is available in API version 41.0 and later.
+ * `bulkQuery()` uses {@link https://sforce.co/4azgczz Bulk API v.2.0 Query} which is available in API version 47.0 and later.
  * This API is subject to {@link https://sforce.co/4b6kn6z rate limits}.
  * @public
  * @example
@@ -709,11 +709,11 @@ function getConnection(state, options) {
   const apiVersionRegex = /^\d{2}\.\d$/;
 
   if (apiVersion && apiVersionRegex.test(apiVersion)) {
-    console.log('Using Salesforce API version', apiVersion);
+    console.log('Using Salesforce API version:', apiVersion);
     options.version = apiVersion;
   } else {
-    options.version = '52.0';
-    console.log('Using Salesforce API version 52.0');
+    options.version = '47.0';
+    console.log('Using Salesforce API version:', options.version);
   }
 
   return new jsforce.Connection(options);

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -712,8 +712,8 @@ function getConnection(state, options) {
     console.log('Using Salesforce API version', apiVersion);
     options.version = apiVersion;
   } else {
-    console.log('apiVersion is not defined');
-    console.log('We recommend using Salesforce API version 52.0 or latest');
+    options.version = '52.0';
+    console.log('Using Salesforce API version 52.0');
   }
 
   return new jsforce.Connection(options);


### PR DESCRIPTION
## Summary

`bulkQuery` uses [Bulk API 2.0 Query](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/query_create_job.htm) which available in API version 47.0 and later. I have updated the default `apiVersion` to `47.0`, If apiVersion is not set.

## Implementation
- Set the default apiVersion to `47.0` 
- Throw an error in `bulkQuery` if apiVersion is less than `47.0`
- Update `bulkQuery` docs with the link to `Bulk API 2.0 Query`

Ref #577 

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
