### PR TITLE
http: automatically add bearer tokens to a request

### DIFF
--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Automatically apply api/oauth tokens"
+- Automatically apply api/oauth tokens from config
 
 ## 6.2.1
 

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-http
 
+## 6.2.2
+
+### Patch Changes
+
+- Automatically apply api/oauth tokens"
+
 ## 6.2.1
 
 ### Patch Changes

--- a/packages/http/configuration-schema.json
+++ b/packages/http/configuration-schema.json
@@ -17,7 +17,7 @@
     "access_token": {
       "title": "Access Token",
       "type": "string",
-      "description": "Bearer token or API key",
+      "description": "OAuth Access token, API key or other Bearer token",
       "writeOnly": true,
       "examples": ["00QCjAl4MlV-WPX"]
     },

--- a/packages/http/configuration-schema.json
+++ b/packages/http/configuration-schema.json
@@ -14,8 +14,8 @@
       "writeOnly": true,
       "examples": ["@some(!)Password"]
     },
-    "token": {
-      "title": "Token",
+    "access_token": {
+      "title": "Access Token",
       "type": "string",
       "description": "Bearer token or API key",
       "writeOnly": true,

--- a/packages/http/configuration-schema.json
+++ b/packages/http/configuration-schema.json
@@ -5,27 +5,21 @@
       "title": "Username",
       "type": "string",
       "description": "Username",
-      "examples": [
-        "test@openfn.org"
-      ]
+      "examples": ["test@openfn.org"]
     },
     "password": {
       "title": "Password",
       "type": "string",
       "description": "Password",
       "writeOnly": true,
-      "examples": [
-        "@some(!)Password"
-      ]
+      "examples": ["@some(!)Password"]
     },
     "token": {
       "title": "Token",
       "type": "string",
-      "description": "Bearer token or API key. This should be added manually to the Authorization header.",
+      "description": "Bearer token or API key",
       "writeOnly": true,
-      "examples": [
-        "00QCjAl4MlV-WPX"
-      ]
+      "examples": ["00QCjAl4MlV-WPX"]
     },
     "baseUrl": {
       "title": "Base URL",
@@ -40,9 +34,7 @@
       "description": "The base URL (http://www.example.com)",
       "format": "uri",
       "minLength": 1,
-      "examples": [
-        "https://instance_name.surveycto.com"
-      ]
+      "examples": ["https://instance_name.surveycto.com"]
     }
   },
   "type": "object",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-http",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -14,10 +14,10 @@ export function addAuth(configuration = {}, headers) {
     return;
   }
 
-  const { username, password, token } = configuration;
+  const { username, password, access_token } = configuration;
 
-  if (token) {
-    Object.assign(headers, { Authorization: `Bearer ${token}` });
+  if (access_token) {
+    Object.assign(headers, { Authorization: `Bearer ${access_token}` });
   } else if (username && password) {
     Object.assign(headers, makeBasicAuthHeader(username, password));
   }

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -9,9 +9,16 @@ import {
 import * as cheerio from 'cheerio';
 import cheerioTableparser from 'cheerio-tableparser';
 
-export function addBasicAuth(configuration = {}, headers) {
-  const { username, password } = configuration;
-  if (username && password && !headers.Authorization) {
+export function addAuth(configuration = {}, headers) {
+  if (headers.Authorization) {
+    return;
+  }
+
+  const { username, password, token } = configuration;
+
+  if (token) {
+    Object.assign(headers, { Authorization: `Bearer ${token}` });
+  } else if (username && password) {
     Object.assign(headers, makeBasicAuthHeader(username, password));
   }
 }
@@ -47,7 +54,7 @@ export function request(method, path, params, callback = s => s) {
 
     const baseUrl = state.configuration?.baseUrl;
 
-    addBasicAuth(state.configuration, headers);
+    addAuth(state.configuration, headers);
 
     const maxRedirections =
       resolvedParams.maxRedirections ??

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -233,10 +233,10 @@ describe('get()', () => {
     expect(data).to.eql({ 'x-openfn': 'testing' });
   });
 
-  it('encodes configuration into basic auth header', async () => {
+  it('sets up a basic auth header', async () => {
     testServer
       .intercept({
-        path: '/api/auth',
+        path: '/api/private',
         method: 'GET',
       })
       .reply(200, req => req.headers, { headers: jsonHeaders });
@@ -249,9 +249,29 @@ describe('get()', () => {
       },
     };
 
-    const { data } = await execute(get('/api/auth'))(state);
+    const { data } = await execute(get('/api/private'))(state);
 
     expect(data.Authorization).to.eql('Basic aGVsbG86dGhlcmU=');
+  });
+
+  it('sets up an oauth/token header', async () => {
+    testServer
+      .intercept({
+        path: '/api/private',
+        method: 'GET',
+      })
+      .reply(200, req => req.headers, { headers: jsonHeaders });
+
+    const state = {
+      configuration: {
+        baseUrl: 'https://www.example.com',
+        token: '00QCjAl4MlV-WPX',
+      },
+    };
+
+    const { data } = await execute(get('/api/private'))(state);
+
+    expect(data.Authorization).to.eql('Bearer 00QCjAl4MlV-WPX');
   });
 
   it('does not override the Authorization header', async () => {

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -265,7 +265,7 @@ describe('get()', () => {
     const state = {
       configuration: {
         baseUrl: 'https://www.example.com',
-        token: '00QCjAl4MlV-WPX',
+        access_token: '00QCjAl4MlV-WPX',
       },
     };
 


### PR DESCRIPTION
## Summary

This PR reads the `token` from the config object and adds it to an `Authorization: Bearer ${token}` header.

## Details

I think this is all that's needed? It should work with oath and I think most api key-style APIs. I don't know how much variance there is in the pattern, maybe we can add more flexibility later if needed.

Note that users can provide their own Authorization header in the request, so even if this doesn't work in all cases, there's an easy work around.

## Issues

Closes #581 

