### PR TITLE
salesforce: Ensure anyscii is loaded before executing

### DIFF
--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-salesforce
 
+## 4.6.8
+
+### Patch Changes
+
+- Properly ensure any-ascii is loaded before executing, resolving a critical
+  race that we are losing in production
+
 ## 4.6.7
 
 ### Patch Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.6.7",
+  "version": "4.6.8",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -24,11 +24,11 @@ import { expandReferences as newExpandReferences } from '@openfn/language-common
 import jsforce from 'jsforce';
 import flatten from 'lodash/flatten';
 
-// use a dynamic import because any-ascii is pure ESM and doesn't play well with CJS
-// Note that technically we should await this, but in practice the module will be loaded
-// before execute is called
 let anyAscii = undefined;
-import('any-ascii').then(m => {
+
+// use a dynamic import because any-ascii is pure ESM and doesn't play well with CJS
+// This promise MUST be resolved by execute before a connection is created
+const loadAnyAscii = import('any-ascii').then(m => {
   anyAscii = m.default;
 });
 
@@ -792,6 +792,7 @@ export function execute(...operations) {
     // Note: we no longer need `steps` anymore since `commonExecute`
     // takes each operation as an argument.
     return commonExecute(
+      loadAnyAscii,
       createConnection,
       ...flatten(operations),
       cleanupState


### PR DESCRIPTION
It's theoretically possible that `any-ascii` has not loaded before `toUTF8` is called.

This seems vanishingly unlikely since we have to call out to the salesforce server before we start executing. Can we really handshake with Salesforce quicker than we can load a Javascript Module? 

But Mutchi is seeing an runtime error  where `anyAscii is not a function`. If I locally disable the salesforce connection code and just call `toUTF`, then it fails the same way. So it feels like somehow the module loader is losing the race :shrug: 

Anyway this is a more robust solution and I wish I'd thought of this earlier.