### PR TITLE
Salesforce: second fix to UTF8

### DIFF
--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-salesforce
 
+## 4.6.9
+
+### Patch Changes
+
+- Fix any-ascii load and add more tests
+
 ## 4.6.8
 
 ### Patch Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.6.8",
+  "version": "4.6.9",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -28,9 +28,11 @@ let anyAscii = undefined;
 
 // use a dynamic import because any-ascii is pure ESM and doesn't play well with CJS
 // This promise MUST be resolved by execute before a connection is created
-const loadAnyAscii = import('any-ascii').then(m => {
-  anyAscii = m.default;
-});
+const loadAnyAscii = state =>
+  import('any-ascii').then(m => {
+    anyAscii = m.default;
+    return state;
+  });
 
 /**
  * Adds a lookup relation or 'dome insert' to a record.
@@ -764,6 +766,10 @@ function createAccessTokenConnection(state) {
  * @returns {State}
  */
 function createConnection(state) {
+  if (state.connection) {
+    return state;
+  }
+
   const { access_token } = state.configuration;
 
   return access_token

--- a/packages/salesforce/test/Adaptor.test.js
+++ b/packages/salesforce/test/Adaptor.test.js
@@ -7,15 +7,8 @@ import {
   upsert,
   upsertIf,
   toUTF8,
-  steps,
-  each,
-  field,
-  fields,
-  sourceValue,
   execute,
 } from '../src/Adaptor';
-
-import testData from './testData' assert { type: 'json' };
 
 const { expect } = chai;
 
@@ -173,18 +166,32 @@ describe('Adaptor', () => {
   });
 
   describe('toUTF8', () => {
-    it('Transliterate unicode to ASCII representation', () => {
-      expect(toUTF8('άνθρωποι')).to.eql('anthropoi');
+    it('Transliterate unicode to ASCII representation', async () => {
+      const state = {
+        connection: {},
+      };
+
+      // Run toUTF8 inside an execute block to ensure that any-ascii gets loaded correctly
+      const convert = str => execute(state => toUTF8(str))(state);
+
+      let result = await convert('άνθρωποι');
+      expect(result).to.eql('anthropoi');
+
       // Misc
-      expect(toUTF8('☆ ♯ ♰ ⚄ ⛌')).to.equal('* # + 5 X');
+      result = await convert('☆ ♯ ♰ ⚄ ⛌');
+      expect(result).to.equal('* # + 5 X');
+
       // Emojis
-      expect(toUTF8('👑 🌴')).to.eql(':crown: :palm_tree:');
+      result = await convert('👑 🌴');
+      expect(result).to.eql(':crown: :palm_tree:');
+
       // Letterlike
-      expect(toUTF8('№ ℳ ⅋ ⅍')).to.eql('No M & A/S');
+      result = await convert('№ ℳ ⅋ ⅍');
+      expect(result).to.eql('No M & A/S');
+
       // Ordinal coordinator
-      expect(toUTF8('Nhamaonha 6ª Classe 2023-10-09')).to.eql(
-        'Nhamaonha 6a Classe 2023-10-09'
-      );
+      result = await convert('Nhamaonha 6ª Classe 2023-10-09');
+      expect(result).to.eql('Nhamaonha 6a Classe 2023-10-09');
     });
   });
 });


### PR DESCRIPTION
The previous fix to UTF8, which introduced loadAnyAscii, didn't quite work.

This PR basically just wraps that function in a function, which ensures that `execute` properly waits for the module to load.

This now works against a local worker, so I'm more confidence it'll work in production.

Also note that to support this fix I've improved the unit tests on `toUTF8`. They now use `execute`, which forces the dynamic module load of `any-ascii`