### PR TITLE
Refactor docs build into two scripts

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,8 +41,10 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build docs
         run: pnpm build:adaptors docs
-      - name: Commit docs to docs branch
-        run: pnpm exec .github/workflows/docs.sh
+      - name: Generate docs.json
+        run: pnpm docs:build
+      - name: Commit docs.json to docs branch
+        run: pnpm docs:publish
 
       # Trigger a rebuild on the docs site to pull adaptor docs
       - name: Trigger deploy on openFn/docs

--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ templates in jsoc2md.
 - Run `pnpm build docs` from root (or just one adaptor folder) and inspect the
   generated `docs/index/md` file.
 
+Once built, the docs need to be compiled into a JSON file to be published to the
+docs site. This is run automatically through github actions.
+
+For local dev against the docsite, you can run `pnpm docs:build` to rebuild your
+local `docs.json` file.
+
 ## Metadata
 
 Check the Wiki for the metadata creation guide:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "migrate": "cd tools/migrate && pnpm migrate",
     "setup": "pnpm --filter \"./tools/**\" install",
+    "docs:publish": "pnpm exec scripts/publish-docs.sh",
+    "docs:build": "pnpm exec scripts/build-docs.sh",
     "build:tools": "pnpm --filter \"./tools/**\" build",
     "build:adaptors": "pnpm --filter \"./packages/**\" build",
     "build": "pnpm build:tools && pnpm build:adaptors",

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
 
+echo "Building docs.json"
+
 # clean tmp directory
 mkdir -p tmp
 rm -rf tmp/*
@@ -15,8 +17,9 @@ find tmp/*/* -type d -empty -delete
 
 # flatten json files
 # jq -s 'flatten' packages/*/docs/*.json > docs/docs.json
-rm tmp/*.json
-# add first opening bracked
+# rm tmp/*.json
+
+# add first opening bracket
 echo [ >>tmp/tmp.json
 # use all json files in current folder
 for i in packages/*/docs/*.json; do
@@ -34,13 +37,4 @@ rm tmp/tmp.json
 # add closing bracket
 echo ] >>tmp/docs.json
 
-# commit new docs
-git fetch origin docs
-git switch docs
-
-rsync -pr tmp/* docs/
-
-git add docs --force
-git status
-git add -A && git commit -m"Update auto-generated documentation."
-git push origin docs
+echo "Done!"

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -l
+
+# commit new docs
+git fetch origin docs
+git switch docs
+
+rsync -pr tmp/* docs/
+
+git add docs --force
+git status
+git add -A && git commit -m "Update auto-generated documentation."
+
+# push
+git push origin docs


### PR DESCRIPTION
To make local docs development easier, this PR splits the docs.json build into two steps: one to build the docs, and one to commit and publish.

Now you can run `pnpm docs:build` to generate your docs.json file, and easily import that into your local docs repo (see https://github.com/OpenFn/docs/pull/498)

I've also moved the scripts into `./scripts`, where they are more discoverable, and hooked them into package.json

This should make absolutely no change to the actual build.