### PR TITLE
Docs: split API into Operations and Functions list

### DIFF
--- a/tools/build/src/commands/docs.ts
+++ b/tools/build/src/commands/docs.ts
@@ -48,6 +48,19 @@ const build = async (lang: string) => {
     'no-cache': true,
   });
 
+  // Identify Operations
+  // TODO we can later add a supporting @operation tag, but this heuristic will go a long way
+  templateData.forEach(doclet => {
+    if (
+      doclet.returns
+        ?.at(0)
+        ?.type?.names.at(0)
+        .match(/operation/i)
+    ) {
+      doclet.kind = 'operation';
+    }
+  });
+
   // sort template data
   // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
   templateData.sort(function (a, b) {
@@ -148,6 +161,10 @@ const build = async (lang: string) => {
   const destination = `${destinationDir}/index.md`;
   await mkdir(destinationDir, { recursive: true });
   await writeFile(destination, docs);
+  await writeFile(
+    `${destinationDir}/raw.json`,
+    JSON.stringify(templateData, null, 2)
+  );
   await writeFile(`${destinationDir}/${lang}.json`, JSON.stringify(docsJson));
 
   await writeFile(

--- a/tools/build/src/util/docs-template.hbs
+++ b/tools/build/src/util/docs-template.hbs
@@ -1,7 +1,9 @@
 {{#if (showMainIndex)~}}
 
-{{#globals kind="function" ~}}
-{{#if @first~}}## Functions
+{{#globals kind="operation" ~}}
+{{#if @first}}
+
+#### Operations
 
 <dl>
 {{/if~}}
@@ -12,7 +14,7 @@
 {{#if @prefix}}{{@prefix}} {{/if~}}
 {{@accessSymbol}}{{#if (isEvent)}}"{{{name}}}"{{else}}{{{name}}}{{/if~}}
 {{~#if @methodSign}}{{#if (isEvent)}} {{@methodSign}}{{else}}{{@methodSign}}{{/if}}{{/if~}}
-{{{@codeClose}~}}
+{{@codeClose~}}
 </a>
 {{~/sig}}{{/if~}}
 </dt>
@@ -20,7 +22,29 @@
 {{#if @last~}}</dl>
 {{/if~}}
 {{/globals~}}
-{{!-- {{>global-index-kinds kind="typedef" title="Typedefs" ~}} --}}
+
+{{#globals kind="function"}}
+{{#if @first}}
+
+#### Functions
+
+<dl>
+{{/if~}}
+<dt>
+    {{#if name}}{{#sig no-gfm=true ~}}
+<a href="#{{toLowerCase (anchorName)}}">
+{{~{@codeOpen}~}}
+{{#if @prefix}}{{@prefix}} {{/if~}}
+{{@accessSymbol}}{{#if (isEvent)}}"{{{name}}}"{{else}}{{{name}}}{{/if~}}
+{{~#if @methodSign}}{{#if (isEvent)}} {{@methodSign}}{{else}}{{@methodSign}}{{/if}}{{/if~}}
+{{@codeClose~}}
+</a>
+{{~/sig}}{{/if~}}
+</dt>
+{{#if @last~}}</dl>
+{{/if~}}
+{{/globals~}}
+
 {{/if~}}
 
 {{#commonFns}}
@@ -35,14 +59,37 @@ The following functions are exported from the common adaptor:
 {{/if}}
 {{/commonFns}}
 
-{{#orphans ~}}
+{{>separator~}}
+
+{{#globals kind="operation" ~}}
+{{#if @first~}}## Operations
+
+Operations are used at the top level of your job code. You can nest Operations, but you cannot use an Operation within a callback.
+{{/if~}}
+
+### {{anchorName}}
+
+{{! operations should list parameters but not returns }}
+{{>sig-name}}
+
+{{>body}}
+{{>separator~}}
+
+{{/globals~}}
+
+{{#globals kind="function" ~}}
+{{#if @first~}}
+
+## Functions
+
+Functions are regular Javascript functions. They are not state aware, they do not neccessarily take state and they usually don't return state. Functions can only be used inside callback functions.
+{{/if~}}
 
 ### {{anchorName}}
 
 {{>sig-name}}
 
 {{>body}}
-{{>member-index~}}
 {{>separator~}}
-{{>members~}}
-{{/orphans~}}
+
+{{/globals~}}

--- a/tools/build/src/util/docs-template.hbs
+++ b/tools/build/src/util/docs-template.hbs
@@ -1,7 +1,7 @@
 {{#if (showMainIndex)~}}
 
 {{#globals kind="function" ~}}
-{{#if @first~}}{{>heading-indent}}Functions
+{{#if @first~}}## Functions
 
 <dl>
 {{/if~}}
@@ -37,7 +37,7 @@ The following functions are exported from the common adaptor:
 
 {{#orphans ~}}
 
-{{>heading-indent}}{{anchorName}}
+### {{anchorName}}
 
 {{>sig-name}}
 


### PR DESCRIPTION
## Summary

This PR changes the  docs template so that Operations and Functions feature in two different lists.

This helps make it clear what is an Operation and what is a Plain Old Function

## Details

As a bonus fix, indenting on the right hand contents menu has been fixed.

These changes do not affect the adaptor JSdoc at all. It just works out of the box.

Screenshots from a first pass:

![image](https://github.com/OpenFn/adaptors/assets/7052509/aec11f2a-2bcf-49a5-bd4d-a8baf33da885)
![image](https://github.com/OpenFn/adaptors/assets/7052509/f3e1bc0d-4e60-4f14-9d45-b4fa54e049dd)
![image](https://github.com/OpenFn/adaptors/assets/7052509/824d6cdf-569a-4638-9bd6-8f64b73035db)



## Issues

Closes https://github.com/OpenFn/docs/issues/439

Related to #522

## Further work

* [ ] Add an `@operation` jsdoc tag, which marks the doclet public and is used to recognise operations
* [ ] The Operations list doesn't show signatures
* [ ] Put the operation/function summary contents into a table with two columns, so you can see both. Maybe just on desktop windows?
* [ ] Don't show the return type in an Operation signature
* [ ] I think the Operation keyword should feature somewhere in each Operation, like a badge. Clicking it would take you to our best explanation of what an Operation is
* [ ] Improve the summary docs at the top of the Operations and Functions sections (include links)