### PR TITLE
common: Fix request params

### DIFF
--- a/.changeset/tame-parrots-complain.md
+++ b/.changeset/tame-parrots-complain.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-commcare': minor
----
-
-Implement better error handling and make post a public function

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-bigquery
 
+## 2.0.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 2.0.9
 
 ### Patch Changes

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-bigquery",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "A Google BigQuery language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@google-cloud/bigquery": "^5.12.0",
-    "@openfn/language-common": "workspace:1.13.4",
+    "@openfn/language-common": "workspace:1.13.5",
     "csv-parse": "^4.16.3",
     "import": "0.0.6",
     "json2csv": "^5.0.7",

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @openfn/language-commcare
 
+## 2.1.0
+
+### Minor Changes
+
+- 0719de00: Implement better error handling and make post a public function
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 2.0.0
 
 Rebase the commcare adaptor on the new HTTP helpers.

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-commcare",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Commcare Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 v0.4.0
 
+## 1.13.5
+
+### Patch Changes
+
+- http helpers: Fix an issue where query parameters in the URL did not get sent
+  to the server
+
 ## 1.13.4
 
 ### Patch Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-common",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "Common Expressions for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -1,6 +1,7 @@
 import { Client, MockAgent } from 'undici';
 import { getReasonPhrase } from 'http-status-codes';
 import { Readable } from 'node:stream';
+import querystring from 'node:querystring';
 
 const clients = new Map();
 
@@ -100,6 +101,7 @@ export const parseUrl = (pathOrUrl = '', baseUrl) => {
     url: url.toString(),
     baseUrl: url.origin,
     path: url.pathname,
+    query: querystring.parse(url.searchParams.toString()),
   };
 };
 
@@ -122,10 +124,15 @@ export const parseUrl = (pathOrUrl = '', baseUrl) => {
  */
 export async function request(method, fullUrlOrPath, options = {}) {
   const startTime = Date.now();
-  const { url, baseUrl, path } = parseUrl(fullUrlOrPath, options.baseUrl);
+  const {
+    url,
+    baseUrl,
+    path,
+    query: urlQuery,
+  } = parseUrl(fullUrlOrPath, options.baseUrl);
   const {
     headers = {},
-    query = {},
+    query: optionQuery = {},
     body,
     errors = {},
     timeout = 300e3, // Default to 300 seconds,
@@ -138,7 +145,10 @@ export async function request(method, fullUrlOrPath, options = {}) {
 
   const response = await client.request({
     path,
-    query,
+    query: {
+      ...optionQuery,
+      ...urlQuery,
+    },
     method,
     headers,
     body: encodeRequestBody(body),

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -62,6 +62,18 @@ describe('parseUrl', () => {
     expect(url).to.eql('https://www.example.org/api/a/b/c');
   });
 
+  it('should extract query parameters', () => {
+    const { query } = parseUrl('a/b/c?x=1&y=2', 'https://www.example.org/api');
+
+    expect(query).to.eql({ x: '1', y: '2' });
+  });
+
+  it('should extract empty query parameters', () => {
+    const { query } = parseUrl('a', 'https://www.example.org/api');
+
+    expect(query).to.eql({});
+  });
+
   it('should throw if base has no protocol', () => {
     try {
       parseUrl('/a/b/c', 'www.example.org');
@@ -121,6 +133,45 @@ describe('request function', () => {
       .reply(200, {});
 
     const response = await request('GET', 'https://www.example.com/api');
+
+    expect(response.statusCode).to.eql(200);
+    expect(response.url).to.eql('https://www.example.com/api');
+  });
+
+  it('should include query parameters in the url', async () => {
+    client
+      .intercept({
+        path: '/api',
+        method: 'GET',
+        query: {
+          name: 'homelander',
+        },
+      })
+      .reply(200, {});
+
+    const response = await request(
+      'GET',
+      'https://www.example.com/api?name=homelander'
+    );
+
+    expect(response.statusCode).to.eql(200);
+    expect(response.url).to.eql('https://www.example.com/api?name=homelander');
+  });
+
+  it('should include query parameters in the options', async () => {
+    client
+      .intercept({
+        path: '/api',
+        method: 'GET',
+        query: {
+          name: 'homelander',
+        },
+      })
+      .reply(200, {});
+
+    const response = await request('GET', 'https://www.example.com/api', {
+      query: { name: 'homelander' },
+    });
 
     expect(response.statusCode).to.eql(200);
     expect(response.url).to.eql('https://www.example.com/api');

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dynamics
 
+## 0.4.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 0.4.13
 
 ### Patch Changes

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dynamics",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "A Microsoft Dynamics Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4",
+    "@openfn/language-common": "1.13.5",
     "request": "^2.72.0"
   },
   "devDependencies": {

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msgraph
 
+## 0.5.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 0.5.4
 
 ### Patch Changes

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-msgraph",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Microsoft Graph Language Pack for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mssql
 
+## 4.2.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 4.2.3
 
 ### Patch Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mssql",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:1.13.4",
+    "@openfn/language-common": "workspace:1.13.5",
     "tedious": "15.1.0"
   },
   "devDependencies": {

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mysql
 
+## 1.4.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 1.4.14
 
 ### Patch Changes

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mysql",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "A MySQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "main": "dist/index.cjs",
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4",
+    "@openfn/language-common": "1.13.5",
     "json-sql": "^0.3.10",
     "mysql": "^2.13.0",
     "squel": "^5.8.0",

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-nexmo
 
+## 0.4.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 0.4.8
 
 ### Patch Changes

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-nexmo",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "An Language Package for Nexmo",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ocl
 
+## 1.1.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 1.1.12
 
 ### Patch Changes

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ocl",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "An OCL language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4"
+    "@openfn/language-common": "1.13.5"
   },
   "devDependencies": {
     "@openfn/simple-ast": "^0.4.1",

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-odk
 
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 1.0.0
 
-Initial release for odk adaptor with `get`, `post`, `getForms` and `getSubmissions`
+Initial release for odk adaptor with `get`, `post`, `getForms` and
+`getSubmissions`

--- a/packages/odk/package.json
+++ b/packages/odk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-odk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenFn odk adaptor",
   "type": "module",
   "exports": {

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openfn
 
+## 1.3.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 1.3.13
 
 ### Patch Changes

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openfn",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "An (experimental) adaptor for accessing the OpenFn web API",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4",
+    "@openfn/language-common": "1.13.5",
     "axios": "^0.21.1"
   },
   "devDependencies": {

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openimis
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/openimis/package.json
+++ b/packages/openimis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openimis",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An OpenIMIS adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openmrs
 
+## 3.0.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 3.0.5
 
 ### Patch Changes

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openmrs",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "OpenMRS Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4"
+    "@openfn/language-common": "1.13.5"
   },
   "devDependencies": {
     "@openfn/simple-ast": "^0.4.1",

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-postgresql
 
+## 4.1.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 4.1.14
 
 ### Patch Changes

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-postgresql",
-  "version": "4.1.14",
+  "version": "4.1.15",
   "description": "A PostgreSQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4",
+    "@openfn/language-common": "1.13.5",
     "pg": "^8.3.2",
     "pg-format": "^1.0.4"
   },

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-primero
 
+## 2.11.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 2.11.13
 
 ### Patch Changes

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-primero",
-  "version": "2.11.13",
+  "version": "2.11.14",
   "description": "A UNICEF Primero language package for use with Open Function",
   "exports": {
     ".": {
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4",
+    "@openfn/language-common": "1.13.5",
     "cheerio": "^1.0.0-rc.10",
     "cheerio-tableparser": "1.0.1",
     "csv-parse": "^4.8.3",

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-progres
 
+## 1.3.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 1.3.13
 
 ### Patch Changes

--- a/packages/progres/package.json
+++ b/packages/progres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-progres",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "An OpenFn adaptor to work with UNHCR's ProGres case management system",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4",
+    "@openfn/language-common": "1.13.5",
     "axios": "^0.21.2"
   },
   "devDependencies": {

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-rapidpro
 
+## 1.0.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 1.0.13
 
 ### Patch Changes

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-rapidpro",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "A RapidPro adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4",
+    "@openfn/language-common": "1.13.5",
     "axios": "^0.21.2"
   },
   "devDependencies": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-salesforce
 
+## 4.6.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 4.6.10
 
 ### Patch Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.6.10",
+  "version": "4.6.11",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-satusehat
 
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 1.0.0
 
 Initial release.

--- a/packages/satusehat/package.json
+++ b/packages/satusehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-satusehat",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenFn satusehat adaptor",
   "type": "module",
   "exports": {
@@ -27,7 +27,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common":  "workspace:*"
+    "@openfn/language-common": "workspace:*"
   },
   "devDependencies": {
     "assertion-error": "2.0.0",

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-sftp
 
+## 1.0.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/language-common@1.13.5
+
 ## 1.0.7
 
 ### Patch Changes

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-sftp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "An SFTP language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -32,7 +32,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.13.4",
+    "@openfn/language-common": "1.13.5",
     "lodash": "^4.17.21",
     "ssh2-sftp-client": "9.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         specifier: ^5.12.0
         version: 5.12.0
       '@openfn/language-common':
-        specifier: workspace:1.13.4
+        specifier: workspace:1.13.5
         version: link:../common
       csv-parse:
         specifier: ^4.16.3
@@ -377,7 +377,7 @@ importers:
   packages/dynamics:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
       request:
         specifier: ^2.72.0
@@ -1061,7 +1061,7 @@ importers:
   packages/mssql:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:1.13.4
+        specifier: workspace:1.13.5
         version: link:../common
       tedious:
         specifier: 15.1.0
@@ -1092,7 +1092,7 @@ importers:
   packages/mysql:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
       json-sql:
         specifier: ^0.3.10
@@ -1172,7 +1172,7 @@ importers:
   packages/ocl:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -1231,7 +1231,7 @@ importers:
   packages/openfn:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
       axios:
         specifier: ^0.21.1
@@ -1351,7 +1351,7 @@ importers:
   packages/openmrs:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -1419,7 +1419,7 @@ importers:
   packages/postgresql:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
       pg:
         specifier: ^8.3.2
@@ -1456,7 +1456,7 @@ importers:
   packages/primero:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
       cheerio:
         specifier: ^1.0.0-rc.10
@@ -1511,7 +1511,7 @@ importers:
   packages/progres:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
       axios:
         specifier: ^0.21.2
@@ -1548,7 +1548,7 @@ importers:
   packages/rapidpro:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
       axios:
         specifier: ^0.21.2
@@ -1693,7 +1693,7 @@ importers:
   packages/sftp:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.13.4
+        specifier: 1.13.5
         version: link:../common
       lodash:
         specifier: ^4.17.21
@@ -2021,7 +2021,7 @@ importers:
   tools/import-tests:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^1.13.4
+        specifier: workspace:^1.13.5
         version: link:../../packages/common
       mocha:
         specifier: ^10.1.0

--- a/tools/import-tests/package.json
+++ b/tools/import-tests/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@openfn/language-common": "workspace:^1.13.4",
+    "@openfn/language-common": "workspace:^1.13.5",
     "mocha": "^10.1.0"
   }
 }


### PR DESCRIPTION
In common http, request parameters in the URL were not getting sent on to the server.

I've tested against the `http` adaptor with this code:
```
get('/tracker/trackedEntities/qv0j4JBXQX0.json?fields=*', {
  // query: { fields: '*' },
});

fn(state => {
  console.log(state.data);
});
```
And this credential (public sandbox)
```
{
  "configuration": {
    "username": "admin",
    "password": "district",
    "baseUrl": "https://play.im.dhis2.org/stable-2-40-3-2/api/40/"
  }
}
```

This code calls out to dhis2 for a tracked entity and asks for all fields to be returned (via query parameter). When the query does not get sent, dhis only returns part of the entity, not the full thing.

In production, the logged response does not include `enrollments` or `programOwners`. Against the built monorepo, it does.

Versions are bumped, tests are added, this is a critical issue ready for release