### PR TITLE
Fix cartodb

### DIFF
--- a/packages/cartodb/package.json
+++ b/packages/cartodb/package.json
@@ -4,7 +4,7 @@
   "description": "cartodb Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
-    "build": "pnpm clean && build-adaptor rapidpro",
+    "build": "pnpm clean && build-adaptor cartodb",
     "test": "mocha --experimental-specifier-resolution=node --no-warnings",
     "test:watch": "mocha -w --experimental-specifier-resolution=node --no-warnings",
     "clean": "rimraf dist types docs",


### PR DESCRIPTION
Cartodb has been building as `rapidpro` since migrating into the monorepo last year.

Closes #616 

No changeset and no version bump needed