### PR TITLE
Add stub script to main

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,15 @@
+name: Pre-release
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
+
+jobs:
+  next:
+    name: 'Publish @next'
+    runs-on: ubuntu-latest
+
+    steps:
+      - run echo "test"


### PR DESCRIPTION
To get the `run_workflow` trigger to work, we need it on main. Annoying.