### PR TITLE
Small fixes on ODK

### DIFF
--- a/.changeset/strange-trainers-promise.md
+++ b/.changeset/strange-trainers-promise.md
@@ -1,0 +1,16 @@
+---
+'@openfn/language-odk': patch
+---
+
+Small fixes includes
+
+- ODK uses email, not username. This changes the config schema so it matches
+  what ODK wants and what their documentation provides.
+  (https://docs.getodk.org/central-api-authentication/)
+- By manually concatenating the baseUrl and the path in the adaptor, rather than
+  relying on commonRequest to do so, we lost the ability to handle /
+  addition/omission. We don't want users to have to figure out if they should or
+  shouldn't put / in various places.
+- This adds a log to explain that authentication failed.
+- This removes the try/catch so that users can see the helpful error message
+  returned by commonRequest`

--- a/.changeset/strange-trainers-promise.md
+++ b/.changeset/strange-trainers-promise.md
@@ -1,7 +1,0 @@
----
-'@openfn/language-odk': major
----
-
-- configuration-schema: rename `username` to `email`
-- Improve logging when authentication fails
-- Improve error reporting when requests fail

--- a/.changeset/strange-trainers-promise.md
+++ b/.changeset/strange-trainers-promise.md
@@ -1,16 +1,7 @@
 ---
-'@openfn/language-odk': patch
+'@openfn/language-odk': major
 ---
 
-Small fixes includes
-
-- ODK uses email, not username. This changes the config schema so it matches
-  what ODK wants and what their documentation provides.
-  (https://docs.getodk.org/central-api-authentication/)
-- By manually concatenating the baseUrl and the path in the adaptor, rather than
-  relying on commonRequest to do so, we lost the ability to handle /
-  addition/omission. We don't want users to have to figure out if they should or
-  shouldn't put / in various places.
-- This adds a log to explain that authentication failed.
-- This removes the try/catch so that users can see the helpful error message
-  returned by commonRequest`
+- configuration-schema: rename `username` to `email`
+- Improve logging when authentication fails
+- Improve error reporting when requests fail

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-odk
 
+## 2.0.0
+
+### Major Changes
+
+- 9234f83: - configuration-schema: rename `username` to `email`
+  - Improve logging when authentication fails
+  - Improve error reporting when requests fail
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/odk/ast.json
+++ b/packages/odk/ast.json
@@ -325,7 +325,7 @@
               "type": "NameExpression",
               "name": "object"
             },
-            "name": "data"
+            "name": "body"
           },
           {
             "title": "param",
@@ -358,7 +358,7 @@
           }
         ]
       },
-      "valid": false
+      "valid": true
     }
   ],
   "exports": [],

--- a/packages/odk/configuration-schema.json
+++ b/packages/odk/configuration-schema.json
@@ -7,26 +7,20 @@
       "description": "ODK base URL",
       "format": "uri",
       "minLength": 1,
-      "examples": [
-        "https://sandbox.getodk.cloud/"
-      ]
+      "examples": ["https://sandbox.getodk.cloud/"]
     },
-    "username": {
-      "title": "Username",
+    "email": {
+      "title": "Email",
       "type": "string",
-      "description": "Username",
-      "examples": [
-        "test@openfn.org"
-      ]
+      "description": "Email",
+      "examples": ["test@openfn.org"]
     },
     "password": {
       "title": "Password",
       "type": "string",
       "description": "Password",
       "writeOnly": true,
-      "examples": [
-        "@some(!)Str0ngp4ss0w0rd"
-      ]
+      "examples": ["@some(!)Str0ngp4ss0w0rd"]
     },
     "access_token": {
       "title": "Access Token",
@@ -34,16 +28,10 @@
       "description": "Your ODK access token",
       "writeOnly": true,
       "minLength": 1,
-      "examples": [
-        "the-long-access-token-from-your-auth"
-      ]
+      "examples": ["the-long-access-token-from-your-auth"]
     }
   },
   "type": "object",
   "additionalProperties": true,
-  "required": [
-    "password",
-    "username",
-    "baseUrl"
-  ]
+  "required": ["password", "email", "baseUrl"]
 }

--- a/packages/odk/package.json
+++ b/packages/odk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-odk",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "OpenFn odk adaptor",
   "type": "module",
   "exports": {

--- a/packages/odk/src/Adaptor.js
+++ b/packages/odk/src/Adaptor.js
@@ -4,7 +4,7 @@ import * as util from './Utils';
 
 /**
  * Execute a sequence of operations.
- * Wraps `language-common/execute`, and prepends initial state for commcare.
+ * Wraps `language-common/execute`, and prepends initial state for odk.
  * @example
  * execute(
  *   create('foo'),

--- a/packages/odk/src/Adaptor.js
+++ b/packages/odk/src/Adaptor.js
@@ -99,7 +99,7 @@ export function post(path, data, params, callback) {
  * @public
  * @param {string} method - HTTP method to use
  * @param {string} path - Path to resource
- * @param {object} data - Object which will be attached to the POST body
+ * @param {object} body - Object which will be attached to the POST body
  * @param {Object} params - Optional request params
  * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}

--- a/packages/odk/src/Adaptor.js
+++ b/packages/odk/src/Adaptor.js
@@ -109,21 +109,17 @@ export function request(method, path, body, params = {}, callback = s => s) {
     const [resolvedMethod, resolvedPath, resolvedData, resolvedParams] =
       expandReferences(state, method, path, body, params);
 
-    try {
-      const response = await util.request(
-        state.configuration,
-        resolvedMethod,
-        resolvedPath,
-        {
-          params: resolvedParams,
-          data: resolvedData,
-        }
-      );
+    const response = await util.request(
+      state.configuration,
+      resolvedMethod,
+      resolvedPath,
+      {
+        params: resolvedParams,
+        data: resolvedData,
+      }
+    );
 
-      return util.prepareNextState(state, response, callback);
-    } catch (error) {
-      throw error.statusCode === 404 ? 'Page Not Found' : error.body ?? error;
-    }
+    return util.prepareNextState(state, response, callback);
   };
 }
 

--- a/packages/odk/src/Utils.js
+++ b/packages/odk/src/Utils.js
@@ -37,6 +37,11 @@ export const authorize = state => {
         throw err;
       });
   }
+
+  // warn if no auth found
+  console.warn(`WARNING: no authentication properties found on congfiguration schema!
+    
+Make sure to either set an access_token or email & password`);
 };
 
 export const prepareNextState = (state, response, callback = s => s) => {

--- a/packages/odk/test/Adaptor.test.js
+++ b/packages/odk/test/Adaptor.test.js
@@ -90,7 +90,8 @@ describe('Create Project', () => {
       return error;
     });
 
-    expect(error).to.eql('Forbidden');
+    expect(error.statusMessage).to.eql('Forbidden');
+    expect(error.statusCode).to.eql(403);
   });
 });
 

--- a/packages/odk/test/Adaptor.test.js
+++ b/packages/odk/test/Adaptor.test.js
@@ -50,7 +50,7 @@ describe('Create Project', () => {
     const state = {
       configuration: {
         baseUrl,
-        username: 'someusername',
+        email: 'someusername',
         password: 'somepassword',
       },
     };
@@ -79,7 +79,7 @@ describe('Create Project', () => {
     const state = {
       configuration: {
         baseUrl,
-        username: 'someusername',
+        email: 'someusername',
         password: 'somepassword',
       },
     };
@@ -116,7 +116,7 @@ describe('getProjects', () => {
     const state = {
       configuration: {
         baseUrl,
-        username: 'someusername',
+        email: 'someusername',
         password: 'somepassword',
       },
     };
@@ -165,7 +165,7 @@ describe('getForms', () => {
     const state = {
       configuration: {
         baseUrl,
-        username: 'someusername',
+        email: 'someusername',
         password: 'somepassword',
       },
     };
@@ -196,7 +196,7 @@ describe('getSubmissions', () => {
     const state = {
       configuration: {
         baseUrl,
-        username: 'someusername',
+        email: 'someusername',
         password: 'somepassword',
       },
     };


### PR DESCRIPTION
## Summary

- ODK uses `email`, not `username`. This changes the config schema so it matches what ODK wants and what their documentation provides. (https://docs.getodk.org/central-api-authentication/)
- By manually concatenating the `baseUrl` and the `path` in the adaptor, rather than relying on `commonRequest` to do so, we lost the ability to handle `/` addition/omission. We don't want users to have to figure out if they should or shouldn't put `/` in various places.
- This adds a log to explain that authentication failed.
- This removes the try/catch so that users can see the helpful error message returned by `commonRequest`

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
