### PR TITLE
Enable automated pre-releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,7 @@ jobs:
       matrix:
         node-version: [18.17.1]
 
-    #if: github.event.pull_request.draft == false
-    if: false
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,4 +32,4 @@ jobs:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
 
       # deprecate any outstanding @next builds, if any
-      # - run: pnpm next:deprecate
+      - run: pnpm next:deprecate

--- a/README.md
+++ b/README.md
@@ -256,9 +256,6 @@ release.
 
 ## Pre-releases
 
-**NOTE: pre-release automation is currently DISABLED until support is activated
-in Lightning**
-
 Pre-release builds for adaptors are availabe with the `@next` tag. These can be
 used in the CLI and Lightning and are generally available on `npm` (but because
 they're not flagged as `latest`, they won't be downloaded by default).


### PR DESCRIPTION
This PR just switches pre-releases back on

Do no merge until  Lightning is ready