### PR TITLE
fix:add error logs

### DIFF
--- a/.changeset/funny-planes-switch.md
+++ b/.changeset/funny-planes-switch.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-satusehat': patch
----
-
-Added extra logging around errors

--- a/.changeset/funny-planes-switch.md
+++ b/.changeset/funny-planes-switch.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-satusehat': minor
+---
+
+Add temporary error logs

--- a/.changeset/funny-planes-switch.md
+++ b/.changeset/funny-planes-switch.md
@@ -1,5 +1,5 @@
 ---
-'@openfn/language-satusehat': minor
+'@openfn/language-satusehat': patch
 ---
 
-Add temporary error logs
+Added extra logging around errors

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-satusehat
 
+## 1.1.2
+
+### Patch Changes
+
+- 218a582: Added extra logging around errors
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/satusehat/package.json
+++ b/packages/satusehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-satusehat",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "OpenFn satusehat adaptor",
   "type": "module",
   "exports": {

--- a/packages/satusehat/src/Adaptor.js
+++ b/packages/satusehat/src/Adaptor.js
@@ -57,7 +57,7 @@ export function get(path, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.error(e);
+     console.error(e.body)
       throw e;
     }
   };
@@ -96,7 +96,7 @@ export function post(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.error(e);
+     console.error(e.body)
       throw e;
     }
   };
@@ -135,7 +135,7 @@ export function put(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.error(e);
+     console.error(e.body)
       throw e;
     }
   };
@@ -179,7 +179,7 @@ export function patch(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.error(e);
+     console.error(e.body)
       throw e;
     }
   };

--- a/packages/satusehat/src/Adaptor.js
+++ b/packages/satusehat/src/Adaptor.js
@@ -57,8 +57,8 @@ export function get(path, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.log({ error: e.body });
-      throw e.body ?? e;
+      console.error(e);
+      throw e;
     }
   };
 }
@@ -96,8 +96,8 @@ export function post(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.log({ error: e.body });
-      throw e.body.issue ?? e;
+      console.error(e);
+      throw e;
     }
   };
 }
@@ -135,8 +135,8 @@ export function put(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.log({ error: e.body });
-      throw e.body.error ?? e;
+      console.error(e);
+      throw e;
     }
   };
 }
@@ -179,8 +179,8 @@ export function patch(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.log({ error: e.body });
-      throw e.body ?? e;
+      console.error(e);
+      throw e;
     }
   };
 }

--- a/packages/satusehat/src/Adaptor.js
+++ b/packages/satusehat/src/Adaptor.js
@@ -57,7 +57,7 @@ export function get(path, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-     console.error(e.body)
+      console.error(JSON.stringify(e.body, null, 2));
       throw e;
     }
   };
@@ -96,7 +96,7 @@ export function post(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-     console.error(e.body)
+      console.error(JSON.stringify(e.body, null, 2));
       throw e;
     }
   };
@@ -135,7 +135,7 @@ export function put(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-     console.error(e.body)
+      console.error(JSON.stringify(e.body, null, 2));
       throw e;
     }
   };
@@ -179,7 +179,7 @@ export function patch(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-     console.error(e.body)
+      console.error(JSON.stringify(e.body, null, 2));
       throw e;
     }
   };

--- a/packages/satusehat/src/Adaptor.js
+++ b/packages/satusehat/src/Adaptor.js
@@ -57,6 +57,7 @@ export function get(path, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
+      console.log({ error: e.body });
       throw e.body ?? e;
     }
   };
@@ -95,7 +96,8 @@ export function post(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      throw e.body.error ?? e;
+      console.log({ error: e.body });
+      throw e.body.issue ?? e;
     }
   };
 }
@@ -133,6 +135,7 @@ export function put(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
+      console.log({ error: e.body });
       throw e.body.error ?? e;
     }
   };
@@ -176,6 +179,7 @@ export function patch(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
+      console.log({ error: e.body });
       throw e.body ?? e;
     }
   };


### PR DESCRIPTION
## Summary

Adding error logs to `satusehat`

## Details

`satusehat` errors are not correctly displayed therefore a temporary log has been added to display the errors before the CLI error log is fixed.

## Issues

#655 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, has the migration tool been run and the
      migration guide followed?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
