### PR TITLE
commcare: Implement pagination on commcare's get request

### DIFF
--- a/.changeset/shy-vans-study.md
+++ b/.changeset/shy-vans-study.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-commcare': minor
----
-
-`get()` will now automatically paginate responses (unless an offset is passed)

--- a/.changeset/shy-vans-study.md
+++ b/.changeset/shy-vans-study.md
@@ -1,5 +1,5 @@
 ---
-'@openfn/language-commcare': major
+'@openfn/language-commcare': minor
 ---
 
-Implement pagination on commcare `get`
+`get()` will now automatically paginate responses (unless an offset is passed)

--- a/.changeset/shy-vans-study.md
+++ b/.changeset/shy-vans-study.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-commcare': major
+---
+
+Implement pagination on commcare `get`

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-commcare
 
+## 2.3.0
+
+### Minor Changes
+
+- ac4b4a0: `get()` will now automatically paginate responses (unless an offset
+  is passed)
+
 ## 2.2.1
 
 ### Patch Changes

--- a/packages/commcare/ast.json
+++ b/packages/commcare/ast.json
@@ -8,7 +8,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a GET request to any commcare endpoint. The returned objects will be written to state.data.\nA `response` key will be added to state with the HTTP response and a `meta` key",
+        "description": "Make a GET request to any commcare endpoint. The returned objects will be written to state.data.\nNot adding an offset param when getting items will trigger an automatic pagination and the returned data is combined and written into state.data\nIf an offset is provided, no auto-pagination occurs\nA `response` key will be added to state with the HTTP response and a `meta` key",
         "tags": [
           {
             "title": "public",
@@ -50,7 +50,7 @@
           },
           {
             "title": "param",
-            "description": "Optional callback to handle the response",
+            "description": "Optional callback to handle the response. During pagination, the callback is called on each pagination request made",
             "type": {
               "type": "OptionalType",
               "expression": {

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -29,7 +29,6 @@
     "JSONPath": "^0.10.0",
     "js2xmlparser": "^1.0.0",
     "lodash-fp": "^0.10.4",
-    "sinon": "^18.0.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"
   },
   "devDependencies": {

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-commcare",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Commcare Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -126,6 +126,7 @@ export function get(path, params = {}, callback = s => s) {
           break;
         }
       } while (allowPagination);
+      
       return {
         ...nextState,
         data: result,

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -90,12 +90,17 @@ export function get(
     try {
       do {
         // fetch a page
+
         const response = await request(
           state.configuration,
           `/a/${domain}/api/v0.5/${resolvedPath}`,
           {
             method: 'GET',
-            params: resolvedParams,
+            params: {
+              ...resolvedParams,
+              offset: offset,
+              limit: limit,
+            },
             contentType: 'application/json',
           }
         );

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -79,19 +79,19 @@ export function get(path, params = {}, callback = s => s) {
       params
     );
 
-    let { offset = 0, limit = 1000 } = resolvedParams;
+    let offset, limit;
 
     let nextState = state;
     let result;
     let allowPagination = isNaN(resolvedParams.offset);
 
-
     try {
       let requestParams = {
         ...resolvedParams,
       };
-  
+
       do {
+        // Make the first request
         const response = await request(
           state.configuration,
           `/a/${domain}/api/v0.5/${resolvedPath}`,
@@ -104,11 +104,13 @@ export function get(path, params = {}, callback = s => s) {
 
         nextState = prepareNextState(state, response, callback);
         if (response?.body?.meta?.next) {
+          // Check if next is present and make another call
+
           if (!result) {
             result = [];
           }
-          offset = response?.body?.meta?.offset + response?.body?.meta?.limit;
-          limit = response?.body?.meta?.limit;
+          offset = response.body.meta.offset + response.body.meta.limit;
+          limit = response.body.meta.limit;
 
           requestParams = {
             ...requestParams,
@@ -122,11 +124,12 @@ export function get(path, params = {}, callback = s => s) {
           } else {
             result = nextState.data;
           }
-
+          //  Break when next is null
           break;
         }
       } while (allowPagination);
-      
+      // Make another call if offset is missing in the params
+
       return {
         ...nextState,
         data: result,

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -56,7 +56,8 @@ export function execute(...operations) {
 
 /**
  * Make a GET request to any commcare endpoint. The returned objects will be written to state.data.
- * Adding an offset param will trigger an automatic pagination and the returned data is combined and written into state.data
+ * Not adding an offset param when getting items will trigger an automatic pagination and the returned data is combined and written into state.data
+ * If an offset is provided, no auto-pagination occurs
  * A `response` key will be added to state with the HTTP response and a `meta` key
  * @public
  * @example <caption>Get a list of cases</caption>
@@ -82,13 +83,14 @@ export function get(path, params = {}, callback = s => s) {
 
     let nextState = state;
     let result;
-    let allowPagination = !isNaN(resolvedParams.offset);
+    let allowPagination = isNaN(resolvedParams.offset);
+
 
     try {
       let requestParams = {
         ...resolvedParams,
       };
-
+  
       do {
         const response = await request(
           state.configuration,
@@ -101,7 +103,6 @@ export function get(path, params = {}, callback = s => s) {
         );
 
         nextState = prepareNextState(state, response, callback);
-
         if (response?.body?.meta?.next) {
           if (!result) {
             result = [];

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -68,7 +68,11 @@ export function execute(...operations) {
  * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
  */
-export function get(path, params = {}, callback = s => s) {
+export function get(
+  path,
+  params = { offset: 0, limit: 1000 },
+  callback = s => s
+) {
   return async state => {
     const { domain } = state.configuration;
     const [resolvedPath, resolvedParams] = expandReferences(
@@ -80,23 +84,18 @@ export function get(path, params = {}, callback = s => s) {
     let allItems = [];
     let next;
     let nextState = state;
-    let offset = 0;
-    const limit = 1000;
+    let offset = resolvedParams.offset;
+    const limit = resolvedParams.limit;
 
     try {
       do {
-        const requestParams = {
-          offset: offset,
-          limit: limit,
-          ...resolvedParams,
-        };
         // fetch a page
         const response = await request(
           state.configuration,
           `/a/${domain}/api/v0.5/${resolvedPath}`,
           {
             method: 'GET',
-            params: requestParams,
+            params: resolvedParams,
             contentType: 'application/json',
           }
         );

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { enableMockClient } from '@openfn/language-common/util';
 import { execute, submitXls, get, post } from '../src';
-import sinon from 'sinon';
 
 const hostUrl = 'http://example.commcare.com';
 const testServer = enableMockClient(hostUrl);
@@ -102,12 +101,8 @@ describe('getCases', () => {
   it('should fetch cases', async () => {
     testServer
       .intercept({
-        path: `/a/${domain}/api/v0.5/case`,
+        path: /\/a\/my-domain\/api\/v0\.5\/case/,
         method: 'GET',
-        query: {
-          limit: 1,
-          offset: 0,
-        },
       })
       .reply(200, () => {
         return {
@@ -170,115 +165,41 @@ describe('getCases', () => {
     expect(data[0]).to.haveOwnProperty('case_id');
     expect(response.meta.limit).to.equal(1);
   });
-
-  it('should fetch cases with pagination', async () => {
+  it('should fetch a single case', async () => {
     testServer
       .intercept({
-        path: `/a/${domain}/api/v0.5/case`,
+        path: /\/a\/my-domain\/api\/v0\.5\/case\/12345/,
         method: 'GET',
-        query: {
-          limit: 1,
-          offset: 0,
-        },
       })
       .reply(200, () => {
         return {
-          meta: {
-            limit: 1,
-            next: null,
-            offset: 0,
-            previous: null,
-            total_count: 3,
+          case_id: '12345',
+          closed: false,
+          closed_by: null,
+          date_closed: null,
+          date_modified: 'xxxxx',
+          domain: `${domain}`,
+          id: '12345',
+          indexed_on: 'xxxxx',
+          indices: {},
+          opened_by: 'xxxxx',
+          properties: {
+            Children_alive: 'no',
+            Last_menstrual_period: 'xxxx',
+            Total_children: '',
+            case_name: 'Jane',
+            case_type: 'pregnancy',
+            date_opened: 'xxxxx',
+            external_id: null,
+            feeling_sick: 'No',
+            owner_id: 'xxxxxx',
+            village_name: 'Somewhere',
           },
-          objects: [
-            {
-              case_id: '12345',
-              closed: false,
-              closed_by: null,
-              date_closed: null,
-              date_modified: 'xxxxx',
-              domain: `${domain}`,
-              id: '12345',
-              indexed_on: 'xxxxx',
-              indices: {},
-              opened_by: 'xxxxx',
-              properties: {
-                Children_alive: 'no',
-                Last_menstrual_period: 'xxxx',
-                Total_children: '',
-                case_name: 'Jane',
-                case_type: 'pregnancy',
-                date_opened: 'xxxxx',
-                external_id: null,
-                feeling_sick: 'No',
-                owner_id: 'xxxxxx',
-                village_name: 'Somewhere',
-              },
-              resource_uri: '',
-              server_date_modified: 'xxxxx',
-              server_date_opened: 'xxxxx',
-              user_id: 'xxxxx',
-              xform_ids: ['xxxx'],
-            },
-            {
-              case_id: '12345',
-              closed: false,
-              closed_by: null,
-              date_closed: null,
-              date_modified: 'xxxxx',
-              domain: `${domain}`,
-              id: '12345',
-              indexed_on: 'xxxxx',
-              indices: {},
-              opened_by: 'xxxxx',
-              properties: {
-                Children_alive: 'no',
-                Last_menstrual_period: 'xxxx',
-                Total_children: '',
-                case_name: 'Jane',
-                case_type: 'pregnancy',
-                date_opened: 'xxxxx',
-                external_id: null,
-                feeling_sick: 'No',
-                owner_id: 'xxxxxx',
-                village_name: 'Somewhere',
-              },
-              resource_uri: '',
-              server_date_modified: 'xxxxx',
-              server_date_opened: 'xxxxx',
-              user_id: 'xxxxx',
-              xform_ids: ['xxxx'],
-            },
-            {
-              case_id: '12345',
-              closed: false,
-              closed_by: null,
-              date_closed: null,
-              date_modified: 'xxxxx',
-              domain: `${domain}`,
-              id: '12345',
-              indexed_on: 'xxxxx',
-              indices: {},
-              opened_by: 'xxxxx',
-              properties: {
-                Children_alive: 'no',
-                Last_menstrual_period: 'xxxx',
-                Total_children: '',
-                case_name: 'Jane',
-                case_type: 'pregnancy',
-                date_opened: 'xxxxx',
-                external_id: null,
-                feeling_sick: 'No',
-                owner_id: 'xxxxxx',
-                village_name: 'Somewhere',
-              },
-              resource_uri: '',
-              server_date_modified: 'xxxxx',
-              server_date_opened: 'xxxxx',
-              user_id: 'xxxxx',
-              xform_ids: ['xxxx'],
-            },
-          ],
+          resource_uri: '',
+          server_date_modified: 'xxxxx',
+          server_date_opened: 'xxxxx',
+          user_id: 'xxxxx',
+          xform_ids: ['xxxx'],
         };
       });
 
@@ -292,71 +213,7 @@ describe('getCases', () => {
       },
     };
 
-    const { data, response } = await execute(
-      get('case', { limit: 1, offset: 0 })
-    )(state);
-
-    expect(data.length).to.equal(3);
-    expect(data[0]).to.haveOwnProperty('case_id');
-    expect(response.meta.limit).to.equal(1);
-  });
-
-  it('should fetch a single case', async () => {
-    testServer
-      .intercept({
-        path: `/a/${domain}/api/v0.5/case/12345`,
-        method: 'GET',
-        query: {
-          limit: 1000,
-          offset: 0,
-        },
-      })
-      .reply(200, () => {
-        return [
-          {
-            case_id: '12345',
-            closed: false,
-            closed_by: null,
-            date_closed: null,
-            date_modified: 'xxxxx',
-            domain: `${domain}`,
-            id: '12345',
-            indexed_on: 'xxxxx',
-            indices: {},
-            opened_by: 'xxxxx',
-            properties: {
-              Children_alive: 'no',
-              Last_menstrual_period: 'xxxx',
-              Total_children: '',
-              case_name: 'Jane',
-              case_type: 'pregnancy',
-              date_opened: 'xxxxx',
-              external_id: null,
-              feeling_sick: 'No',
-              owner_id: 'xxxxxx',
-              village_name: 'Somewhere',
-            },
-            resource_uri: '',
-            server_date_modified: 'xxxxx',
-            server_date_opened: 'xxxxx',
-            user_id: 'xxxxx',
-            xform_ids: ['xxxx'],
-          },
-        ];
-      });
-
-    const state = {
-      configuration: {
-        hostUrl,
-        domain,
-        appId: app,
-        username: 'user',
-        password: 'password',
-      },
-    };
-
     const { data } = await execute(get('case/12345'))(state);
-
     expect(data[0].case_id).to.equal('12345');
     expect(data[0].properties.case_type).to.equal('pregnancy');
   });
@@ -364,7 +221,7 @@ describe('getCases', () => {
   it('should fetch cases and call the callback', async () => {
     testServer
       .intercept({
-        path: `/a/${domain}/api/v0.5/case`,
+        path: /\/a\/my-domain\/api\/v0\.5\/case/,
         method: 'GET',
         query: {
           limit: 1000,
@@ -461,6 +318,54 @@ describe('getCases', () => {
         xform_ids: ['xxxx'],
       },
     ]);
+  });
+
+  it('should fetch cases with pagination', async () => {
+    const objects = [
+      { case_id: '123' },
+      { case_id: '456' },
+      { case_id: '789' },
+    ];
+    testServer
+      .intercept({
+        path: /\/a\/my-domain\/api\/v0\.5\/case/,
+        method: 'GET',
+      })
+      .reply(200, req => {
+        const offset = req.query.offset;
+        const next =
+          req.query.offset < objects.length - 1
+            ? `offset=${offset + 1}&limit=1`
+            : null;
+        return {
+          meta: {
+            limit: 1,
+            next: next,
+            offset: offset,
+            previous: null,
+            total_count: 3,
+          },
+          objects: [objects[offset]],
+        };
+      })
+      .times(4);
+
+    const state = {
+      configuration: {
+        hostUrl,
+        domain,
+        appId: app,
+        username: 'user',
+        password: 'password',
+      },
+    };
+
+    const { data, response } = await execute(
+      get('case', { limit: 1, offset: 0 })
+    )(state);
+    expect(data.length).to.equal(3);
+    expect(response.meta.limit).to.equal(1);
+    expect(response.meta.offset).to.equal(2);
   });
 });
 

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -15,7 +15,7 @@ const defaultObjects = [
   { case_id: '5' },
   { case_id: '6' },
 ];
-const handlePayload = (offset = 0, limit, objects = defaultObjects) => {
+const paginatedResponse = (offset = 0, limit, objects = defaultObjects) => {
   const next =
     offset + limit < objects.length ? `offset=${offset + limit}&limit=1` : null;
 
@@ -30,9 +30,9 @@ const handlePayload = (offset = 0, limit, objects = defaultObjects) => {
   };
 };
 
-describe('handlePayload', () => {
+describe('paginatedResponse', () => {
   it('should handle offset=0 limit=1', () => {
-    const result = handlePayload(0, 1);
+    const result = paginatedResponse(0, 1);
     expect(result).to.eql({
       meta: {
         limit: 1,
@@ -45,7 +45,7 @@ describe('handlePayload', () => {
   });
 
   it('should handle offset=3 limit=3', () => {
-    const result = handlePayload(3, 3);
+    const result = paginatedResponse(3, 3);
     expect(result.meta).to.eql({
       limit: 3,
       offset: 3,
@@ -55,7 +55,7 @@ describe('handlePayload', () => {
     expect(result.objects.length).to.equal(3);
   });
   it('should handle offset=5 limit=1', () => {
-    const result = handlePayload(5, 1);
+    const result = paginatedResponse(5, 1);
     expect(result.meta).to.eql({
       limit: 1,
       offset: 5,
@@ -66,7 +66,7 @@ describe('handlePayload', () => {
   });
 
   it('should handle offset=0 limit=6', () => {
-    const result = handlePayload(0, 6);
+    const result = paginatedResponse(0, 6);
     expect(result.meta).to.eql({
       limit: 6,
       offset: 0,
@@ -76,7 +76,7 @@ describe('handlePayload', () => {
     expect(result.objects.length).to.equal(6);
   });
   it('should handle offset=5 limit=12', () => {
-    const result = handlePayload(5, 12);
+    const result = paginatedResponse(5, 12);
     expect(result.meta).to.eql({
       limit: 12,
       offset: 5,
@@ -87,7 +87,6 @@ describe('handlePayload', () => {
   });
 });
 
-//  add a describe to test above function- atleast 6, small 5 limit 1 0 limit 6 limit 12 off 5
 describe('execute', () => {
   it('executes each operation in sequence', done => {
     let state = {
@@ -422,7 +421,7 @@ describe('get', () => {
         method: 'GET',
       })
       .reply(200, req => {
-        return handlePayload(req.query.offset, 1, objects);
+        return paginatedResponse(req.query.offset, 1, objects);
       })
       .times(5);
 
@@ -454,7 +453,7 @@ describe('get', () => {
         method: 'GET',
       })
       .reply(200, req => {
-        return handlePayload(req.query.offset, 1, objects);
+        return paginatedResponse(req.query.offset, 1, objects);
       })
       .times(3);
 
@@ -565,7 +564,7 @@ describe('get', () => {
         },
       })
       .reply(200, req => {
-        return handlePayload(req.query.offset, req.query.limit);
+        return paginatedResponse(req.query.offset, req.query.limit);
       })
       .times(5);
 
@@ -625,38 +624,6 @@ describe('get', () => {
 
     await execute(get('case', {}, callback))(state);
     expect(callbackArgCount).to.deep.equal(1);
-  });
-
-  it.skip('should stop paginating after the first error', async () => {
-    const objects = [
-      { case_id: '123' },
-      { case_id: '456' },
-      { case_id: '789' },
-    ];
-    testServer
-      .intercept({
-        path: /\/a\/my-domain\/api\/v0\.5\/case/,
-        method: 'GET',
-      })
-      .reply(200, req => {
-        return handlePayload(req.query.offset, 1, objects);
-      })
-      .times(5);
-
-    const state = {
-      configuration: {
-        hostUrl,
-        domain,
-        appId: app,
-        username: 'user',
-        password: 'password',
-      },
-    };
-
-    const { data, response } = await execute(get('case'))(state);
-    expect(data.length).to.equal(3);
-    expect(response.meta.limit).to.equal(1);
-    expect(response.meta.offset).to.equal(2);
   });
 });
 describe('createUser', () => {

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -104,16 +104,19 @@ describe('getCases', () => {
       .intercept({
         path: `/a/${domain}/api/v0.5/case`,
         method: 'GET',
+        query: {
+          limit: 1,
+          offset: 0,
+        },
       })
       .reply(200, () => {
-        // simulate a return from commcare
         return {
           meta: {
             limit: 1,
             next: null,
             offset: 0,
             previous: null,
-            total_count: 2,
+            total_count: 1,
           },
           objects: [
             {
@@ -159,9 +162,141 @@ describe('getCases', () => {
       },
     };
 
-    const { data, response } = await execute(get('case'))(state);
+    const { data, response } = await execute(
+      get('case', { limit: 1, offset: 0 })
+    )(state);
 
     expect(data.length).to.equal(1);
+    expect(data[0]).to.haveOwnProperty('case_id');
+    expect(response.meta.limit).to.equal(1);
+  });
+
+  it('should fetch cases with pagination', async () => {
+    testServer
+      .intercept({
+        path: `/a/${domain}/api/v0.5/case`,
+        method: 'GET',
+        query: {
+          limit: 1,
+          offset: 0,
+        },
+      })
+      .reply(200, () => {
+        return {
+          meta: {
+            limit: 1,
+            next: null,
+            offset: 0,
+            previous: null,
+            total_count: 3,
+          },
+          objects: [
+            {
+              case_id: '12345',
+              closed: false,
+              closed_by: null,
+              date_closed: null,
+              date_modified: 'xxxxx',
+              domain: `${domain}`,
+              id: '12345',
+              indexed_on: 'xxxxx',
+              indices: {},
+              opened_by: 'xxxxx',
+              properties: {
+                Children_alive: 'no',
+                Last_menstrual_period: 'xxxx',
+                Total_children: '',
+                case_name: 'Jane',
+                case_type: 'pregnancy',
+                date_opened: 'xxxxx',
+                external_id: null,
+                feeling_sick: 'No',
+                owner_id: 'xxxxxx',
+                village_name: 'Somewhere',
+              },
+              resource_uri: '',
+              server_date_modified: 'xxxxx',
+              server_date_opened: 'xxxxx',
+              user_id: 'xxxxx',
+              xform_ids: ['xxxx'],
+            },
+            {
+              case_id: '12345',
+              closed: false,
+              closed_by: null,
+              date_closed: null,
+              date_modified: 'xxxxx',
+              domain: `${domain}`,
+              id: '12345',
+              indexed_on: 'xxxxx',
+              indices: {},
+              opened_by: 'xxxxx',
+              properties: {
+                Children_alive: 'no',
+                Last_menstrual_period: 'xxxx',
+                Total_children: '',
+                case_name: 'Jane',
+                case_type: 'pregnancy',
+                date_opened: 'xxxxx',
+                external_id: null,
+                feeling_sick: 'No',
+                owner_id: 'xxxxxx',
+                village_name: 'Somewhere',
+              },
+              resource_uri: '',
+              server_date_modified: 'xxxxx',
+              server_date_opened: 'xxxxx',
+              user_id: 'xxxxx',
+              xform_ids: ['xxxx'],
+            },
+            {
+              case_id: '12345',
+              closed: false,
+              closed_by: null,
+              date_closed: null,
+              date_modified: 'xxxxx',
+              domain: `${domain}`,
+              id: '12345',
+              indexed_on: 'xxxxx',
+              indices: {},
+              opened_by: 'xxxxx',
+              properties: {
+                Children_alive: 'no',
+                Last_menstrual_period: 'xxxx',
+                Total_children: '',
+                case_name: 'Jane',
+                case_type: 'pregnancy',
+                date_opened: 'xxxxx',
+                external_id: null,
+                feeling_sick: 'No',
+                owner_id: 'xxxxxx',
+                village_name: 'Somewhere',
+              },
+              resource_uri: '',
+              server_date_modified: 'xxxxx',
+              server_date_opened: 'xxxxx',
+              user_id: 'xxxxx',
+              xform_ids: ['xxxx'],
+            },
+          ],
+        };
+      });
+
+    const state = {
+      configuration: {
+        hostUrl,
+        domain,
+        appId: app,
+        username: 'user',
+        password: 'password',
+      },
+    };
+
+    const { data, response } = await execute(
+      get('case', { limit: 1, offset: 0 })
+    )(state);
+
+    expect(data.length).to.equal(3);
     expect(data[0]).to.haveOwnProperty('case_id');
     expect(response.meta.limit).to.equal(1);
   });
@@ -171,38 +306,43 @@ describe('getCases', () => {
       .intercept({
         path: `/a/${domain}/api/v0.5/case/12345`,
         method: 'GET',
+        query: {
+          limit: 1000,
+          offset: 0,
+        },
       })
       .reply(200, () => {
-        // simulate a return from commcare
-        return {
-          case_id: '12345',
-          closed: false,
-          closed_by: null,
-          date_closed: null,
-          date_modified: 'xxxxx',
-          domain: `${domain}`,
-          id: '12345',
-          indexed_on: 'xxxxx',
-          indices: {},
-          opened_by: 'xxxxx',
-          properties: {
-            Children_alive: 'no',
-            Last_menstrual_period: 'xxxx',
-            Total_children: '',
-            case_name: 'Jane',
-            case_type: 'pregnancy',
-            date_opened: 'xxxxx',
-            external_id: null,
-            feeling_sick: 'No',
-            owner_id: 'xxxxxx',
-            village_name: 'Somewhere',
+        return [
+          {
+            case_id: '12345',
+            closed: false,
+            closed_by: null,
+            date_closed: null,
+            date_modified: 'xxxxx',
+            domain: `${domain}`,
+            id: '12345',
+            indexed_on: 'xxxxx',
+            indices: {},
+            opened_by: 'xxxxx',
+            properties: {
+              Children_alive: 'no',
+              Last_menstrual_period: 'xxxx',
+              Total_children: '',
+              case_name: 'Jane',
+              case_type: 'pregnancy',
+              date_opened: 'xxxxx',
+              external_id: null,
+              feeling_sick: 'No',
+              owner_id: 'xxxxxx',
+              village_name: 'Somewhere',
+            },
+            resource_uri: '',
+            server_date_modified: 'xxxxx',
+            server_date_opened: 'xxxxx',
+            user_id: 'xxxxx',
+            xform_ids: ['xxxx'],
           },
-          resource_uri: '',
-          server_date_modified: 'xxxxx',
-          server_date_opened: 'xxxxx',
-          user_id: 'xxxxx',
-          xform_ids: ['xxxx'],
-        };
+        ];
       });
 
     const state = {
@@ -217,8 +357,8 @@ describe('getCases', () => {
 
     const { data } = await execute(get('case/12345'))(state);
 
-    expect(data.case_id).to.equal('12345');
-    expect(data.properties.case_type).to.equal('pregnancy');
+    expect(data[0].case_id).to.equal('12345');
+    expect(data[0].properties.case_type).to.equal('pregnancy');
   });
 
   it('should fetch cases and call the callback', async () => {
@@ -226,9 +366,12 @@ describe('getCases', () => {
       .intercept({
         path: `/a/${domain}/api/v0.5/case`,
         method: 'GET',
+        query: {
+          limit: 1000,
+          offset: 0,
+        },
       })
       .reply(200, () => {
-        // simulate a return from commcare
         return {
           meta: {
             limit: 1,
@@ -280,13 +423,13 @@ describe('getCases', () => {
         password: 'password',
       },
     };
-
-    const callback = sinon.spy();
+    let callbackArg;
+    const callback = state => {
+      callbackArg = state;
+      return state;
+    };
 
     await execute(get('case', {}, callback))(state);
-
-    expect(callback.calledOnce).to.be.true;
-    const callbackArg = callback.firstCall.args[0];
     expect(callbackArg.data).to.deep.equal([
       {
         case_id: '12345',

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -178,7 +178,7 @@ describe('SubmitXls', () => {
 });
 
 describe('getCases', () => {
-  it('should fetch cases', async () => {
+  it.only('should fetch cases', async () => {
     testServer
       .intercept({
         path: `/a/${domain}/api/v0.5/case`,
@@ -296,15 +296,11 @@ describe('getCases', () => {
     expect(data.properties.case_type).to.equal('pregnancy');
   });
 
-  it('should fetch cases and call the callback', async () => {
+  it.only('should fetch cases and call the callback', async () => {
     testServer
       .intercept({
         path: `/a/${domain}/api/v0.5/case`,
         method: 'GET',
-        query: {
-          limit: 400,
-          offset: 0,
-        },
       })
       .reply(200, () => {
         return {
@@ -313,7 +309,7 @@ describe('getCases', () => {
             next: null,
             offset: 0,
             previous: null,
-            total_count: 2,
+            total_count: 1,
           },
           objects: [
             {
@@ -364,16 +360,7 @@ describe('getCases', () => {
       return state;
     };
 
-    await execute(
-      get(
-        'case',
-        {
-          limit: 400,
-          offset: 0,
-        },
-        callback
-      )
-    )(state);
+    await execute(get('case', {}, callback))(state);
     expect(callbackArg.data).to.deep.equal([
       {
         case_id: '12345',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,9 +247,6 @@ importers:
       lodash-fp:
         specifier: ^0.10.4
         version: 0.10.4
-      sinon:
-        specifier: ^18.0.0
-        version: 18.0.0
       xlsx:
         specifier: https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz
         version: '@cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz'
@@ -3527,6 +3524,7 @@ packages:
     resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
     dependencies:
       type-detect: 4.0.8
+    dev: true
 
   /@sinonjs/commons@3.0.0:
     resolution: {integrity: sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==}
@@ -3534,23 +3532,11 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /@sinonjs/commons@3.0.1:
-    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
-    dependencies:
-      type-detect: 4.0.8
-    dev: false
-
   /@sinonjs/fake-timers@10.3.0:
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
     dependencies:
       '@sinonjs/commons': 3.0.0
     dev: true
-
-  /@sinonjs/fake-timers@11.2.2:
-    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-    dev: false
 
   /@sinonjs/fake-timers@6.0.1:
     resolution: {integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==}
@@ -3580,16 +3566,9 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /@sinonjs/samsam@8.0.0:
-    resolution: {integrity: sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==}
-    dependencies:
-      '@sinonjs/commons': 2.0.0
-      lodash.get: 4.4.2
-      type-detect: 4.0.8
-    dev: false
-
   /@sinonjs/text-encoding@0.7.2:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
+    dev: true
 
   /@slack/logger@3.0.0:
     resolution: {integrity: sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==}
@@ -6390,11 +6369,6 @@ packages:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
     dev: true
-
-  /diff@5.2.0:
-    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
-    engines: {node: '>=0.3.1'}
-    dev: false
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -9432,10 +9406,6 @@ packages:
     resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
     dev: true
 
-  /just-extend@6.2.0:
-    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
-    dev: false
-
   /jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
     dependencies:
@@ -10397,16 +10367,6 @@ packages:
       path-to-regexp: 1.8.0
     dev: true
 
-  /nise@6.0.0:
-    resolution: {integrity: sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==}
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 11.2.2
-      '@sinonjs/text-encoding': 0.7.2
-      just-extend: 6.2.0
-      path-to-regexp: 6.2.2
-    dev: false
-
   /nock@12.0.3:
     resolution: {integrity: sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==}
     engines: {node: '>= 10.13'}
@@ -11058,10 +11018,6 @@ packages:
     dependencies:
       isarray: 0.0.1
     dev: true
-
-  /path-to-regexp@6.2.2:
-    resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
-    dev: false
 
   /path-type@2.0.0:
     resolution: {integrity: sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ==}
@@ -12151,17 +12107,6 @@ packages:
       nise: 5.1.4
       supports-color: 7.2.0
     dev: true
-
-  /sinon@18.0.0:
-    resolution: {integrity: sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==}
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 11.2.2
-      '@sinonjs/samsam': 8.0.0
-      diff: 5.2.0
-      nise: 6.0.0
-      supports-color: 7.2.0
-    dev: false
 
   /sinon@9.2.4:
     resolution: {integrity: sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==}
@@ -13289,6 +13234,7 @@ packages:
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
+    dev: true
 
   /type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}


### PR DESCRIPTION
## Summary

Implement pagination on commcare`get`

## Details

A manual implementation of pagination of data fetched from commcare. Users can override the default pagination when they pass in `offset` and/or `limit` 

## Issues

#569 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, Added the adaptor on marketing website ?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
