### PR TITLE
Don't allow common http helpers to call absolute URLs

### DIFF
--- a/.changeset/clever-cars-invent.md
+++ b/.changeset/clever-cars-invent.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-http': patch
+---
+
+In all functions, if baseUrl if set, path MUST be relative.

--- a/.changeset/lemon-rivers-speak.md
+++ b/.changeset/lemon-rivers-speak.md
@@ -1,0 +1,7 @@
+---
+'@openfn/language-asana': patch
+---
+
+Don't allow HTTP helpers to call out to different domains. This can cause a
+security violation where credentials are sent to external servers. Use generic
+HTTP helpers like `http.get` or `fetch` instead.

--- a/.changeset/perfect-badgers-appear.md
+++ b/.changeset/perfect-badgers-appear.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-asana': patch
+---
+
+Fix an issue where not passing a params argument would trigger an exception

--- a/.changeset/tough-items-compete.md
+++ b/.changeset/tough-items-compete.md
@@ -1,5 +1,6 @@
 ---
 '@openfn/language-odk': patch
+'@openfn/language-satusehat': patch
 ---
 
 Enforce that absolute urls should not be passed

--- a/.changeset/tough-items-compete.md
+++ b/.changeset/tough-items-compete.md
@@ -1,6 +1,7 @@
 ---
 '@openfn/language-odk': patch
 '@openfn/language-satusehat': patch
+'@openfn/language-surveycto': patch
 ---
 
-Enforce that absolute urls should not be passed
+Enforce that absolute urls must not be passed to HTTP functions

--- a/.changeset/tough-items-compete.md
+++ b/.changeset/tough-items-compete.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-odk': patch
+---
+
+Enforce that absolute urls should not be passed

--- a/.changeset/yellow-candles-ring.md
+++ b/.changeset/yellow-candles-ring.md
@@ -1,5 +1,6 @@
 ---
 '@openfn/language-fhir': patch
+'@openfn/language-lmis': patch
 ---
 
 Use common helper code to handle invalid absolute URLs

--- a/.changeset/yellow-candles-ring.md
+++ b/.changeset/yellow-candles-ring.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-fhir': patch
+---
+
+Use common helper code to handle invalid absolute URLs

--- a/packages/asana/src/Adaptor.js
+++ b/packages/asana/src/Adaptor.js
@@ -264,23 +264,34 @@ export function createTaskStory(taskGid, params, callback) {
  */
 
 /**
- * Make a request in Asana API
+ * Make a HTTP request against the Asana API.
  * @public
- * @example
- * request("/asanaEndpoint", {
+ * @example Get a task by id
+ * request("/tasks/1234");
+ * @example Query for tasks in a given project
+ * request("/tasks", {
+ *   query: { project: "abc" },
+ * });
+ * @example Create a new task
+ * request("/tasks", {
  *   method: "POST",
- *   query: { foo: "bar", a: 1 },
+ *   body: { data: { name: "do the thing", completed: false } },
  * });
  * @function
- * @param {string} path - Path to resource
- * @param {RequestOptions} params - Query, body and method parameters
+ * @param {string} path - Path to resource (excluding api/version)
+ * @param {RequestOptions} params - (Optional) Query, body and method parameters
  * @param {function} callback - (Optional) Callback function
  * @returns {Operation}
  */
 export function request(path, params = {}, callback) {
   return state => {
-    const [resolvedPath, { body = {}, query = {}, method = 'GET' }] =
-      expandReferences(state, path, params);
+    const [resolvedPath, resolvedParams] = expandReferences(
+      state,
+      path,
+      params
+    );
+
+    const { body = {}, query = {}, method = 'GET' } = resolvedParams;
 
     return requestHelper(
       state,

--- a/packages/asana/src/Adaptor.js
+++ b/packages/asana/src/Adaptor.js
@@ -277,7 +277,7 @@ export function createTaskStory(taskGid, params, callback) {
  * @param {function} callback - (Optional) Callback function
  * @returns {Operation}
  */
-export function request(path, params, callback) {
+export function request(path, params = {}, callback) {
   return state => {
     const [resolvedPath, { body = {}, query = {}, method = 'GET' }] =
       expandReferences(state, path, params);

--- a/packages/asana/src/Utils.js
+++ b/packages/asana/src/Utils.js
@@ -36,9 +36,10 @@ export function request(state, path, params, callback = s => s) {
     })
     .then(callback)
     .catch(err => {
-      console.log('Asana says:');
-      logResponse(err);
-
+      if (err.code !== 'BASE_URL_MISMATCH') {
+        console.log('Asana says:');
+        logResponse(err);
+      }
       throw err;
     });
 }

--- a/packages/asana/test/index.js
+++ b/packages/asana/test/index.js
@@ -41,7 +41,7 @@ describe('request', () => {
     // happily the request won't actually be made, so we don't need to mock anything here
     let err;
     try {
-      await execute(request('https:///www.blah.com/a/b/c'))({});
+      await execute(request('https://www.blah.com/a/b/c'))({});
     } catch (e) {
       err = e;
     }

--- a/packages/asana/test/index.js
+++ b/packages/asana/test/index.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { execute } from '../src';
+import { execute, request } from '../src';
 
 describe('execute', () => {
   it('executes each operation in sequence', done => {
@@ -33,6 +33,19 @@ describe('execute', () => {
     execute()(state).then(finalState => {
       expect(finalState).to.eql({ references: [], data: null });
     });
+  });
+});
+
+describe('request', () => {
+  it('throws if an absolute URL is passed', async () => {
+    // happily the request won't actually be made, so we don't need to mock anything here
+    let err;
+    try {
+      await execute(request('https:///www.blah.com/a/b/c'))({});
+    } catch (e) {
+      err = e;
+    }
+    expect(err.code).to.equal('BASE_URL_MISMATCH');
   });
 });
 

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -78,6 +78,21 @@ const assertOK = async (response, errorMap, fullUrl, method, startTime) => {
   }
 };
 
+export const ERROR_ABSOLUTE_URL = 'Absolute URLs not suppored';
+
+// throws if a path is absolute
+export const assertRelativeUrl = path => {
+  if (/https?:\/\//.test(path)) {
+    const e = new Error('');
+    e.code = 'INVALID_ABSOLUTE_URL';
+    e.description = 'An absolute URL was provided but only a path is supported';
+    e.url = path;
+    e.fix =
+      'Remove the protocol, domain and origin from the provided URL. Maybe you need to use the generic HTTP helper functions instead?';
+    throw e;
+  }
+};
+
 export const ERROR_URL_MISMATCH = 'Target origin does not match baseUrl origin';
 
 export const parseUrl = (pathOrUrl = '', baseUrl) => {
@@ -91,6 +106,7 @@ export const parseUrl = (pathOrUrl = '', baseUrl) => {
     // If the url is absolute, and there's a basePath, ensure they point to the same origin
     if (baseUrl) {
       const base = new URL(baseUrl);
+      // TODO should I `assertURLPath` here instead? Is that actually a cleaner error?
       if (fullUrl.origin !== base.origin) {
         const e = new Error(ERROR_URL_MISMATCH);
         e.code = 'BASE_URL_MISMATCH';

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -84,7 +84,7 @@ export const ERROR_ABSOLUTE_URL = 'Absolute URLs not suppored';
 export const assertRelativeUrl = path => {
   if (/https?:\/\//.test(path)) {
     const e = new Error('');
-    e.code = 'INVALID_ABSOLUTE_URL';
+    e.code = 'UNEXPECTED_ABSOLUTE_URL';
     e.description = 'An absolute URL was provided but only a path is supported';
     e.url = path;
     e.fix =

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -92,7 +92,14 @@ export const parseUrl = (pathOrUrl = '', baseUrl) => {
     if (baseUrl) {
       const base = new URL(baseUrl);
       if (fullUrl.origin !== base.origin) {
-        throw new Error(ERROR_URL_MISMATCH);
+        const e = new Error(ERROR_URL_MISMATCH);
+        e.code = 'BASE_URL_MISMATCH';
+        e.description = `A request was attempted to an absolute URL, but a different base URL was specified. This is potential security violation.`;
+        e.target = pathOrUrl;
+        e.baseUrl = baseUrl;
+        e.fix = 'Try using a generic HTTP function to access the target URL';
+        // TODO maybe link to docs?
+        throw e;
       }
     }
   } else if (baseUrl) {

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -2,6 +2,7 @@ import { Client, MockAgent } from 'undici';
 import { getReasonPhrase } from 'http-status-codes';
 import { Readable } from 'node:stream';
 import querystring from 'node:querystring';
+import path from 'node:path';
 
 const clients = new Map();
 
@@ -77,31 +78,35 @@ const assertOK = async (response, errorMap, fullUrl, method, startTime) => {
   }
 };
 
+export const ERROR_URL_MISMATCH = 'Target origin does not match baseUrl origin';
+
 export const parseUrl = (pathOrUrl = '', baseUrl) => {
   let fullUrl;
 
   // We handle our own URL parsing rather than leaning on node:url
   // because we are non-strict about the baseURL (ie, we do not ignore the path)
   if (/https?:\/\//.test(pathOrUrl)) {
-    fullUrl = pathOrUrl;
-  } else if (baseUrl) {
-    // ensure the base url ends with a /
-    const base = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
-    // ensure the path does not start with /
-    const path = pathOrUrl.startsWith('/') ? pathOrUrl.substring(1) : pathOrUrl;
+    fullUrl = new URL(pathOrUrl);
 
-    fullUrl = base + path;
+    // If the url is absolute, and there's a basePath, ensure they point to the same origin
+    if (baseUrl) {
+      const base = new URL(baseUrl);
+      if (fullUrl.origin !== base.origin) {
+        throw new Error(ERROR_URL_MISMATCH);
+      }
+    }
+  } else if (baseUrl) {
+    fullUrl = new URL(path.join(baseUrl, pathOrUrl));
   } else {
     // let this throw
     new URL(pathOrUrl);
   }
 
-  const url = new URL(fullUrl);
   return {
-    url: url.toString(),
-    baseUrl: url.origin,
-    path: url.pathname,
-    query: querystring.parse(url.searchParams.toString()),
+    url: fullUrl.toString(),
+    baseUrl: fullUrl.origin,
+    path: fullUrl.pathname,
+    query: querystring.parse(fullUrl.searchParams.toString()),
   };
 };
 

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -94,7 +94,7 @@ export const parseUrl = (pathOrUrl = '', baseUrl) => {
       if (fullUrl.origin !== base.origin) {
         const e = new Error(ERROR_URL_MISMATCH);
         e.code = 'BASE_URL_MISMATCH';
-        e.description = `A request was attempted to an absolute URL, but a different base URL was specified. This is potential security violation.`;
+        e.description = `A request was attempted to an absolute URL, but a different base URL was specified. This is a potential security violation.`;
         e.target = pathOrUrl;
         e.baseUrl = baseUrl;
         e.fix = 'Try using a generic HTTP function to access the target URL';

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -85,7 +85,8 @@ export const assertRelativeUrl = path => {
   if (/https?:\/\//.test(path)) {
     const e = new Error('');
     e.code = 'UNEXPECTED_ABSOLUTE_URL';
-    e.description = 'An absolute URL was provided but only a path is supported';
+    e.description =
+      'An absolute URL was provided (https://...) but only a path (/a/b/c) is supported';
     e.url = path;
     e.fix =
       'Remove the protocol, domain and origin from the provided URL. Maybe you need to use the generic HTTP helper functions instead?';
@@ -106,7 +107,6 @@ export const parseUrl = (pathOrUrl = '', baseUrl) => {
     // If the url is absolute, and there's a basePath, ensure they point to the same origin
     if (baseUrl) {
       const base = new URL(baseUrl);
-      // TODO should I `assertURLPath` here instead? Is that actually a cleaner error?
       if (fullUrl.origin !== base.origin) {
         const e = new Error(ERROR_URL_MISMATCH);
         e.code = 'BASE_URL_MISMATCH';
@@ -114,7 +114,6 @@ export const parseUrl = (pathOrUrl = '', baseUrl) => {
         e.target = pathOrUrl;
         e.baseUrl = baseUrl;
         e.fix = 'Try using a generic HTTP function to access the target URL';
-        // TODO maybe link to docs?
         throw e;
       }
     }

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -13,8 +13,6 @@ import {
 
 const client = enableMockClient('https://www.example.com');
 
-// TODO double check these tests and make sure they cover enoguh cases now
-// Also send some invalid requests - break it!
 describe('parseUrl', () => {
   it('should work with a url and path', () => {
     const { url, baseUrl, path } = parseUrl('https://www.example.org/a/b/c');

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -63,6 +63,17 @@ describe('parseUrl', () => {
     expect(url).to.eql('https://www.example.org/api/a/b/c');
   });
 
+  it('should work with matching absolute url and base', () => {
+    const { url, baseUrl, path } = parseUrl(
+      'https://www.example.org/api/a/b/c',
+      'https://www.example.org/api'
+    );
+
+    expect(baseUrl).to.equal('https://www.example.org');
+    expect(path).to.equal('/api/a/b/c');
+    expect(url).to.eql('https://www.example.org/api/a/b/c');
+  });
+
   it('should extract query parameters', () => {
     const { query } = parseUrl('a/b/c?x=1&y=2', 'https://www.example.org/api');
 

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -8,12 +8,15 @@ import {
   post,
   del,
   parseUrl,
+  ERROR_URL_MISMATCH,
 } from '../../src/util/http.js';
 
 const client = enableMockClient('https://www.example.com');
 
+// TODO double check these tests and make sure they cover enoguh cases now
+// Also send some invalid requests - break it!
 describe('parseUrl', () => {
-  it('should work with a url as a path', () => {
+  it('should work with a url and path', () => {
     const { url, baseUrl, path } = parseUrl('https://www.example.org/a/b/c');
 
     expect(baseUrl).to.equal('https://www.example.org');
@@ -79,6 +82,22 @@ describe('parseUrl', () => {
       parseUrl('/a/b/c', 'www.example.org');
     } catch (e) {
       expect(e.message).to.eql('Invalid URL');
+    }
+  });
+
+  it('should throw if path and no base', () => {
+    try {
+      parseUrl('/a/b/c');
+    } catch (e) {
+      expect(e.message).to.eql('Invalid URL');
+    }
+  });
+
+  it('should throw if url and base mismatch', () => {
+    try {
+      parseUrl('http://www.x.com/a', 'http://www.y.com/a');
+    } catch (e) {
+      expect(e.message).to.eql(ERROR_URL_MISMATCH);
     }
   });
 });

--- a/packages/common/test/util/parse-date.test.js
+++ b/packages/common/test/util/parse-date.test.js
@@ -7,102 +7,101 @@ import { startOfDay, subDays, subHours } from 'date-fns';
 // there is a vanishingly small chance that dates could be 1ns apart
 // but cross an ms line - there's only so much we can do about this
 const approxEqual = (a, b) => {
-  const a_ms = a.substring(0, a.length - 5)
-  const b_ms = a.substring(0, a.length - 5)
-  expect(a_ms).eql(b_ms)
-}
+  const a_ms = a.substring(0, a.length - 5);
+  const b_ms = a.substring(0, a.length - 5);
+  expect(a_ms).eql(b_ms);
+};
 
-describe.only('parse date', () => {
-
+describe('parse date', () => {
   it('should return now', () => {
-    const today = new Date().toISOString()
-    
-    const result = parseDate('now').toISOString()
-    approxEqual(result, today)
-  })
+    const today = new Date().toISOString();
+
+    const result = parseDate('now').toISOString();
+    approxEqual(result, today);
+  });
 
   it('should return start of today', () => {
-    const today = startOfDay(new Date()).toISOString()
-    
-    const result = parseDate('today').toISOString()
-    expect(result).eql(today)
-  })
+    const today = startOfDay(new Date()).toISOString();
+
+    const result = parseDate('today').toISOString();
+    expect(result).eql(today);
+  });
 
   it('should return start of yesterday', () => {
-    const yesterday = startOfDay(subDays(new Date(), 1)).toISOString()
-    
-    const result = parseDate('yesterday').toISOString()
-    expect(result).eql(yesterday)
-  })
+    const yesterday = startOfDay(subDays(new Date(), 1)).toISOString();
+
+    const result = parseDate('yesterday').toISOString();
+    expect(result).eql(yesterday);
+  });
 
   it('should return 1 hour ago', () => {
-    const target = subHours(new Date(), 1).toISOString()
-    
-    const result = parseDate('1 hour ago').toISOString()
-    approxEqual(result, target)
-  })
+    const target = subHours(new Date(), 1).toISOString();
+
+    const result = parseDate('1 hour ago').toISOString();
+    approxEqual(result, target);
+  });
 
   it('should return 1 hours ago', () => {
-    const target = subHours(new Date(), 1).toISOString()
-    
-    const result = parseDate('1 hours ago').toISOString()
-    approxEqual(result, target)
-  })
+    const target = subHours(new Date(), 1).toISOString();
+
+    const result = parseDate('1 hours ago').toISOString();
+    approxEqual(result, target);
+  });
 
   it('should return 0001 hours ago', () => {
-    const target = subHours(new Date(), 1).toISOString()
-    
-    const result = parseDate('0001 hours ago').toISOString()
-    approxEqual(result, target)
-  })
+    const target = subHours(new Date(), 1).toISOString();
+
+    const result = parseDate('0001 hours ago').toISOString();
+    approxEqual(result, target);
+  });
 
   it('should return 333 hours ago', () => {
-    const target = subHours(new Date(), 333).toISOString()
-    
-    const result = parseDate('333 hours ago').toISOString()
-    approxEqual(result, target)
-  })
+    const target = subHours(new Date(), 333).toISOString();
+
+    const result = parseDate('333 hours ago').toISOString();
+    approxEqual(result, target);
+  });
 
   it('should return 1 day ago', () => {
-    const target = subDays(new Date(), 1).toISOString()
-    
-    const result = parseDate('1 day ago').toISOString()
-    approxEqual(result, target)
-  })
+    const target = subDays(new Date(), 1).toISOString();
+
+    const result = parseDate('1 day ago').toISOString();
+    approxEqual(result, target);
+  });
 
   it('should return 1 days ago', () => {
-    const target = subDays(new Date(), 1).toISOString()
-    
-    const result = parseDate('1 days ago').toISOString()
-    approxEqual(result, target)
-  })
+    const target = subDays(new Date(), 1).toISOString();
+
+    const result = parseDate('1 days ago').toISOString();
+    approxEqual(result, target);
+  });
 
   it('should return 2 days ago', () => {
-    const target = startOfDay(subDays(new Date(), 2)).toLocaleString()
-    console.log(target)
-    const result = parseDate('2 days ago').toLocaleString()
-    console.log(result)
-    expect(result).eql(target)
-  })
+    const target = startOfDay(subDays(new Date(), 2)).toLocaleString();
+    console.log(target);
+    const result = parseDate('2 days ago').toLocaleString();
+    console.log(result);
+    expect(result).eql(target);
+  });
 
   it('should return 9999 days ago', () => {
-    const target = startOfDay(subDays(new Date(), 9999)).toISOString()
-    
-    const result = parseDate('9999 days ago').toISOString()
-    expect(result).eql(target)
-  })
+    const target = startOfDay(subDays(new Date(), 9999)).toISOString();
+
+    const result = parseDate('9999 days ago').toISOString();
+    expect(result).eql(target);
+  });
 
   it('should return start', () => {
-    const start = subHours(new Date(), 1).toISOString()
-    
-    const result = parseDate('start', start)
-    expect(result).eql(start)
-  })
+    const start = subHours(new Date(), 1).toISOString();
+
+    const result = parseDate('start', start);
+    expect(result).eql(start);
+  });
 
   it('should return a date', () => {
-    const date = subHours(new Date(), 3).toISOString()
-    
-    const result = parseDate(date)
-    expect(result).eql(date)
+    const date = subHours(new Date(), 3).toISOString();
+
+    const result = parseDate(date);
+    expect(result).eql(date);
   });
-})
+});

--- a/packages/fhir/src/Utils.js
+++ b/packages/fhir/src/Utils.js
@@ -4,10 +4,8 @@ import {
   request as commonRequest,
   logResponse,
   makeBasicAuthHeader,
+  assertRelativeUrl,
 } from '@openfn/language-common/util';
-
-import { composeNextState } from '@openfn/language-common';
-import { assertRelativeUrl } from '../../common/src/util/http';
 
 export function addAuth(configuration = {}, headers) {
   if (headers.Authorization) return;

--- a/packages/fhir/src/Utils.js
+++ b/packages/fhir/src/Utils.js
@@ -7,6 +7,7 @@ import {
 } from '@openfn/language-common/util';
 
 import { composeNextState } from '@openfn/language-common';
+import { assertRelativeUrl } from '../../common/src/util/http';
 
 export function addAuth(configuration = {}, headers) {
   if (headers.Authorization) return;
@@ -30,11 +31,12 @@ export const prepareNextState = (state, response, callback) => {
 };
 
 export const request = (configuration, method, path, options = {}) => {
+  assertRelativeUrl(path);
+
   const { baseUrl, apiPath } = configuration;
   const { headers = {}, ...otherOptions } = options;
   const fullPath = nodepath.join(apiPath ?? '', path);
 
-  urlMatchesBase(path, baseUrl);
   addAuth(configuration, headers);
 
   const opts = {
@@ -50,13 +52,3 @@ export const request = (configuration, method, path, options = {}) => {
 
   return commonRequest(method, fullPath, opts).then(logResponse);
 };
-
-function urlMatchesBase(path, baseUrl) {
-  const base = new URL(baseUrl);
-  const url = new URL(path, baseUrl);
-
-  if (url.origin !== base.origin) {
-    throw new Error(`The URL ${path} does not match the base URL ${baseUrl}`);
-  }
-  return true;
-}

--- a/packages/fhir/src/Utils.js
+++ b/packages/fhir/src/Utils.js
@@ -1,5 +1,6 @@
 import nodepath from 'node:path';
 
+import { composeNextState } from '@openfn/language-common';
 import {
   request as commonRequest,
   logResponse,

--- a/packages/fhir/test/Adaptor.test.js
+++ b/packages/fhir/test/Adaptor.test.js
@@ -248,6 +248,6 @@ describe('post', () => {
       return error;
     });
 
-    expect(error.code).to.eql('INVALID_ABSOLUTE_URL');
+    expect(error.code).to.eql('UNEXPECTED_ABSOLUTE_URL');
   });
 });

--- a/packages/fhir/test/Adaptor.test.js
+++ b/packages/fhir/test/Adaptor.test.js
@@ -248,8 +248,6 @@ describe('post', () => {
       return error;
     });
 
-    expect(error.message).to.eql(
-      'The URL https://example.com/claim does not match the base URL https://hapi.fhir.org'
-    );
+    expect(error.code).to.eql('INVALID_ABSOLUTE_URL');
   });
 });

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -116,7 +116,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a HTTP request",
+        "description": "Make a HTTP request. If `configuration.baseUrl` is set, paths must be relative.",
         "tags": [
           {
             "title": "public",
@@ -134,7 +134,7 @@
           },
           {
             "title": "param",
-            "description": "The HTTP method to use",
+            "description": "The HTTP method to use.",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -143,7 +143,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -192,7 +192,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a GET request",
+        "description": "Make a GET request. If `configuration.baseUrl` is set, paths must be relative.",
         "tags": [
           {
             "title": "public",
@@ -210,7 +210,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -259,7 +259,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a POST request",
+        "description": "Make a POST request. If `configuration.baseUrl` is set, paths must be relative.",
         "tags": [
           {
             "title": "public",
@@ -277,7 +277,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -326,7 +326,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a PUT request",
+        "description": "Make a PUT request. If `configuration.baseUrl` is set, paths must be relative.",
         "tags": [
           {
             "title": "public",
@@ -344,7 +344,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -393,7 +393,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a PATCH request",
+        "description": "Make a PATCH request. If `configuration.baseUrl` is set, paths must be relative.",
         "tags": [
           {
             "title": "public",
@@ -411,7 +411,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -460,7 +460,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a DELETE request",
+        "description": "Make a DELETE request. If `configuration.baseUrl` is set, paths must be relative.",
         "tags": [
           {
             "title": "public",
@@ -478,7 +478,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.",
             "type": {
               "type": "NameExpression",
               "name": "string"

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -46,7 +46,7 @@ export function execute(...operations) {
 }
 
 /**
- * Make a HTTP request
+ * Make a HTTP request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
  * request(
@@ -58,8 +58,8 @@ export function execute(...operations) {
  *    }
  * )
  * @function
- * @param {string} method - The HTTP method to use
- * @param {string} path - Path to resource
+ * @param {string} method - The HTTP method to use.
+ * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} params - Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
@@ -70,7 +70,7 @@ export function request(method, path, params, callback) {
 }
 
 /**
- * Make a GET request
+ * Make a GET request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
  * get('/myEndpoint', {
@@ -78,7 +78,7 @@ export function request(method, path, params, callback) {
  *   headers: {'content-type': 'application/json'},
  * })
  * @function
- * @param {string} path - Path to resource
+ * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} params - Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
@@ -89,7 +89,7 @@ export function get(path, params, callback) {
 }
 
 /**
- * Make a POST request
+ * Make a POST request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
  *  post('/myEndpoint', {
@@ -97,7 +97,7 @@ export function get(path, params, callback) {
  *    headers: {'content-type': 'application/json'},
  *  })
  * @function
- * @param {string} path - Path to resource
+ * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} params - Body, Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
@@ -109,7 +109,7 @@ export function post(path, params, callback) {
 }
 
 /**
- * Make a PUT request
+ * Make a PUT request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
  *  put('/myEndpoint', {
@@ -117,7 +117,7 @@ export function post(path, params, callback) {
  *    headers: {'content-type': 'application/json'},
  *  })
  * @function
- * @param {string} path - Path to resource
+ * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} params - Body, Query, Headers and Auth parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
@@ -128,7 +128,7 @@ export function put(path, params, callback) {
 }
 
 /**
- * Make a PATCH request
+ * Make a PATCH request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
  *  patch('/myEndpoint', {
@@ -136,7 +136,7 @@ export function put(path, params, callback) {
  *    headers: {'content-type': 'application/json'},
  *  })
  * @function
- * @param {string} path - Path to resource
+ * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} params - Body, Query, Headers and Auth parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
@@ -147,14 +147,14 @@ export function patch(path, params, callback) {
 }
 
 /**
- * Make a DELETE request
+ * Make a DELETE request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
  *  del(`/myendpoint/${state => state.data.id}`, {
  *    headers: {'content-type': 'application/json'}
  *  })
  * @function
- * @param {string} path - Path to resource
+ * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} params - Body, Query, Headers and Auth parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -54,7 +54,9 @@ export function request(method, path, params, callback = s => s) {
 
     const baseUrl = state.configuration?.baseUrl;
 
-    addAuth(state.configuration, headers);
+    if (baseUrl) {
+      addAuth(state.configuration, headers);
+    }
 
     const maxRedirections =
       resolvedParams.maxRedirections ??

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -56,6 +56,25 @@ describe('request()', () => {
 
     expect(result.data).to.eql('hello');
   });
+
+  it('should throw if url is absolute and does not match baseURL', async () => {
+    const state = {
+      configuration: {
+        baseUrl: 'https://www.example.com',
+      },
+    };
+
+    let err;
+    try {
+      await execute(request('GET', 'https://www.something.net/greeting'))(
+        state
+      );
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err.code).to.eql('BASE_URL_MISMATCH');
+  });
 });
 
 describe('get()', () => {

--- a/packages/odk/ast.json
+++ b/packages/odk/ast.json
@@ -59,7 +59,7 @@
         "options"
       ],
       "docs": {
-        "description": "Make a GET request against the base URL.",
+        "description": "Make a GET request against the ODK server.",
         "tags": [
           {
             "title": "example",
@@ -123,7 +123,7 @@
         "options"
       ],
       "docs": {
-        "description": "Make a POST request against the base URL.",
+        "description": "Make a POST request against the ODK server.",
         "tags": [
           {
             "title": "example",
@@ -192,7 +192,7 @@
         "options"
       ],
       "docs": {
-        "description": "Make a general HTTP request against the base URL.",
+        "description": "Make a general HTTP request against the ODK server.",
         "tags": [
           {
             "title": "example",

--- a/packages/odk/src/Adaptor.js
+++ b/packages/odk/src/Adaptor.js
@@ -88,7 +88,7 @@ export function getForms(projectId) {
 }
 
 /**
- * Make a GET request against the base URL.
+ * Make a GET request against the ODK server.
  * @example <caption>Get a list of available projects</caption>
  * get("v1/projects");
  * @example <caption>Get projects with query parameters</caption>
@@ -107,7 +107,7 @@ export function get(path, options) {
 }
 
 /**
- * Make a POST request against the base URL.
+ * Make a POST request against the ODK server.
  * @example <caption>Create a new project</caption>
  * post('v1/projects', { name: 'Project Name' });
  * @function
@@ -123,7 +123,7 @@ export function post(path, body, options) {
 }
 
 /**
- * Make a general HTTP request against the base URL.
+ * Make a general HTTP request against the ODK server.
  * @example <caption>Make a POST request to create a new project</caption>
  * request("POST", 'v1/projects', { name: 'Project Name' });
  * @function
@@ -155,10 +155,6 @@ export function request(method, path, body, options = {}) {
 /**
  * Execute a sequence of operations.
  * Wraps `language-common/execute`, and prepends initial state for odk.
- * @example
-<caption> * execute(</caption>
- *   get("v1/projects")
- * )(state)
  * @private
  * @param {Operations} operations - Operations to be performed.
  * @returns {Operation}

--- a/packages/odk/test/Adaptor.test.js
+++ b/packages/odk/test/Adaptor.test.js
@@ -494,4 +494,40 @@ describe('HTTP wrappers', () => {
     expect(error.statusMessage).to.eql('Forbidden');
     expect(error.statusCode).to.eql(403);
   });
+
+  it('throws when an absolute URL is passed', async () => {
+    const state = {
+      configuration,
+    };
+
+    const error = await post('https://www.example.com', {
+      name: 'Project Name',
+    })(state).catch(error => {
+      return error;
+    });
+
+    expect(error.code).to.eql('BASE_URL_MISMATCH');
+  });
+
+  it('does not throw throws when matching absolute URL is passed', async () => {
+    const state = {
+      configuration,
+    };
+
+    testServer
+      .intercept({
+        path: '/v1/projects',
+        method: 'GET',
+      })
+      .reply(200, fixtures.projects);
+
+    // prettier-ignore
+    const finalState = await execute(
+      get(`${configuration.baseUrl}/v1/projects`
+    ))(state);
+
+    expect(finalState.data).to.eql(fixtures.projects);
+    expect(finalState.data[0].id).to.eql(66);
+    expect(finalState.response.statusCode).to.equal(200);
+  });
 });

--- a/packages/odk/test/Adaptor.test.js
+++ b/packages/odk/test/Adaptor.test.js
@@ -509,7 +509,7 @@ describe('HTTP wrappers', () => {
     expect(error.code).to.eql('BASE_URL_MISMATCH');
   });
 
-  it('does not throw throws when matching absolute URL is passed', async () => {
+  it('does not throw when matching absolute URL is passed', async () => {
     const state = {
       configuration,
     };

--- a/packages/openlmis/ast.json
+++ b/packages/openlmis/ast.json
@@ -8,7 +8,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a GET request in OpenLMIS",
+        "description": "Send a GET request to OpenLMIS",
         "tags": [
           {
             "title": "example",
@@ -79,7 +79,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a POST request in OpenLMIS",
+        "description": "Send a POST request to OpenLMIS",
         "tags": [
           {
             "title": "example",
@@ -150,7 +150,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a PUT request in OpenLMIS",
+        "description": "Send a PUT request to OpenLMIS",
         "tags": [
           {
             "title": "example",
@@ -223,7 +223,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a general HTTP request in OpenLMIS",
+        "description": "Send a HTTP request to OpenLMIS",
         "tags": [
           {
             "title": "example",

--- a/packages/openlmis/src/Adaptor.js
+++ b/packages/openlmis/src/Adaptor.js
@@ -35,7 +35,7 @@ export function execute(...operations) {
   return commonExecute(util.authorize, ...operations);
 }
 /**
- * Make a GET request in OpenLMIS
+ * Send a GET request to OpenLMIS
  * @example <caption>Get all supplyLines</caption>
  * get("/supplyLines");
  * @function
@@ -51,7 +51,7 @@ export function get(path, options, callback) {
 }
 
 /**
- * Make a POST request in OpenLMIS
+ * Send a POST request to OpenLMIS
  * @example <caption>Creates new program</caption>
  * post("/programs", { name: "Bukayo", code: "abc" });
  * @function
@@ -67,7 +67,7 @@ export function post(path, body, callback) {
 }
 
 /**
- * Make a PUT request in OpenLMIS
+ * Send a PUT request to OpenLMIS
  * @example <caption>Update existing program</caption>
  * put("/programs/123", { name: "DigTalent", code: "123" });
  * @function
@@ -83,7 +83,7 @@ export function put(path, body, callback) {
 }
 
 /**
- * Make a general HTTP request in OpenLMIS
+ * Send a HTTP request to OpenLMIS
  * @example
  * request("POST", "/programs", { name: "WSH", code: "123" });
  * @function

--- a/packages/openlmis/src/Utils.js
+++ b/packages/openlmis/src/Utils.js
@@ -1,6 +1,7 @@
 import nodepath from 'node:path';
 import { composeNextState } from '@openfn/language-common';
 import {
+  assertRelativeUrl,
   request as commonRequest,
   makeBasicAuthHeader,
 } from '@openfn/language-common/util';
@@ -70,7 +71,7 @@ export const request = (configuration = {}, method, path, options) => {
   const { baseUrl, access_token } = configuration;
   const { headers = {}, ...otherOptions } = options;
 
-  urlMatchesBase(path, baseUrl);
+  assertRelativeUrl(path);
 
   const opts = {
     parseAs: 'json',
@@ -85,14 +86,3 @@ export const request = (configuration = {}, method, path, options) => {
 
   return commonRequest(method, safepath, opts);
 };
-
-function urlMatchesBase(path, baseUrl) {
-  const base = new URL(baseUrl);
-  const url = new URL(path, baseUrl);
-
-  if (url.origin !== base.origin) {
-    throw new Error(`Requests must be sent to the base URL: ${baseUrl}`);
-  }
-
-  return true;
-}

--- a/packages/openlmis/test/Adaptor.test.js
+++ b/packages/openlmis/test/Adaptor.test.js
@@ -254,8 +254,6 @@ describe('HTTP wrappers', () => {
       return error;
     });
 
-    expect(error.message).to.eql(
-      'Requests must be sent to the base URL: https://test.openlmis.org'
-    );
+    expect(error.code).to.eql('INVALID_ABSOLUTE_URL');
   });
 });

--- a/packages/openlmis/test/Adaptor.test.js
+++ b/packages/openlmis/test/Adaptor.test.js
@@ -254,6 +254,6 @@ describe('HTTP wrappers', () => {
       return error;
     });
 
-    expect(error.code).to.eql('INVALID_ABSOLUTE_URL');
+    expect(error.code).to.eql('UNEXPECTED_ABSOLUTE_URL');
   });
 });

--- a/packages/satusehat/ast.json
+++ b/packages/satusehat/ast.json
@@ -8,7 +8,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a get request to any satusehat endpoint",
+        "description": "Make a GET request to Satusehat",
         "tags": [
           {
             "title": "public",

--- a/packages/satusehat/src/Adaptor.js
+++ b/packages/satusehat/src/Adaptor.js
@@ -32,7 +32,7 @@ export function execute(...operations) {
 }
 
 /**
- * Make a get request to any satusehat endpoint
+ * Make a GET request to Satusehat
  * @public
  * @example
  * get("Organization", {"name": "somename"})
@@ -50,21 +50,20 @@ export function get(path, params = {}, callback = s => s) {
       params
     );
     try {
-      const response = await request(state.configuration, `/${resolvedPath}`, {
+      const response = await request(state.configuration, resolvedPath, {
         method: 'GET',
         params: resolvedParams,
       });
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.error(JSON.stringify(e.body, null, 2));
       throw e;
     }
   };
 }
 
 /**
- * Make a post request to satusehat
+ * Make a POST request to Satusehat
  * @example
  * post(
  *   "Organization",
@@ -89,7 +88,7 @@ export function post(path, data, params = {}, callback = s => s) {
     );
 
     try {
-      const response = await request(state.configuration, `/${resolvedPath}`, {
+      const response = await request(state.configuration, resolvedPath, {
         method: 'POST',
         data: resolvedData,
         params: resolvedParams,
@@ -97,14 +96,13 @@ export function post(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.error(JSON.stringify(e.body, null, 2));
       throw e;
     }
   };
 }
 
 /**
- * Make a put request to satusehat
+ * Make a PUT request to Satusehat
  * @example
  * put(
  *   "Organization/123",
@@ -129,7 +127,7 @@ export function put(path, data, params = {}, callback = s => s) {
     );
 
     try {
-      const response = await request(state.configuration, `/${resolvedPath}`, {
+      const response = await request(state.configuration, resolvedPath, {
         method: 'PUT',
         data: resolvedData,
         params: resolvedParams,
@@ -137,14 +135,13 @@ export function put(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.error(JSON.stringify(e.body, null, 2));
       throw e;
     }
   };
 }
 
 /**
- * Make a patch request to satusehat
+ * Make a PATCH request to Satusehat
  * @example
  * patch(
  *   "Organization/123",
@@ -173,7 +170,7 @@ export function patch(path, data, params = {}, callback = s => s) {
     );
 
     try {
-      const response = await request(state.configuration, `/${resolvedPath}`, {
+      const response = await request(state.configuration, resolvedPath, {
         method: 'PATCH',
         data: JSON.stringify(resolvedData),
         params: resolvedParams,
@@ -182,7 +179,6 @@ export function patch(path, data, params = {}, callback = s => s) {
 
       return prepareNextState(state, response, callback);
     } catch (e) {
-      console.error(JSON.stringify(e.body, null, 2));
       throw e;
     }
   };

--- a/packages/satusehat/src/Utils.js
+++ b/packages/satusehat/src/Utils.js
@@ -1,7 +1,9 @@
 import { composeNextState } from '@openfn/language-common';
+import nodepath from 'node:path';
 import {
   request as commonRequest,
   logResponse,
+  assertRelativeUrl,
 } from '@openfn/language-common/util';
 
 const generateUserAgent = () => {
@@ -84,14 +86,18 @@ export async function request(configuration, path, opts) {
     'content-type': contentType,
   };
 
+  assertRelativeUrl(path);
+
+  const safePath = nodepath.join('fhir-r4/v1', path);
+
   const options = {
     body: data,
     headers,
     query: params,
     parseAs,
     maxRedirections: 1,
-    baseUrl: `${baseUrl}/fhir-r4/v1/`,
+    baseUrl,
   };
 
-  return commonRequest(method, path, options).then(logResponse);
+  return commonRequest(method, safePath, options).then(logResponse);
 }

--- a/packages/satusehat/test/Adaptor.test.js
+++ b/packages/satusehat/test/Adaptor.test.js
@@ -74,7 +74,26 @@ describe('execute', () => {
   });
 });
 
-describe('getOrganizations', () => {
+describe('get', () => {
+  it('throws if an absolute URL is passed', async () => {
+    const state = {
+      configuration: {
+        baseUrl,
+        clientId: 'someclientid',
+        clientSecret: 'someclientsecret',
+      },
+    };
+
+    // happily the request won't actually be made, so we don't need to mock anything here
+    let err;
+    try {
+      await execute(get('https://www.blah.com/a/b/c'))(state);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.code).to.equal('INVALID_ABSOLUTE_URL');
+  });
+
   it('should fetch organizations', async () => {
     testServer
       .intercept({
@@ -190,7 +209,7 @@ describe('getOrganizations', () => {
   });
 });
 
-describe('Create organization', () => {
+describe('post', () => {
   it('should create an organization', async () => {
     testServer
       .intercept({
@@ -377,7 +396,7 @@ describe('Create organization', () => {
   });
 });
 
-describe('updateOrganization', () => {
+describe('put', () => {
   it('should update an organization', async () => {
     testServer
       .intercept({
@@ -418,7 +437,7 @@ describe('updateOrganization', () => {
   });
 });
 
-describe('partiallyUpdateOrganization', () => {
+describe('patch', () => {
   it('should partially update an organization', async () => {
     testServer
       .intercept({

--- a/packages/satusehat/test/Adaptor.test.js
+++ b/packages/satusehat/test/Adaptor.test.js
@@ -91,7 +91,7 @@ describe('get', () => {
     } catch (e) {
       err = e;
     }
-    expect(err.code).to.equal('INVALID_ABSOLUTE_URL');
+    expect(err.code).to.equal('UNEXPECTED_ABSOLUTE_URL');
   });
 
   it('should fetch organizations', async () => {

--- a/packages/surveycto/src/Utils.js
+++ b/packages/surveycto/src/Utils.js
@@ -1,10 +1,12 @@
 import { composeNextState } from '@openfn/language-common';
 import {
+  assertRelativeUrl,
   request as commonRequest,
   logResponse,
   makeBasicAuthHeader,
 } from '@openfn/language-common/util';
 import { formatInTimeZone } from 'date-fns-tz';
+import nodepath from 'node:path';
 
 const addBasicAuth = (configuration = {}, headers) => {
   const { username, password } = configuration;
@@ -15,8 +17,14 @@ const addBasicAuth = (configuration = {}, headers) => {
 
 const buildUrl = (configuration = {}, path) => {
   const { servername, apiVersion = 'v1' } = configuration;
-  if (!servername) throw 'Please specify servername in your credentials';
-  return `https://${servername}.surveycto.com/api/${apiVersion}/${path}`;
+  if (!servername) {
+    throw 'Error: specify servername in your credentials';
+  }
+  return nodepath.join(
+    `https://${servername}.surveycto.com/api`,
+    apiVersion,
+    path
+  );
 };
 
 export const prepareNextState = (state, response, callback) => {
@@ -30,6 +38,8 @@ export const prepareNextState = (state, response, callback) => {
 };
 
 export const requestHelper = (state, path, params, callback = s => s) => {
+  assertRelativeUrl(path);
+
   let { body = {}, headers, method = 'GET', query } = params;
 
   addBasicAuth(state.configuration, headers);

--- a/packages/surveycto/test/index.js
+++ b/packages/surveycto/test/index.js
@@ -53,7 +53,7 @@ describe('request', () => {
     } catch (e) {
       err = e;
     }
-    expect(err.code).to.equal('INVALID_ABSOLUTE_URL');
+    expect(err.code).to.equal('UNEXPECTED_ABSOLUTE_URL');
   });
 });
 

--- a/packages/surveycto/test/index.js
+++ b/packages/surveycto/test/index.js
@@ -5,7 +5,7 @@ import ClientFixtures, { fixtures } from './ClientFixtures';
 import Adaptor from '../src';
 import { convertDate, dateRegex } from '../src/Utils';
 
-const { execute } = Adaptor;
+const { execute, request } = Adaptor;
 
 describe('execute', () => {
   it.skip('executes each operation in sequence', done => {
@@ -41,6 +41,19 @@ describe('execute', () => {
         data: null,
       });
     });
+  });
+});
+
+describe('request', () => {
+  it('throws if an absolute URL is passed', async () => {
+    // happily the request won't actually be made, so we don't need to mock anything here
+    let err;
+    try {
+      await execute(request('https://www.blah.com/a/b/c'))({});
+    } catch (e) {
+      err = e;
+    }
+    expect(err.code).to.equal('INVALID_ABSOLUTE_URL');
   });
 });
 

--- a/tools/generate/template/src/Utils.js
+++ b/tools/generate/template/src/Utils.js
@@ -2,12 +2,13 @@
  * If you have any helper functions which are NOT operations,
  * you should add them here
  */
-
 import { composeNextState } from '@openfn/language-common';
 import {
   request as commonRequest,
   makeBasicAuthHeader,
+  assertRelativeUrl,
 } from '@openfn/language-common/util';
+import nodepath from 'node:path';
 
 export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
@@ -28,6 +29,11 @@ export const prepareNextState = (state, response, callback = s => s) => {
 // and add authorisation headers
 // Refer to the common request function for options and details
 export const request = (configuration = {}, method, path, options) => {
+  // You might want to check that the path is not an absolute URL befor
+  // appending credentials commonRequest will do this for you if you
+  // pass a baseURL to it and you don't need to build a path here
+  // assertRelativeUrl(path);
+
   // TODO This example adds basic auth from config data
   //       you may need to support other auth strategies
   const { baseUrl, username, password } = configuration;
@@ -60,7 +66,9 @@ export const request = (configuration = {}, method, path, options) => {
   };
 
   // TODO you may want to add a prefix to the path
+  // use path.join to build the path safely
+  const safePath = nodepath.join(path);
 
   // Make the actual request
-  return commonRequest(method, path, options);
+  return commonRequest(method, safePath, options);
 };


### PR DESCRIPTION
This PR prevents http helpers on adaptors from calling absolute URLs if the baseURL is set.

Fixes #665




Part of the #681 epic

## Notes

* The risk of this isn't as bad as I feared: many adaptors (and docs) are strongly geared towards paths anyway
* I've tightened up the common `util.request` so that it throws if the request path has a different origin to the base URL. If no baseURL is passed, the function won't throw. This should automatically "fix" most adaptors.
* I've also added  an `assertRelativeURL` helper for adaptors to use before manipulating the path
* I've updated adaptors and docs
* commcare is already designed to take a path, not a full URL. This is clearly documented. No action needed there.
* The template has been updated to encourage better practice
* Unit tests have been added to ensure we throw for an absolute URL

## Example: asana

The Asana adaptor always sets a base URL. So any request to an absolute URL will try to append credentials.

Asana will now throw in this case.

Job code (no config needed):


```
request('https://jsonplaceholder.typicode.com/todos/1');
````

Output:
```
$ openfn tmp/http.js -ma asana

[CLI] ♦ Versions:
         ▸ node.js                   18.17.1
         ▸ cli                       1.6.1
         ▸ @openfn/language-asana    monorepo
[CLI] ✔ Loading adaptors from monorepo at /d/repo/openfn/adaptors
[CLI] ⚠ Skipping auto-install as monorepo is being used
[CLI] ✔ Compiled all expressions in workflow
Asana says:
[R/T] ✘ Failed step job-1 after 146ms
[R/T] ✘ {
  "source": "runtime",
  "name": "AdaptorError",
  "severity": "fail",
  "message": "Target origin does not match baseUrl origin",
  "details": {
    "code": "BASE_URL_MISMATCH",
    "description": "A request was attempted to an absolute URL, but a different base URL was specified. This is potential security violation.",
    "target": "https://jsonplaceholder.typicode.com/todos/1",
    "baseUrl": "https://app.asana.com/api/1",
    "fix": "Try using a generic HTTP function to access the target URL"
  }
}
[R/T] ✘ Check state.errors.job-1 for details.
[CLI] ✔ State written to tmp/output.json
[CLI] ⚠ Errors reported in 1 jobs
[CLI] ✔ Finished in 255ms
```

## Further work

The generic HTTP helpers need to be fixed. Note that any adaptors which re-export http require major version bumps in that work. Also in that work, adaptors which do not export http must do so.

We could probably release this standalone, but I'd quite like to do more work in this area in the epic

## QA Notes

I've updated all the adaptors that I think need updating, but maybe I've missed some?

