### PR TITLE
fix: display error message

### DIFF
--- a/.changeset/clean-kids-double.md
+++ b/.changeset/clean-kids-double.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-asana': minor
+---
+
+Display the error body in the console

--- a/packages/asana/src/Utils.js
+++ b/packages/asana/src/Utils.js
@@ -37,7 +37,11 @@ export function request(state, path, params, callback = s => s) {
     .then(callback)
     .catch(err => {
       console.log('Asana says:');
-      logResponse(err);
+      const body = err.body;
+      logResponse({
+        ...err,
+        body: JSON.stringify(body, null, 2),
+      });
 
       throw err;
     });


### PR DESCRIPTION
## Summary

Display the error messages in `asana`

## Details

The body data when an error is received is not visible in the run logs in `asana`.

## Issues

#530 

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, Added the adaptor on marketing website ?
- [ ] Are there any unit tests? Should there be?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
