### PR TITLE
Fix survey CTO and automate tags

### DIFF
--- a/.changeset/famous-sloths-talk.md
+++ b/.changeset/famous-sloths-talk.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-cht': major
----
-
-Implement `get`, `post`, and `put` methods for cht adaptor

--- a/.changeset/twenty-lemons-fail.md
+++ b/.changeset/twenty-lemons-fail.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-surveycto': patch
----
-
-Fix an issue assembling surveyCTO urls (which manifested as
-`TypeError: Cannot read properties of undefined (reading 'toString'`)

--- a/.changeset/twenty-lemons-fail.md
+++ b/.changeset/twenty-lemons-fail.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-surveycto': patch
+---
+
+Fix an issue assembling surveyCTO urls (which manifested as
+`TypeError: Cannot read properties of undefined (reading 'toString'`)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+          fetch-tags: true
       - uses: actions/setup-node@v3
         with:
           node-version: '18.17.1'
@@ -24,6 +25,9 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run:
           pnpm publish -r --report-summary --publish-branch main --access=public
+
+      - run: pnpm changeset tag
+      - run: git push --tags
 
       - run: pnpm slack:notify
         env:

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -118,6 +118,10 @@ export const parseUrl = (pathOrUrl = '', baseUrl) => {
       }
     }
   } else if (baseUrl) {
+    // Note: we use path.join here because our "baseUrl" may not be a stict base url
+    //       Ie it may be https://example.com/api/v1
+    //       Doing new URl(path, base) will chop off the "base path" so to speak, and break stuff
+    //       Technically path.join will produce an invalid URL, but the URL parser handles it safely
     fullUrl = new URL(path.join(baseUrl, pathOrUrl));
   } else {
     // let this throw

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -13,7 +13,7 @@ import {
 
 const client = enableMockClient('https://www.example.com');
 
-describe.only('parseUrl', () => {
+describe('parseUrl', () => {
   it('should work with a url and path', () => {
     const { url, baseUrl, path } = parseUrl('https://www.example.org/a/b/c');
 

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -13,7 +13,7 @@ import {
 
 const client = enableMockClient('https://www.example.com');
 
-describe('parseUrl', () => {
+describe.only('parseUrl', () => {
   it('should work with a url and path', () => {
     const { url, baseUrl, path } = parseUrl('https://www.example.org/a/b/c');
 
@@ -67,6 +67,16 @@ describe('parseUrl', () => {
     const { url, baseUrl, path } = parseUrl(
       'https://www.example.org/api/a/b/c',
       'https://www.example.org/api'
+    );
+
+    expect(baseUrl).to.equal('https://www.example.org');
+    expect(path).to.equal('/api/a/b/c');
+    expect(url).to.eql('https://www.example.org/api/a/b/c');
+  });
+
+  it('should work with matching absolute url and no base', () => {
+    const { url, baseUrl, path } = parseUrl(
+      'https://www.example.org/api/a/b/c'
     );
 
     expect(baseUrl).to.equal('https://www.example.org');

--- a/packages/surveycto/CHANGELOG.md
+++ b/packages/surveycto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-surveycto
 
+## 2.2.2
+
+### Patch Changes
+
+- d54ab59: Fix an issue assembling surveyCTO urls (which manifested as
+  `TypeError: Cannot read properties of undefined (reading 'toString'`)
+
 ## 2.2.1
 
 ### Patch Changes

--- a/packages/surveycto/package.json
+++ b/packages/surveycto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-surveycto",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A SurveyCTO Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/surveycto/src/Adaptor.js
+++ b/packages/surveycto/src/Adaptor.js
@@ -71,7 +71,7 @@ export function execute(...operations) {
  * @param {function} callback - (Optional) Callback function
  * @returns {Operation}
  */
-export function fetchSubmissions(formId, options, callback = s => s) {
+export function fetchSubmissions(formId, options = {}, callback = s => s) {
   return state => {
     const [resolvedFormId, resolvedOptions] = expandReferences(
       state,

--- a/packages/surveycto/src/Utils.js
+++ b/packages/surveycto/src/Utils.js
@@ -21,6 +21,7 @@ const buildUrl = (configuration = {}, path) => {
     throw 'Error: specify servername in your credentials';
   }
   return (
+    // Warning: nodepath will convert https:// into https:/
     'https://' +
     nodepath.join(`${servername}.surveycto.com/api`, apiVersion, path)
   );

--- a/packages/surveycto/src/Utils.js
+++ b/packages/surveycto/src/Utils.js
@@ -20,10 +20,9 @@ const buildUrl = (configuration = {}, path) => {
   if (!servername) {
     throw 'Error: specify servername in your credentials';
   }
-  return nodepath.join(
-    `https://${servername}.surveycto.com/api`,
-    apiVersion,
-    path
+  return (
+    'https://' +
+    nodepath.join(`${servername}.surveycto.com/api`, apiVersion, path)
   );
 };
 


### PR DESCRIPTION
## Summary

SurveyCTO 2.2.1 has started throwing an error on `fetchSubmissions`:

```
TypeError: Cannot read properties of undefined (reading 'toString')
```

Turns out this is a bug introduced in the recent patch.

## Tag automation

I've snuck in a little tweak here to run `pnpm chaneset tag && git push --tags` after publish.

I have had trouble getting this to work in the past, but let's see if it work this time :crossed_fingers:  We'll just have to see.

## path.join and URLs

I should have clocked that this would be problematic, but we didn't have enough tests in the adaptor (and I didn't add them) so it got by me.

We've been using a new pattern of `path.join(a,c,b)` for safer URL assembly. It works great on paths - but when surveyCTO does it, it builds a whole URL, starting with `https://`. And when nodepath sees `//` it strips out the extra slash, so the URL becomes `https:/test.surveycto.com`, which is not a valid URL.

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [x] If this is a new adaptor, Added the adaptor on marketing website ?
- [x] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
