### PR TITLE
`redis` update `scan` function 

### DIFF
--- a/.changeset/three-items-perform.md
+++ b/.changeset/three-items-perform.md
@@ -1,0 +1,8 @@
+---
+'@openfn/language-redis': minor
+---
+
+- `scan` now iterate the whole database
+- Removed `cursor` option from `scan`.
+- Removed default value for `type` option
+- Mapped `json` data type to the redis internal type

--- a/packages/redis/ast.json
+++ b/packages/redis/ast.json
@@ -24,7 +24,7 @@
           },
           {
             "title": "property",
-            "description": "Limits the keys returned to those of a specified type (e.g., string, list, set, hash, etc.).",
+            "description": "Limits the keys returned to those of a specified type (e.g., string, list, set, hash, json, zset or stream).",
             "type": {
               "type": "NameExpression",
               "name": "string"

--- a/packages/redis/ast.json
+++ b/packages/redis/ast.json
@@ -24,29 +24,12 @@
           },
           {
             "title": "property",
-            "description": "A numeric value used to continue the iteration from where it left off. Initially, you start with 0.",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "integer"
-              }
-            },
-            "name": "cursor",
-            "default": "0"
-          },
-          {
-            "title": "property",
             "description": "Limits the keys returned to those of a specified type (e.g., string, list, set, hash, etc.).",
             "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "string"
-              }
+              "type": "NameExpression",
+              "name": "string"
             },
-            "name": "type",
-            "default": "'hash'"
+            "name": "type"
           },
           {
             "title": "property",
@@ -394,10 +377,6 @@
           {
             "title": "state",
             "description": "data - an array of keys which match the pattern"
-          },
-          {
-            "title": "state",
-            "description": "cursor - A numeric value used to continue the iteration from where it left off"
           },
           {
             "title": "returns",

--- a/packages/redis/ast.json
+++ b/packages/redis/ast.json
@@ -330,7 +330,7 @@
         "options"
       ],
       "docs": {
-        "description": "Returns all keys which patch the provided pattern.",
+        "description": "Returns all keys which match the provided pattern.\nscan iterates the whole database to find the matching keys",
         "tags": [
           {
             "title": "example",

--- a/packages/redis/src/Adaptor.js
+++ b/packages/redis/src/Adaptor.js
@@ -191,7 +191,8 @@ export function hset(key, value) {
 }
 
 /**
- * Returns all keys which patch the provided pattern.
+ * Returns all keys which match the provided pattern.
+ * scan iterates the whole database to find the matching keys
  * @example <caption>Scan for matching keys</caption>
  * scan('*:20240524T172736Z*');
  * @example <caption>Scan for keys and fetch the string values inside</caption>
@@ -225,7 +226,7 @@ export function scan(pattern, options = {}) {
       const reply = await client.scan(cursor, {
         MATCH: resolvedPattern,
         COUNT: count,
-        TYPE: type,
+        TYPE: type === 'json' ? 'ReJSON-RL' : type,
       });
       cursor = reply.cursor;
       for (const key of reply.keys) {

--- a/packages/redis/src/Adaptor.js
+++ b/packages/redis/src/Adaptor.js
@@ -47,7 +47,7 @@ const disconnect = async state => {
  * Options provided to the scan function
  * @typedef {Object} ScanOptions
  * @public
- * @property {string} type - Limits the keys returned to those of a specified type (e.g., string, list, set, hash, etc.).
+ * @property {string} type - Limits the keys returned to those of a specified type (e.g., string, list, set, hash, json, zset or stream).
  * @property {integer} count - A hint to the server about how many elements to return in the call (default is 10).
  */
 

--- a/packages/redis/test/Adaptor.test.js
+++ b/packages/redis/test/Adaptor.test.js
@@ -254,6 +254,19 @@ describe('hset', () => {
 });
 
 describe('scan', () => {
+  it('should return json keys', async () => {
+    setMockClient({
+      scan: async (cursor, options) => {
+        expect(cursor).to.eql(0);
+        expect(options.MATCH).to.eql('*:abc*');
+        expect(options.TYPE).to.eql('ReJSON-RL');
+        return { keys: ['node:abc'], cursor: 0 };
+      },
+    });
+    const state = {};
+    const result = await scan('*:abc*', { type: 'json' })(state);
+    expect(result.data).to.eql(['node:abc']);
+  });
   it('should return empty array if key not found', async () => {
     setMockClient({
       scan: async (cursor, options) => {

--- a/packages/redis/test/Adaptor.test.js
+++ b/packages/redis/test/Adaptor.test.js
@@ -265,7 +265,6 @@ describe('scan', () => {
     const state = {};
     const result = await scan('*:abc*')(state);
     expect(result.data).to.eql([]);
-    expect(result.cursor).to.eql(0);
   });
 
   it('should return collection of keys', async () => {
@@ -273,7 +272,6 @@ describe('scan', () => {
       scan: async (cursor, options) => {
         expect(cursor).to.eql(0);
         expect(options.MATCH).to.eql('*:animals*');
-        expect(options.TYPE).to.eql('hash');
         return { keys: ['noderedis:animals:1'], cursor: 0 };
       },
     });
@@ -281,15 +279,13 @@ describe('scan', () => {
     const state = {};
     const result = await scan('*:animals*')(state);
     expect(result.data).to.eql(['noderedis:animals:1']);
-    expect(result.cursor).to.eql(0);
   });
 
-  it('should return all hash keys if no query is specified', async () => {
+  it('should return all keys if no query is specified', async () => {
     setMockClient({
       scan: async (cursor, options) => {
         expect(cursor).to.eql(0);
         expect(options.MATCH).to.eql(undefined);
-        expect(options.TYPE).to.eql('hash');
 
         return {
           keys: ['animals:1', 'family:name'],
@@ -301,7 +297,6 @@ describe('scan', () => {
     const state = {};
     const result = await scan()(state);
     expect(result.data).to.eql(['animals:1', 'family:name']);
-    expect(result.cursor).to.eql(0);
   });
 
   it('should return all string keys', async () => {
@@ -320,7 +315,6 @@ describe('scan', () => {
     const state = {};
     const result = await scan('', { type: 'string' })(state);
     expect(result.data).to.eql(['animal', 'family']);
-    expect(result.cursor).to.eql(0);
   });
 
   it('should return a string key', async () => {
@@ -339,7 +333,6 @@ describe('scan', () => {
     const state = {};
     const result = await scan('animal', { type: 'string' })(state);
     expect(result.data).to.eql(['animal']);
-    expect(result.cursor).to.eql(0);
   });
 
   it('should expand referecence', async () => {
@@ -347,7 +340,6 @@ describe('scan', () => {
       scan: async (cursor, options) => {
         expect(cursor).to.eql(0);
         expect(options.MATCH).to.eql('*:animals*');
-        expect(options.TYPE).to.eql('hash');
         return { keys: ['animals:1'], cursor: 0 };
       },
     });
@@ -355,7 +347,6 @@ describe('scan', () => {
     const state = { pattern: '*:animals*' };
     const result = await scan(s => s.pattern)(state);
     expect(result.data).to.eql(['animals:1']);
-    expect(result.cursor).to.eql(0);
   });
 });
 

--- a/packages/redis/test/Adaptor.test.js
+++ b/packages/redis/test/Adaptor.test.js
@@ -254,6 +254,24 @@ describe('hset', () => {
 });
 
 describe('scan', () => {
+  it('should return all pages results', async () => {
+    const results = [
+      { keys: ['a'], cursor: 22 },
+      { keys: ['b', 'c'], cursor: 33 },
+      { keys: ['d'], cursor: 0 },
+    ];
+    setMockClient({
+      scan: async (cursor, options) => {
+        expect(options.TYPE).to.eql('string');
+        return results.shift();
+      },
+    });
+
+    const state = {};
+    const result = await scan('*', { type: 'string' })(state);
+
+    expect(result.data).to.eql(['a', 'b', 'c', 'd']);
+  });
   it('should return json keys', async () => {
     setMockClient({
       scan: async (cursor, options) => {


### PR DESCRIPTION
## Summary

Update scan to `scan` function to scan whole database based on the provided pattern 

Ref: #710 

## Notes

- [x] scan now iterate the whole database
- [x] removed `cursor` parameter from scan 
- [x] We support count as an argument in options object. Incase users want bigger "pages". This allows for some optimization.
- [x] Removed default for `type` option
- [x] Add support for json type and map it to the redis internal type

## Review Checklist

- [x] Does the PR do what it claims to do?
- [x] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
