### PR TITLE
`redis` Update host type configuration-schema

### DIFF
--- a/.changeset/ninety-brooms-tickle.md
+++ b/.changeset/ninety-brooms-tickle.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-redis': patch
+---
+
+- Update host type configuration-schema

--- a/.changeset/ninety-brooms-tickle.md
+++ b/.changeset/ninety-brooms-tickle.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-redis': patch
----
-
-- Update host type configuration-schema

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-redis
 
+## 1.1.1
+
+### Patch Changes
+
+- 2b8ec34: - Update host type configuration-schema
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/redis/configuration-schema.json
+++ b/packages/redis/configuration-schema.json
@@ -3,17 +3,10 @@
   "properties": {
     "host": {
       "title": "Host",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
+      "type": "string",
+      "minLength": 1,
       "description": "Redis server hostname",
       "format": "uri",
-      "minLength": 1,
       "examples": [
         "redis.example.com"
       ]

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-redis",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenFn redis adaptor",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Update `redis`  host type `configuration-schema` to use `string`. This will remove the validation error on lightning when a user is creating the redis credential 

## Review Checklist

- [x] Does the PR do what it claims to do?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
