### PR TITLE
Add typescript defs to fhir create

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "devDependencies": {
     "@changesets/cli": "2.27.5",
     "@openfn/buildtools": "workspace:^1.0.2",
+    "@openfn/language-common": "workspace:^",
+    "@openfn/language-dhis2": "workspace:^",
+    "@openfn/language-fhir": "workspace:^",
     "@openfn/metadata": "workspace:^1.0.1",
     "@openfn/parse-jsdoc": "workspace:^1.0.0",
     "@openfn/simple-ast": "0.4.1",

--- a/packages/fhir/ast.json
+++ b/packages/fhir/ast.json
@@ -192,7 +192,7 @@
             "description": "The resource type to create",
             "type": {
               "type": "NameExpression",
-              "name": "string"
+              "name": "FhirResourceTypes"
             },
             "name": "resourceType"
           },
@@ -201,7 +201,7 @@
             "description": "The resource to create",
             "type": {
               "type": "NameExpression",
-              "name": "object"
+              "name": "FhirResource"
             },
             "name": "resource"
           },

--- a/packages/fhir/build-dts.ts
+++ b/packages/fhir/build-dts.ts
@@ -1,0 +1,3 @@
+export default async () => {
+  console.log(' >> WOOP WOOP <<<');
+};

--- a/packages/fhir/package.json
+++ b/packages/fhir/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/openfn/adaptors.git"
   },
   "type": "module",
-  "types": "types/index.d.ts",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/fhir/package.json
+++ b/packages/fhir/package.json
@@ -42,7 +42,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./types/index.d.ts"
     },
     "./package.json": "./package.json"
   }

--- a/packages/fhir/package.json
+++ b/packages/fhir/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "@openfn/language-common": "workspace:^2.0.0",
+    "@types/fhir": "^0.0.41",
     "undici": "^5.28.4"
   },
   "devDependencies": {

--- a/packages/fhir/src/Adaptor.js
+++ b/packages/fhir/src/Adaptor.js
@@ -3,6 +3,8 @@ import { expandReferences } from '@openfn/language-common/util';
 
 import * as util from './Utils';
 
+export { util };
+
 /**
  * State object
  * @typedef {Object} FHIRHttpState
@@ -168,8 +170,8 @@ export function get(path, params = {}, options = {}, callback = s => s) {
  *     },
  *   ],
  * });
- * @param {string} resourceType - The resource type to create
- * @param {object} resource - The resource to create
+ * @param {FhirResourceTypes} resourceType - The resource type to create
+ * @param {FhirResource} resource - The resource to create
  * @param {object} params - (Optional) FHIR parameters to control and configure resource creation
  * @param {function} callback - (Optional) callback function
  * @returns {Operation}

--- a/packages/fhir/src/Adaptor.js
+++ b/packages/fhir/src/Adaptor.js
@@ -172,18 +172,20 @@ export function get(path, params = {}, options = {}, callback = s => s) {
  * });
  * @param {FhirResourceTypes} resourceType - The resource type to create
  * @param {FhirResource} resource - The resource to create
- * @param {object} params - (Optional) FHIR parameters to control and configure resource creation
+ * @param {object} params - (Optional) FHIR parameters to control and configure resource creation. You can specify a version ie r4 here.
  * @param {function} callback - (Optional) callback function
  * @returns {Operation}
  * @state {FHIRHttpState}
  */
 export function create(resourceType, resource, params, callback = s => s) {
   return async state => {
-    const [resolvedResourceType, resolvedResource, resolvedParams] =
+    const [resolvedResourceType, resolvedResource, resolvedParams = {}] =
       expandReferences(state, resourceType, resource, params);
 
+    const { version, ...paramsWithoutVersion } = resolvedParams;
+
     const opts = {
-      ...resolvedParams,
+      ...paramsWithoutVersion,
       body: { ...resolvedResource, resourceType: resolvedResourceType },
     };
 

--- a/packages/fhir/src/Utils.js
+++ b/packages/fhir/src/Utils.js
@@ -1,4 +1,5 @@
 import nodepath from 'node:path';
+import r5 from 'fhir/r5';
 
 import { composeNextState } from '@openfn/language-common';
 import {
@@ -7,6 +8,18 @@ import {
   makeBasicAuthHeader,
   assertRelativeUrl,
 } from '@openfn/language-common/util';
+
+/**
+ * Create a FHIR object. Code assist will be provided in Lightning
+ * & the VSC extension
+ * @returns
+ */
+export function create(type, data, options = {}) {
+  return {
+    type: type,
+    ...data,
+  };
+}
 
 export function addAuth(configuration = {}, headers) {
   if (headers.Authorization) return;

--- a/packages/fhir/src/Utils.ts
+++ b/packages/fhir/src/Utils.ts
@@ -1,0 +1,3 @@
+// declare create(type, data, options) {
+
+// }

--- a/packages/fhir/src/index.ts
+++ b/packages/fhir/src/index.ts
@@ -2,14 +2,18 @@ import './types';
 
 // // export * as utils from './Utils';
 
-// import * as r5 from 'fhir/r5';
+import * as r5 from 'fhir/r5';
 
-// export declare function create(
-//   resourceType: 'Patient' | 'Bundle',
-//   resource: r5.Patient | r5.Bundle,
-//   params: any,
-//   callback: any
-// ): any;
+// this needs to override the built in sig
+/**
+ * CREATE TWO ELECTRIC BOOGALOO
+ */
+export declare function create(
+  resourceType: 'Patient' | 'Bundle',
+  resource: r5.Patient | r5.Bundle,
+  params: any,
+  callback: any
+): any;
 
 // export declare function jam(
 //   resourceType: 'Patient' | 'Bundle',

--- a/packages/fhir/src/index.ts
+++ b/packages/fhir/src/index.ts
@@ -2,19 +2,24 @@ import './types';
 
 // We gonna have a problem with this in Lightning
 // the client won't download this typing
-import r5 from 'fhir/r5';
+import * as r5 from 'fhir/r5';
 
 interface FhirResources {
   // can I automate this?
+  // I don't think so
+  // Also I guess not every type is something you create
+  // So instead I have to duplicate @types/fhir/FhirResource
   Patient: r5.Patient;
   Contract: r5.Contract;
   Bundle: r5.Bundle;
 }
 
-export declare function create<R extends keyof FhirResources>(
+// TODO how do we control versions?
+export declare function create<R extends keyof typeof r5>(
   resourceType: R,
   // Exclude the duplicated underscored props from @types/fhir
   // insane! https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
+  // But doesn't affected nested types
   resource: Omit<FhirResources[R], 'resourceType' | `_${string}`>,
   params: any,
   callback: any

--- a/packages/fhir/src/index.ts
+++ b/packages/fhir/src/index.ts
@@ -1,28 +1,24 @@
 import './types';
 
-// // export * as utils from './Utils';
+// We gonna have a problem with this in Lightning
+// the client won't download this typing
+import r5 from 'fhir/r5';
 
-import * as r5 from 'fhir/r5';
+interface FhirResources {
+  // can I automate this?
+  Patient: r5.Patient;
+  Contract: r5.Contract;
+  Bundle: r5.Bundle;
+}
 
-// this needs to override the built in sig
-/**
- * CREATE TWO ELECTRIC BOOGALOO
- */
-export declare function create(
-  resourceType: 'Patient' | 'Bundle',
-  resource: r5.Patient | r5.Bundle,
+export declare function create<R extends keyof FhirResources>(
+  resourceType: R,
+  // Exclude the duplicated underscored props from @types/fhir
+  // insane! https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
+  resource: Omit<FhirResources[R], 'resourceType' | `_${string}`>,
   params: any,
   callback: any
 ): any;
-
-// export declare function jam(
-//   resourceType: 'Patient' | 'Bundle',
-//   resource: r5.Patient | r5.Bundle,
-//   params: any,
-//   callback: any
-// ): any;
-
-// // create()
 
 import * as Adaptor from './Adaptor';
 export default Adaptor;

--- a/packages/fhir/src/index.ts
+++ b/packages/fhir/src/index.ts
@@ -1,0 +1,26 @@
+import './types';
+
+// // export * as utils from './Utils';
+
+// import * as r5 from 'fhir/r5';
+
+// export declare function create(
+//   resourceType: 'Patient' | 'Bundle',
+//   resource: r5.Patient | r5.Bundle,
+//   params: any,
+//   callback: any
+// ): any;
+
+// export declare function jam(
+//   resourceType: 'Patient' | 'Bundle',
+//   resource: r5.Patient | r5.Bundle,
+//   params: any,
+//   callback: any
+// ): any;
+
+// // create()
+
+import * as Adaptor from './Adaptor';
+export default Adaptor;
+
+export * from './Adaptor';

--- a/packages/fhir/src/index.ts
+++ b/packages/fhir/src/index.ts
@@ -2,26 +2,36 @@ import './types';
 
 // We gonna have a problem with this in Lightning
 // the client won't download this typing
-import * as r5 from 'fhir/r5';
+import r5 from 'fhir/r5';
+import r4 from 'fhir/r5';
 
-interface FhirResources {
-  // can I automate this?
-  // I don't think so
-  // Also I guess not every type is something you create
-  // So instead I have to duplicate @types/fhir/FhirResource
-  Patient: r5.Patient;
-  Contract: r5.Contract;
-  Bundle: r5.Bundle;
-}
+// TODO is there any way to automate or generate this?
+type VersionMap = {
+  r4: {
+    Patient: r4.Patient;
+    Contract: r4.Contract;
+    Bundle: r4.Bundle;
+    Person: r4.Person;
+  };
+  r5: {
+    Patient: r5.Patient;
+    Contract: r5.Contract;
+    Bundle: r5.Bundle;
+  };
+};
 
-// TODO how do we control versions?
-export declare function create<R extends keyof typeof r5>(
+export declare function create<
+  R extends keyof VersionMap[V],
+  V extends keyof VersionMap = 'r5'
+>(
   resourceType: R,
   // Exclude the duplicated underscored props from @types/fhir
   // insane! https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
   // But doesn't affected nested types
-  resource: Omit<FhirResources[R], 'resourceType' | `_${string}`>,
-  params: any,
+  resource: Omit<VersionMap[V][R], 'resourceType' | `_${string}`>,
+  params: {
+    version?: V;
+  },
   callback: any
 ): any;
 

--- a/packages/fhir/src/types.ts
+++ b/packages/fhir/src/types.ts
@@ -1,0 +1,8 @@
+import * as r5 from 'fhir/r5';
+
+// TODO this will be a complex type
+// I think I can only handle simple types in the js doc
+// how will I bind this to the resourceType in the function ?
+export type FhirResource = r5.Patient | r5.Bundle;
+
+export type FhirResourceType = 'Patient' | 'Bundle';

--- a/packages/fhir/test/Adaptor.test.js
+++ b/packages/fhir/test/Adaptor.test.js
@@ -7,7 +7,8 @@ import {
   post,
   getClaim,
   createTransactionBundle,
-} from '../src/Adaptor.js';
+} from '../src/Adaptor';
+import { create } from '../src/Utils';
 import { fixtures } from './ClientFixtures';
 
 import MockAgent from './mockAgent.js';
@@ -73,6 +74,10 @@ describe('create', () => {
     )(state);
 
     expect(finalState.data).to.eql(fixtures.patientBundleCreateResponse);
+  });
+
+  it('should have typings', () => {
+    create('Patient', {});
   });
 });
 
@@ -249,5 +254,11 @@ describe('post', () => {
     });
 
     expect(error.code).to.eql('UNEXPECTED_ABSOLUTE_URL');
+  });
+});
+
+describe('util.create', () => {
+  it('should create a patient', () => {
+    create();
   });
 });

--- a/packages/fhir/tsconfig.json
+++ b/packages/fhir/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "*.d.ts"],
+  "compilerOptions": {
+    "outDir": "dist-tmp",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "target": "ES2020",
+    "module": "es2020"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,15 @@ importers:
       '@openfn/buildtools':
         specifier: workspace:^1.0.2
         version: link:tools/build
+      '@openfn/language-common':
+        specifier: workspace:^
+        version: link:packages/common
+      '@openfn/language-dhis2':
+        specifier: workspace:^
+        version: link:packages/dhis2
+      '@openfn/language-fhir':
+        specifier: workspace:^
+        version: link:packages/fhir
       '@openfn/metadata':
         specifier: workspace:^1.0.1
         version: link:tools/metadata
@@ -469,6 +478,9 @@ importers:
       '@openfn/language-common':
         specifier: workspace:^2.0.0
         version: link:../common
+      '@types/fhir':
+        specifier: ^0.0.41
+        version: 0.0.41
       undici:
         specifier: ^5.28.4
         version: 5.28.4
@@ -3777,6 +3789,10 @@ packages:
     resolution: {integrity: sha512-erqUpFXksaeR2kejKnhnjZjbFxUpGZx4Z7ydNL9ie8tEhXPiZTsLeUDJ6aR1F8j5wWUAtOAQWUqkc7givBJbBA==}
     dependencies:
       '@types/node': 18.17.5
+    dev: false
+
+  /@types/fhir@0.0.41:
+    resolution: {integrity: sha512-MAQAFufNZBZ6V0F94Nhknmmh/E3iMXFK4n/L8RkSNjKtOJnvaAJERivNOj35VVx9VCQBJbE0BHSzikfBahoRhA==}
     dev: false
 
   /@types/form-data@0.0.33:

--- a/test.js
+++ b/test.js
@@ -1,0 +1,15 @@
+import { create } from '@openfn/language-fhir';
+// this is good enough, the module path doesn't seem to resolve
+// but it won't find the typings this way right?
+// import { create, jam } from './packages/fhir/dist/index';
+import { cursor } from '@openfn/language-common';
+
+import { create as dhis2Create } from '@openfn/language-dhis2';
+
+// Ok so basically VSC isn't loading the typings for these imports AT ALL
+
+create();
+
+cursor('x', {});
+
+dhis2Create();

--- a/test.js
+++ b/test.js
@@ -6,3 +6,13 @@ create('Contract', {
     //display
   },
 });
+
+create('Patient', {
+  address: [
+    {
+      country,
+    },
+  ],
+});
+
+create('');

--- a/test.js
+++ b/test.js
@@ -6,8 +6,6 @@ import { cursor } from '@openfn/language-common';
 
 import { create as dhis2Create } from '@openfn/language-dhis2';
 
-// Ok so basically VSC isn't loading the typings for these imports AT ALL
-
 create();
 
 cursor('x', {});

--- a/test.js
+++ b/test.js
@@ -15,4 +15,10 @@ create('Patient', {
   ],
 });
 
-create('');
+create('', {});
+
+// v4 only
+create('Person', {
+  birthDate: '01/01/2001',
+  
+}, { version: 'r4' });

--- a/test.js
+++ b/test.js
@@ -1,13 +1,8 @@
 import { create } from '@openfn/language-fhir';
-// this is good enough, the module path doesn't seem to resolve
-// but it won't find the typings this way right?
-// import { create, jam } from './packages/fhir/dist/index';
-import { cursor } from '@openfn/language-common';
 
-import { create as dhis2Create } from '@openfn/language-dhis2';
-
-create();
-
-cursor('x', {});
-
-dhis2Create();
+create('Contract', {
+  authority: {
+    // No code assist here though?
+    //display
+  },
+});


### PR DESCRIPTION
## Summary

An experiment to add typescript support to `create`, giving code assist while using that particular function.

This was conceived as a quick alternative to the FHIR Builders issue. But it won't get us very far because each fhir implementation is different and the generic types aren't actually all that useful.

What we really need to be able to auto-generate a fhir adaptor based on a spec, and for the autogenerated mapper to include typings, cross-version mappings, and builders. All the information is there in the spec so it's possible.

Anyway I'm going to keep this open for a little while in case it provides a useful template for something later.

## TODO

This is left basically in a broken state.

The big problem right now (apart from a hack to shortcut the dts build in fhir) is that the typings depend upon `@types/fhir`. Lightning, in its current form anyway, won't actually load the external typings, so you'll get no benefit. What we need to do is use `dts-bundle` to include `@types/fhir` in-line in our adaptor's typings.

Oh, and related to that, `@types/fhir` does this really annoying thing where every prop is duplicated with an underscore. It's a nightmare for code assist because you can't find what you want.

We can fix that in build too though, by stripping out all the underscore props just before we bundle.

## Issues

Relates to #696 

