### PR TITLE
`redis` Add `mGet` operation  

### DIFF
--- a/.changeset/flat-peas-notice.md
+++ b/.changeset/flat-peas-notice.md
@@ -1,0 +1,7 @@
+---
+'@openfn/language-redis': minor
+---
+
+- Add `mGet()` function
+- Remove console.log in `hget()`
+- Add logging to `scan()`

--- a/.changeset/flat-peas-notice.md
+++ b/.changeset/flat-peas-notice.md
@@ -1,7 +1,0 @@
----
-'@openfn/language-redis': minor
----
-
-- Add `mGet()` function
-- Remove console.log in `hget()`
-- Add logging to `scan()`

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-redis
 
+## 1.2.0
+
+### Minor Changes
+
+- c1e3221: - Add `mGet()` function
+  - Remove console.log in `hget()`
+  - Add logging to `scan()`
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/redis/ast.json
+++ b/packages/redis/ast.json
@@ -199,6 +199,63 @@
       "valid": true
     },
     {
+      "name": "mGet",
+      "params": [
+        "keys"
+      ],
+      "docs": {
+        "description": "Get the values at specified paths in JSON documents stored at multiple keys.",
+        "tags": [
+          {
+            "title": "example",
+            "description": "mGet([\"patient\", \"doctor\"]);",
+            "caption": "Get JSON document values of the patient and doctor keys"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "param",
+            "description": "The keys at which the JSON documents are stored.",
+            "type": {
+              "type": "TypeApplication",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Array"
+              },
+              "applications": [
+                {
+                  "type": "NameExpression",
+                  "name": "string"
+                }
+              ]
+            },
+            "name": "keys"
+          },
+          {
+            "title": "state",
+            "description": "{RedisState}"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "hGetAll",
       "params": [
         "key"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-redis",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "OpenFn redis adaptor",
   "type": "module",
   "exports": {


### PR DESCRIPTION
#### Description 

Add `mGet()` function in redis adaptor with unit tests.  `mGet()` function is used to get multiple json keys from redis. 

Related #731 