### PR TITLE
`mssql` remove process.exit(1)

### DIFF
--- a/.changeset/thin-icons-change.md
+++ b/.changeset/thin-icons-change.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-mssql': patch
+---
+
+Removed process.exit(1) to prevent workflow crashes on errors

--- a/.changeset/thin-icons-change.md
+++ b/.changeset/thin-icons-change.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-mssql': patch
----
-
-Removed process.exit(1) to prevent workflow crashes on errors

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-mssql
 
+## 5.0.3
+
+### Patch Changes
+
+- 6d38a48: Removed process.exit(1) to prevent workflow crashes on errors
+
 ## 5.0.2
 
 ### Patch Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mssql",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -84,11 +84,7 @@ export function execute(...operations) {
       createConnection,
       ...operations,
       cleanupState
-    )({ ...initialState, ...state }).catch(e => {
-      console.error(e);
-      console.error('Unhandled error in the operations. Exiting process.');
-      process.exit(1);
-    });
+    )({ ...initialState, ...state });
   };
 }
 


### PR DESCRIPTION
## Summary

Removed the catch logic on `execute()` function. The catch was using `process.exit(1)` which cause a crash and stop the whole workflow from running. 


## Issues

- https://github.com/OpenFn/health-partners/issues/24

## Review Checklist

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests? Should there be?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
