### PR TITLE
`http` better error when no `baseUrl` and no absolute url

### DIFF
--- a/.changeset/quiet-plums-clap.md
+++ b/.changeset/quiet-plums-clap.md
@@ -2,5 +2,6 @@
 '@openfn/language-http': patch
 ---
 
+- Fix an issue where an error is thrown if `state.configuration` is `null`
 - better error when `baseUrl` is not set and the passed url is a relative url.
 - better error when `baseUrl` is not set and no url is provided.

--- a/.changeset/quiet-plums-clap.md
+++ b/.changeset/quiet-plums-clap.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-http': patch
+---
+
+- better error when `baseUrl` is not set and the passed url is a relative url.
+- better error when `baseUrl` is not set and no url is provided.

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -31,7 +31,23 @@ function encodeFormBody(data) {
   return form;
 }
 
-const isAbsoluteUrl = url => /^https?:\/\//.test(url);
+const assertUrl = (pathOrUrl, baseUrl) => {
+  if (!baseUrl && pathOrUrl && !/^https?:\/\//.test(pathOrUrl)) {
+    const e = new Error('UNEXPECTED_RELATIVE_URL');
+    e.code = 'UNEXPECTED_RELATIVE_URL';
+    e.description = `You passed a relative URL but didn't set baseUrl`;
+    e.url = pathOrUrl;
+    e.fix = `Set the baseUrl or pass an absolute URL. Ie it may be https://example.com/api/${pathOrUrl}`;
+    throw e;
+  }
+  if (!baseUrl && !pathOrUrl) {
+    const e = new Error('ERROR_NO_URL');
+    e.code = 'ERROR_NO_URL';
+    e.description = `No URL was provided`;
+    e.fix = `Set the baseUrl or pass an absolute URL. Ie it may be https://example.com/api/users`;
+    throw e;
+  }
+};
 
 export function request(method, path, params, callback = s => s) {
   return state => {
@@ -56,14 +72,7 @@ export function request(method, path, params, callback = s => s) {
 
     const baseUrl = state.configuration?.baseUrl;
 
-    if (!baseUrl && !isAbsoluteUrl(resolvedPath)) {
-      const e = new Error('UNEXPECTED_RELATIVE_URL');
-      e.code = 'UNEXPECTED_RELATIVE_URL';
-      e.description = `You passed a relative URL but didn't set baseUrl`;
-      e.url = resolvedPath;
-      e.fix = `Set the baseUrl or pass an absolute URL. Ie it may be https://example.com/api/${resolvedPath}`;
-      throw e;
-    }
+    assertUrl(resolvedPath, baseUrl);
 
     if (baseUrl) {
       addAuth(state.configuration, headers);

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -31,6 +31,8 @@ function encodeFormBody(data) {
   return form;
 }
 
+const isAbsoluteUrl = url => /^https?:\/\//.test(url);
+
 export function request(method, path, params, callback = s => s) {
   return state => {
     const [resolvedPath, resolvedParams = {}] = expandReferences(
@@ -53,6 +55,15 @@ export function request(method, path, params, callback = s => s) {
     }
 
     const baseUrl = state.configuration?.baseUrl;
+
+    if (!baseUrl && !isAbsoluteUrl(resolvedPath)) {
+      const e = new Error('UNEXPECTED_RELATIVE_URL');
+      e.code = 'UNEXPECTED_RELATIVE_URL';
+      e.description = `You passed a relative URL but didn't set baseUrl`;
+      e.url = resolvedPath;
+      e.fix = `Set the baseUrl or pass an absolute URL. Ie it may be https://example.com/api/${resolvedPath}`;
+      throw e;
+    }
 
     if (baseUrl) {
       addAuth(state.configuration, headers);

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -9,12 +9,12 @@ import {
 import * as cheerio from 'cheerio';
 import cheerioTableparser from 'cheerio-tableparser';
 
-export function addAuth(configuration = {}, headers) {
+export function addAuth(configuration, headers) {
   if (headers.Authorization) {
     return;
   }
 
-  const { username, password, access_token } = configuration;
+  const { username, password, access_token } = configuration ?? {};
 
   if (access_token) {
     Object.assign(headers, { Authorization: `Bearer ${access_token}` });

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -37,14 +37,14 @@ const assertUrl = (pathOrUrl, baseUrl) => {
     e.code = 'UNEXPECTED_RELATIVE_URL';
     e.description = `You passed a relative URL but didn't set baseUrl`;
     e.url = pathOrUrl;
-    e.fix = `Set the baseUrl or pass an absolute URL. Ie it may be https://example.com/api/${pathOrUrl}`;
+    e.fix = `Set the baseUrl on state.configuration or use an absolute URL, like https://example.com/api/${pathOrUrl}`;
     throw e;
   }
   if (!baseUrl && !pathOrUrl) {
     const e = new Error('ERROR_NO_URL');
     e.code = 'ERROR_NO_URL';
-    e.description = `No URL was provided`;
-    e.fix = `Set the baseUrl or pass an absolute URL. Ie it may be https://example.com/api/users`;
+    e.description = `No URL provided`;
+    e.fix = `Make sure to pass a URL string into the request. You may need to set a baseURL on state.configuration.`;
     throw e;
   }
 };

--- a/packages/http/src/Utils.js
+++ b/packages/http/src/Utils.js
@@ -41,8 +41,8 @@ const assertUrl = (pathOrUrl, baseUrl) => {
     throw e;
   }
   if (!baseUrl && !pathOrUrl) {
-    const e = new Error('ERROR_NO_URL');
-    e.code = 'ERROR_NO_URL';
+    const e = new Error('NO_URL');
+    e.code = 'NO_URL';
     e.description = `No URL provided`;
     e.fix = `Make sure to pass a URL string into the request. You may need to set a baseURL on state.configuration.`;
     throw e;

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -57,6 +57,33 @@ describe('request()', () => {
     expect(result.data).to.eql('hello');
   });
 
+  it('should pass if baseUrl is not set and url is absolute', async () => {
+    testServer.intercept({ path: '/greeting' }).reply(200, 'hello');
+
+    const state = {
+      configuration: null,
+    };
+    const result = await execute(
+      request('GET', 'https://www.example.com/greeting')
+    )(state);
+    expect(result.data).to.eql('hello');
+  });
+  it('should throw if baseUrl is not set and url is relative', async () => {
+    const state = {
+      configuration: null,
+    };
+    let err;
+    try {
+      await execute(request('GET', 'greeting'))(state);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.code).to.eql('UNEXPECTED_RELATIVE_URL');
+    expect(err.description).to.eql(
+      "You passed a relative URL but didn't set baseUrl"
+    );
+  });
+
   it('should throw if url is absolute and does not match baseURL', async () => {
     const state = {
       configuration: {

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -67,8 +67,8 @@ describe('request()', () => {
     } catch (e) {
       err = e;
     }
-    expect(err.code).to.eql('ERROR_NO_URL');
-    expect(err.description).to.eql('No URL was provided');
+    expect(err.code).to.eql('NO_URL');
+    expect(err.description).to.not.be.undefined;
   });
   it('should pass if baseUrl is not set and url is absolute', async () => {
     testServer.intercept({ path: '/greeting' }).reply(200, 'hello');
@@ -92,9 +92,7 @@ describe('request()', () => {
       err = e;
     }
     expect(err.code).to.eql('UNEXPECTED_RELATIVE_URL');
-    expect(err.description).to.eql(
-      "You passed a relative URL but didn't set baseUrl"
-    );
+    expect(err.description).to.not.be.undefined
   });
 
   it('should throw if url is absolute and does not match baseUrl', async () => {

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -57,6 +57,19 @@ describe('request()', () => {
     expect(result.data).to.eql('hello');
   });
 
+  it('should throw if no baseUrl is set and no url is provided', async () => {
+    const state = {
+      configuration: null,
+    };
+    let err;
+    try {
+      await execute(request('GET'))(state);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.code).to.eql('ERROR_NO_URL');
+    expect(err.description).to.eql('No URL was provided');
+  });
   it('should pass if baseUrl is not set and url is absolute', async () => {
     testServer.intercept({ path: '/greeting' }).reply(200, 'hello');
 
@@ -84,7 +97,7 @@ describe('request()', () => {
     );
   });
 
-  it('should throw if url is absolute and does not match baseURL', async () => {
+  it('should throw if url is absolute and does not match baseUrl', async () => {
     const state = {
       configuration: {
         baseUrl: 'https://www.example.com',


### PR DESCRIPTION
## Summary

Add better error when `baseUrl` is not set and the passed url is a relative url.

Fixes #
- #733 

## Details

Added an if statement that check if baseUrl is not set and check if the url is not an absolute url. If both conditions are true, I am throwing an error `UNEXPECTED_RELATIVE_URL`. In addition if `baseUrl` is not set and no url is provided, i am throwing `ERROR_NO_URL`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [x] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?