### PR TITLE
fhir-ndr-et: disable builds

### DIFF
--- a/packages/fhir-ndr-et/README.md
+++ b/packages/fhir-ndr-et/README.md
@@ -3,6 +3,8 @@
 An OpenFn **_adaptor_** for building integration jobs for use with the FHIR API
 for NDR Ethopia.
 
+**Builds are DISABLED in CI and local development at the moment - see https://github.com/OpenFn/adaptors/issues/776**
+
 ## Documentation
 
 This adaptor is largely auto-generated from the spec at

--- a/packages/fhir-ndr-et/package.json
+++ b/packages/fhir-ndr-et/package.json
@@ -20,7 +20,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "pnpm clean && esno build/build.ts && build-adaptor fhir-ndr-et",
+    "_build": "pnpm clean && esno build/build.ts && build-adaptor fhir-ndr-et",
     "build:src": "esno build/build.ts",
     "build:adaptor": "pnpm build-adaptor fhir-ndr-et",
     "build:schema": "esno build/generate-schema.ts",


### PR DESCRIPTION
## Summary

This PR disabled builds of the fhir-jembi adaptor

It's a workaround to #777, which is causing problems in CI and local builds because basically we can't effectively lock the spec version, resulting in strange diffs creeping up (and `pnpm publish` failing)

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

