### PR TITLE
Update jsonpath to 10.x

### DIFF
--- a/.changeset/kind-moles-fry.md
+++ b/.changeset/kind-moles-fry.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': patch
+---
+
+Fix a critical security issue in jsonpath-plus

--- a/.changeset/kind-moles-fry.md
+++ b/.changeset/kind-moles-fry.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-common': patch
----
-
-Fix a critical security issue in jsonpath-plus

--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-asana
 
+## 4.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 4.0.2
 
 ### Patch Changes

--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 4.0.2

--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-asana",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "An adaptor to access objects in Asana",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 2.0.2

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-azure-storage
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/azure-storage/package.json
+++ b/packages/azure-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-azure-storage",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "OpenFn adaptor for Azure Storage",
   "type": "module",
   "exports": {

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.3.4

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-beyonic
 
+## 0.3.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.3.4
 
 ### Patch Changes

--- a/packages/beyonic/package.json
+++ b/packages/beyonic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-beyonic",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "beyonic Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-bigquery
 
+## 3.0.4
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 3.0.3
 
 ### Patch Changes

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 3.0.3

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-bigquery",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A Google BigQuery language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.4.4

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cartodb
 
+## 0.4.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.4.4
 
 ### Patch Changes

--- a/packages/cartodb/package.json
+++ b/packages/cartodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-cartodb",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "cartodb Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cht
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 1.0.2

--- a/packages/cht/package.json
+++ b/packages/cht/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-cht",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenFn CHT adaptor",
   "type": "module",
   "exports": {

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-commcare
 
+## 3.2.2
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 3.2.1

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-commcare",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Commcare Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 2.0.0
 
+## 2.0.3
+
+### Patch Changes
+
+- 33973a2: Fix a critical security issue in jsonpath-plus
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -47,7 +47,7 @@
     "csvtojson": "^2.0.10",
     "date-fns": "^2.25.0",
     "http-status-codes": "^2.3.0",
-    "jsonpath-plus": "^4.0.0",
+    "jsonpath-plus": "^10.0.0",
     "lodash": "^4.17.21",
     "undici": "^5.28.4"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-common",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Common Expressions for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dhis2
 
+## 5.0.4
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 5.0.3
 
 ### Patch Changes

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 5.0.3

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dhis2",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "DHIS2 Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.5.6

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dynamics
 
+## 0.5.7
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.5.6
 
 ### Patch Changes

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dynamics",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "A Microsoft Dynamics Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "2.0.2",
+    "@openfn/language-common": "2.0.3",
     "request": "^2.72.0"
   },
   "devDependencies": {

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-facebook
 
+## 0.4.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.4.4
 
 ### Patch Changes

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.4.4

--- a/packages/facebook/package.json
+++ b/packages/facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-facebook",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "An Language Package for Facebook Messenger API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.1.1

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir-ndr-et
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/fhir-ndr-et/package.json
+++ b/packages/fhir-ndr-et/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-fhir-ndr-et",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenFn fhir adaptor for NDR HIV in Ehtiopia",
   "type": "module",
   "exports": {

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 3.0.2

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googlesheets
 
+## 3.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 3.0.2
 
 ### Patch Changes

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-googlesheets",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A Google Sheets Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.3.4

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-hive
 
+## 0.3.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.3.4
 
 ### Patch Changes

--- a/packages/hive/package.json
+++ b/packages/hive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-hive",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "An Apache HIVE adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-http
 
+## 6.4.6
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 6.4.5
 
 ### Patch Changes

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 6.4.5

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-http",
-  "version": "6.4.5",
+  "version": "6.4.6",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.5.4

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-khanacademy
 
+## 0.5.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.5.4
 
 ### Patch Changes

--- a/packages/khanacademy/package.json
+++ b/packages/khanacademy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-khanacademy",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A Khan Academy Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 1.0.5

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailchimp
 
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mailchimp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "An OpenFn adaptor for use with Mailchimp",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailgun
 
+## 0.5.4
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.5.3
 
 ### Patch Changes

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.5.3

--- a/packages/mailgun/package.json
+++ b/packages/mailgun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mailgun",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "mailgun Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.5.5

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-maximo
 
+## 0.5.6
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.5.5
 
 ### Patch Changes

--- a/packages/maximo/package.json
+++ b/packages/maximo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-maximo",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "An IBM Maximo EAM Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-medicmobile
 
+## 0.5.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.5.4
 
 ### Patch Changes

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.5.4

--- a/packages/medicmobile/package.json
+++ b/packages/medicmobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-medicmobile",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A Medic Mobile language pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -4,7 +4,7 @@ v0.1.6
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.5.5

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -1,5 +1,12 @@
 v0.1.6
 
+## 0.5.6
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.5.5
 
 ### Patch Changes

--- a/packages/mogli/package.json
+++ b/packages/mogli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mogli",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A Mogli SMS Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mongodb
 
+## 2.1.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 2.1.4
 
 ### Patch Changes

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 2.1.4

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mongodb",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "A language package for working with MongoDb",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.7.4

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msgraph
 
+## 0.7.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.7.4
 
 ### Patch Changes

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-msgraph",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Microsoft Graph Language Pack for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mssql
 
+## 5.0.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 5.0.4
 
 ### Patch Changes

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 5.0.4

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mssql",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mysql
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 2.0.2

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mysql",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A MySQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "main": "dist/index.cjs",

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-nexmo
 
+## 0.5.7
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.5.6
 
 ### Patch Changes

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.5.6

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-nexmo",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "An Language Package for Nexmo",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ocl
 
+## 1.2.6
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 1.2.5
 
 ### Patch Changes

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 1.2.5

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ocl",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "An OCL language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "2.0.2"
+    "@openfn/language-common": "2.0.3"
   },
   "devDependencies": {
     "@openfn/simple-ast": "^0.4.1",

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-odk
 
+## 3.0.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 3.0.4
 
 ### Patch Changes

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 3.0.4

--- a/packages/odk/package.json
+++ b/packages/odk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-odk",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "OpenFn odk adaptor",
   "type": "module",
   "exports": {

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 2.0.3

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openfn
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openfn",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "An (experimental) adaptor for accessing the OpenFn web API",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openhim
 
+## 0.3.4
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.3.3
 
 ### Patch Changes

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.3.3

--- a/packages/openhim/package.json
+++ b/packages/openhim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openhim",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "openhim Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 2.0.2

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openimis
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/openimis/package.json
+++ b/packages/openimis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openimis",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "An OpenIMIS adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 1.0.4

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openlmis
 
+## 1.0.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/openlmis/package.json
+++ b/packages/openlmis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openlmis",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenFn openlmis adaptor",
   "type": "module",
   "exports": {

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openmrs
 
+## 4.1.1
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 4.1.0

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openmrs",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "OpenMRS Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 2.0.2

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openspp
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/openspp/package.json
+++ b/packages/openspp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openspp",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "An OpenFn adaptor for working with the OpenSPP json rpc",
   "type": "module",
   "exports": {

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-postgresql
 
+## 6.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 6.0.2
 
 ### Patch Changes

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 6.0.2

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-postgresql",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "A PostgreSQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-primero
 
+## 3.0.4
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 3.0.3
 
 ### Patch Changes

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 3.0.3

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-primero",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A UNICEF Primero language package for use with Open Function",
   "exports": {
     ".": {

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 1.2.1

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-redis
 
+## 1.2.2
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-redis",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "OpenFn redis adaptor",
   "type": "module",
   "exports": {

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.4.4

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-resourcemap
 
+## 0.4.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.4.4
 
 ### Patch Changes

--- a/packages/resourcemap/package.json
+++ b/packages/resourcemap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-resourcemap",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Resourcemap Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-satusehat
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 2.0.2

--- a/packages/satusehat/package.json
+++ b/packages/satusehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-satusehat",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "OpenFn Satusehat adaptor",
   "type": "module",
   "exports": {

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 2.0.2

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-sftp
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-sftp",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "An SFTP language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/smpp/CHANGELOG.md
+++ b/packages/smpp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 1.4.4

--- a/packages/smpp/CHANGELOG.md
+++ b/packages/smpp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-smpp
 
+## 1.4.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 1.4.4
 
 ### Patch Changes

--- a/packages/smpp/package.json
+++ b/packages/smpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-smpp",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "An SMPP client API Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.3.3

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-telerivet
 
+## 0.3.4
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.3.3
 
 ### Patch Changes

--- a/packages/telerivet/package.json
+++ b/packages/telerivet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-telerivet",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "telerivet Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-testing
 
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 1.0.5

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-testing",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "OpenFn test adaptor. Internal use only.",
   "type": "module",
   "exports": {

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 1.3.4

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-vtiger
 
+## 1.3.5
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 1.3.4
 
 ### Patch Changes

--- a/packages/vtiger/package.json
+++ b/packages/vtiger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-vtiger",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A Vtiger Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2]
   - @openfn/language-common@2.0.3
 
 ## 0.4.3

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-zoho
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies [33973a2]
+  - @openfn/language-common@2.0.3
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/zoho/package.json
+++ b/packages/zoho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-zoho",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "zoho Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,8 +301,8 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       jsonpath-plus:
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^10.0.0
+        version: 10.0.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -3387,6 +3387,24 @@ packages:
       lodash: 4.17.21
     dev: false
 
+  /@jsep-plugin/assignment@1.2.1(jsep@1.3.9):
+    resolution: {integrity: sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+    dependencies:
+      jsep: 1.3.9
+    dev: false
+
+  /@jsep-plugin/regex@1.0.3(jsep@1.3.9):
+    resolution: {integrity: sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+    dependencies:
+      jsep: 1.3.9
+    dev: false
+
   /@ljharb/through@2.3.13:
     resolution: {integrity: sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==}
     engines: {node: '>= 0.4'}
@@ -5952,7 +5970,7 @@ packages:
     requiresBuild: true
     dependencies:
       buildcheck: 0.0.6
-      nan: 2.20.0
+      nan: 2.22.0
     dev: false
     optional: true
 
@@ -7814,7 +7832,7 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.20.0
+      nan: 2.22.0
     dev: true
     optional: true
 
@@ -9200,6 +9218,11 @@ packages:
       underscore: 1.13.6
     dev: false
 
+  /jsep@1.3.9:
+    resolution: {integrity: sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==}
+    engines: {node: '>= 10.16.0'}
+    dev: false
+
   /jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
     hasBin: true
@@ -9337,6 +9360,16 @@ packages:
   /jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
+    dev: false
+
+  /jsonpath-plus@10.0.0:
+    resolution: {integrity: sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      '@jsep-plugin/assignment': 1.2.1(jsep@1.3.9)
+      '@jsep-plugin/regex': 1.0.3(jsep@1.3.9)
+      jsep: 1.3.9
     dev: false
 
   /jsonpath-plus@4.0.0:
@@ -10170,8 +10203,8 @@ packages:
       thenify-all: 1.6.0
     dev: false
 
-  /nan@2.20.0:
-    resolution: {integrity: sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==}
+  /nan@2.22.0:
+    resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
     requiresBuild: true
     optional: true
 
@@ -12192,7 +12225,7 @@ packages:
       bcrypt-pbkdf: 1.0.2
     optionalDependencies:
       cpu-features: 0.0.10
-      nan: 2.20.0
+      nan: 2.22.0
     dev: false
 
   /sshpk@1.17.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,7 +372,7 @@ importers:
   packages/dynamics:
     dependencies:
       '@openfn/language-common':
-        specifier: 2.0.2
+        specifier: 2.0.3
         version: link:../common
       request:
         specifier: ^2.72.0
@@ -1150,7 +1150,7 @@ importers:
   packages/ocl:
     dependencies:
       '@openfn/language-common':
-        specifier: 2.0.2
+        specifier: 2.0.3
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -2011,7 +2011,7 @@ importers:
   tools/import-tests:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^2.0.2
+        specifier: workspace:^2.0.3
         version: link:../../packages/common
 
   tools/metadata:

--- a/tools/import-tests/package.json
+++ b/tools/import-tests/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@openfn/language-common": "workspace:^2.0.2"
+    "@openfn/language-common": "workspace:^2.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Update JSON path to 10.0 to fix a critical security vulnerability that affects, well, everything: https://github.com/OpenFn/adaptors/security/dependabot/104

## Details

This updates everyone on the 2.0 branch of common.

I'll raise a separate PR for the adaptors fix to 1.x.

This does not affect legacy releases

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
