### PR TITLE
Patch common to 1.15.2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,6 @@
 name: Publish
 
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
   publish:
@@ -22,8 +19,8 @@ jobs:
       - run: pnpm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run:
-          pnpm publish -r --report-summary --publish-branch main --access=public
+      - run: pnpm publish -r --report-summary --publish-branch release/common-1-15-2
+          --access=public --tag legacy --no-git-checks
 
       - run: pnpm slack:notify
         env:

--- a/packages/beyonic/package.json
+++ b/packages/beyonic/package.json
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "^1.15.1",
+    "@openfn/language-common": "^1.15.2",
     "JSONPath": "^0.10.0",
     "lodash-fp": "^0.10.2",
     "superagent": "^8.0.0"

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@google-cloud/bigquery": "^5.12.0",
-    "@openfn/language-common": "workspace:1.15.1",
+    "@openfn/language-common": "workspace:1.15.2",
     "csv-parse": "^4.16.3",
     "import": "0.0.6",
     "json2csv": "^5.0.7",

--- a/packages/cartodb/package.json
+++ b/packages/cartodb/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "JSONPath": "^0.10.0",
     "json-sql": "^0.3.8",
-    "@openfn/language-common": "^1.15.1",
+    "@openfn/language-common": "^1.15.2",
     "lodash-fp": "^0.10.2",
     "superagent": "^3.7.0"
   },

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.15.2
+
+### Patch Changes
+
+- Update jsonpath-plus to v10.x
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-common",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Common Expressions for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -47,7 +47,7 @@
     "csvtojson": "^2.0.10",
     "date-fns": "^2.25.0",
     "http-status-codes": "^2.3.0",
-    "jsonpath-plus": "^4.0.0",
+    "jsonpath-plus": "^10.0.0",
     "lodash": "^4.17.21",
     "undici": "^5.28.4"
   },

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "request": "^2.72.0"
   },
   "devDependencies": {

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:^1.15.1",
+    "@openfn/language-common": "workspace:^1.15.2",
     "googleapis": "100.0.0"
   },
   "devDependencies": {

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:^1.15.1"
+    "@openfn/language-common": "workspace:^1.15.2"
   },
   "devDependencies": {
     "assertion-error": "^1.0.1",

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@mailchimp/mailchimp_marketing": "^3.0.80",
-    "@openfn/language-common": "^1.15.1",
+    "@openfn/language-common": "^1.15.2",
     "axios": "^0.21.2",
     "md5": "^2.3.0",
     "undici": "^5.28.4"

--- a/packages/maximo/package.json
+++ b/packages/maximo/package.json
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "^1.15.1",
+    "@openfn/language-common": "^1.15.2",
     "base-64": "^0.1.0",
     "request": "^2.88.2",
     "utf8": "^2.1.2"

--- a/packages/mogli/package.json
+++ b/packages/mogli/package.json
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "^1.15.1",
+    "@openfn/language-common": "^1.15.2",
     "JSONPath": "^0.10.0",
     "jsforce": "1.5.1",
     "lodash-fp": "^0.10.4",

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "^1.15.1",
+    "@openfn/language-common": "^1.15.2",
     "mongodb": "^3.7.3"
   },
   "devDependencies": {

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:1.15.1",
+    "@openfn/language-common": "workspace:1.15.2",
     "tedious": "15.1.0"
   },
   "devDependencies": {

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "json-sql": "^0.3.10",
     "mysql": "^2.13.0",
     "squel": "^5.8.0",

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1"
+    "@openfn/language-common": "1.15.2"
   },
   "devDependencies": {
     "@openfn/simple-ast": "^0.4.1",

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "axios": "^0.21.1"
   },
   "devDependencies": {

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1"
+    "@openfn/language-common": "1.15.2"
   },
   "devDependencies": {
     "@openfn/simple-ast": "^0.4.1",

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "pg": "^8.3.2",
     "pg-format": "^1.0.4"
   },

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -31,7 +31,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "cheerio": "^1.0.0-rc.10",
     "cheerio-tableparser": "1.0.1",
     "csv-parse": "^4.8.3",

--- a/packages/progres/package.json
+++ b/packages/progres/package.json
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "axios": "^0.21.2"
   },
   "devDependencies": {

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "axios": "^0.21.2"
   },
   "devDependencies": {

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -32,7 +32,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "lodash": "^4.17.21",
     "ssh2-sftp-client": "9.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
   packages/beyonic:
     dependencies:
       '@openfn/language-common':
-        specifier: ^1.14.0
+        specifier: ^1.15.2
         version: link:../common
       JSONPath:
         specifier: ^0.10.0
@@ -138,7 +138,7 @@ importers:
         specifier: ^5.12.0
         version: 5.12.0
       '@openfn/language-common':
-        specifier: workspace:1.15.0
+        specifier: workspace:1.15.2
         version: link:../common
       csv-parse:
         specifier: ^4.16.3
@@ -193,7 +193,7 @@ importers:
   packages/cartodb:
     dependencies:
       '@openfn/language-common':
-        specifier: ^1.14.0
+        specifier: ^1.15.2
         version: link:../common
       JSONPath:
         specifier: ^0.10.0
@@ -300,8 +300,8 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       jsonpath-plus:
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^10.0.0
+        version: 10.0.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -377,7 +377,7 @@ importers:
   packages/dynamics:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
       request:
         specifier: ^2.72.0
@@ -550,7 +550,7 @@ importers:
   packages/googlesheets:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^1.14.0
+        specifier: workspace:^1.15.2
         version: link:../common
       googleapis:
         specifier: 100.0.0
@@ -686,7 +686,7 @@ importers:
   packages/kobotoolbox:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^1.15.0
+        specifier: workspace:^1.15.2
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -769,7 +769,7 @@ importers:
         specifier: ^3.0.80
         version: 3.0.80
       '@openfn/language-common':
-        specifier: ^1.14.0
+        specifier: ^1.15.2
         version: link:../common
       axios:
         specifier: ^0.21.2
@@ -849,7 +849,7 @@ importers:
   packages/maximo:
     dependencies:
       '@openfn/language-common':
-        specifier: ^1.14.0
+        specifier: ^1.15.2
         version: link:../common
       base-64:
         specifier: ^0.1.0
@@ -941,7 +941,7 @@ importers:
   packages/mogli:
     dependencies:
       '@openfn/language-common':
-        specifier: ^1.14.0
+        specifier: ^1.15.2
         version: link:../common
       JSONPath:
         specifier: ^0.10.0
@@ -993,7 +993,7 @@ importers:
   packages/mongodb:
     dependencies:
       '@openfn/language-common':
-        specifier: ^1.14.0
+        specifier: ^1.15.2
         version: link:../common
       mongodb:
         specifier: ^3.7.3
@@ -1061,7 +1061,7 @@ importers:
   packages/mssql:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:1.15.0
+        specifier: workspace:1.15.2
         version: link:../common
       tedious:
         specifier: 15.1.0
@@ -1092,7 +1092,7 @@ importers:
   packages/mysql:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
       json-sql:
         specifier: ^0.3.10
@@ -1172,7 +1172,7 @@ importers:
   packages/ocl:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -1231,7 +1231,7 @@ importers:
   packages/openfn:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
       axios:
         specifier: ^0.21.1
@@ -1379,7 +1379,7 @@ importers:
   packages/openmrs:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
     devDependencies:
       '@openfn/simple-ast':
@@ -1447,7 +1447,7 @@ importers:
   packages/postgresql:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
       pg:
         specifier: ^8.3.2
@@ -1484,7 +1484,7 @@ importers:
   packages/primero:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
       cheerio:
         specifier: ^1.0.0-rc.10
@@ -1539,7 +1539,7 @@ importers:
   packages/progres:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
       axios:
         specifier: ^0.21.2
@@ -1576,7 +1576,7 @@ importers:
   packages/rapidpro:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
       axios:
         specifier: ^0.21.2
@@ -1721,7 +1721,7 @@ importers:
   packages/sftp:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.0
+        specifier: 1.15.2
         version: link:../common
       lodash:
         specifier: ^4.17.21
@@ -2080,7 +2080,7 @@ importers:
   tools/import-tests:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^1.15.0
+        specifier: workspace:^1.15.2
         version: link:../../packages/common
       mocha:
         specifier: ^10.1.0
@@ -3457,6 +3457,24 @@ packages:
     engines: {node: '>=v12.0.0'}
     dependencies:
       lodash: 4.17.21
+    dev: false
+
+  /@jsep-plugin/assignment@1.2.1(jsep@1.3.9):
+    resolution: {integrity: sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+    dependencies:
+      jsep: 1.3.9
+    dev: false
+
+  /@jsep-plugin/regex@1.0.3(jsep@1.3.9):
+    resolution: {integrity: sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+    dependencies:
+      jsep: 1.3.9
     dev: false
 
   /@ljharb/through@2.3.13:
@@ -5968,7 +5986,7 @@ packages:
     requiresBuild: true
     dependencies:
       buildcheck: 0.0.6
-      nan: 2.20.0
+      nan: 2.22.0
     dev: false
     optional: true
 
@@ -7843,11 +7861,11 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.20.0
+      nan: 2.22.0
     dev: true
     optional: true
 
@@ -8247,7 +8265,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.18.0
+      uglify-js: 3.19.3
     dev: false
 
   /har-schema@2.0.0:
@@ -9248,6 +9266,11 @@ packages:
       underscore: 1.13.6
     dev: false
 
+  /jsep@1.3.9:
+    resolution: {integrity: sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==}
+    engines: {node: '>= 10.16.0'}
+    dev: false
+
   /jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
     hasBin: true
@@ -9387,9 +9410,14 @@ packages:
     engines: {'0': node >= 0.2.0}
     dev: false
 
-  /jsonpath-plus@4.0.0:
-    resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
-    engines: {node: '>=10.0'}
+  /jsonpath-plus@10.0.0:
+    resolution: {integrity: sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      '@jsep-plugin/assignment': 1.2.1(jsep@1.3.9)
+      '@jsep-plugin/regex': 1.0.3(jsep@1.3.9)
+      jsep: 1.3.9
     dev: false
 
   /jsonpath@1.1.1:
@@ -10324,8 +10352,8 @@ packages:
       thenify-all: 1.6.0
     dev: false
 
-  /nan@2.20.0:
-    resolution: {integrity: sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==}
+  /nan@2.22.0:
+    resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
     requiresBuild: true
     optional: true
 
@@ -12374,7 +12402,7 @@ packages:
       bcrypt-pbkdf: 1.0.2
     optionalDependencies:
       cpu-features: 0.0.10
-      nan: 2.20.0
+      nan: 2.22.0
     dev: false
 
   /sshpk@1.17.0:
@@ -13392,8 +13420,8 @@ packages:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
     dev: false
 
-  /uglify-js@3.18.0:
-    resolution: {integrity: sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==}
+  /uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true

--- a/tools/import-tests/package.json
+++ b/tools/import-tests/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@openfn/language-common": "workspace:^1.15.1",
+    "@openfn/language-common": "workspace:^1.15.2",
     "mocha": "^10.1.0"
   }
 }


### PR DESCRIPTION
## Summary

This fixes the legacy common 1.15.2 to use `jsonpath-plus` > 10

This PR should not be merged.

Sister PR to https://github.com/OpenFn/adaptors/pull/782

## Details

Once 1.15.2 is out we'll open a new PR to handle the few outstanding legacy adaptors

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
