### PR TITLE
Fix  json path for adaptors version locked to common 1.15.1

### DIFF
--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-kobotoolbox
 
+## 2.4.3
+
+### Patch Changes
+
+- Security fix: update jsonpath-plus version
+
 ## 2.4.2
 
 ### Patch Changes

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-kobotoolbox",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "A Kobo Toolbox Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1"
+    "@openfn/language-common": "1.15.2"
   },
   "devDependencies": {
     "@openfn/simple-ast": "0.4.1",

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-progres
 
+## 1.4.6
+
+### Patch Changes
+
+- Security fix: update jsonpath-plus version
+
 ## 1.4.5
 
 ### Patch Changes

--- a/packages/progres/package.json
+++ b/packages/progres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-progres",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "An OpenFn adaptor to work with UNHCR's ProGres case management system",
   "homepage": "https://docs.openfn.org",
   "repository": {
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "axios": "^1.7.7"
   },
   "devDependencies": {

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-rapidpro
 
+## 1.1.5
+
+### Patch Changes
+
+- Security fix: update jsonpath-plus version
+
 ## 1.1.4
 
 ### Patch Changes

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-rapidpro",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A RapidPro adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "axios": "^1.7.7"
   },
   "devDependencies": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-salesforce
 
+## 4.8.6
+
+### Patch Changes
+
+- Security fix: update jsonpath-plus version
+
 ## 4.8.5
 
 ### Patch Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "4.8.5",
+  "version": "4.8.6",
   "description": "Salesforce Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {
@@ -32,7 +32,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "any-ascii": "^0.3.2",
     "axios": "^1.7.7",
     "jsforce": "^1.11.1",

--- a/packages/twilio/CHANGELOG.md
+++ b/packages/twilio/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-twilio
 
+## 0.5.2
+
+### Patch Changes
+
+- Security fix: update jsonpath-plus version
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-twilio",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "An Language Package for twilio",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.1",
+    "@openfn/language-common": "1.15.2",
     "twilio": "^3.83.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -700,8 +700,8 @@ importers:
   packages/kobotoolbox:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.1
-        version: 1.15.1
+        specifier: 1.15.2
+        version: 1.15.2
     devDependencies:
       '@openfn/simple-ast':
         specifier: 0.4.1
@@ -1484,8 +1484,8 @@ importers:
   packages/progres:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.1
-        version: 1.15.1
+        specifier: 1.15.2
+        version: 1.15.2
       axios:
         specifier: ^1.7.7
         version: 1.7.7
@@ -1518,8 +1518,8 @@ importers:
   packages/rapidpro:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.1
-        version: 1.15.1
+        specifier: 1.15.2
+        version: 1.15.2
       axios:
         specifier: ^1.7.7
         version: 1.7.7
@@ -1605,8 +1605,8 @@ importers:
   packages/salesforce:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.1
-        version: 1.15.1
+        specifier: 1.15.2
+        version: 1.15.2
       any-ascii:
         specifier: ^0.3.2
         version: 0.3.2
@@ -1840,8 +1840,8 @@ importers:
   packages/twilio:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.1
-        version: 1.15.1
+        specifier: 1.15.2
+        version: 1.15.2
       twilio:
         specifier: ^3.83.2
         version: 3.83.3
@@ -3460,8 +3460,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
 
-  /@openfn/language-common@1.15.1:
-    resolution: {integrity: sha512-8707YCyKy4DMnAtnojYAzV17SvWALtjuhGtBP48VVsJWQvMXH1AjGEL6AFMmU5ySp5ZS8xxVlYcOclhNCvm2KQ==}
+  /@openfn/language-common@1.15.2:
+    resolution: {integrity: sha512-0FWF3iAXm0QJcNnJ4aBVNZgXGUD0hpW592suW5BRRRwh7gxQaOPng+ZjKWqGL9j83KCDY8BKWD8Ol3zpM5bCTQ==}
     dependencies:
       ajv: 8.12.0
       axios: 1.1.3
@@ -3469,7 +3469,7 @@ packages:
       csvtojson: 2.0.10
       date-fns: 2.29.3
       http-status-codes: 2.3.0
-      jsonpath-plus: 4.0.0
+      jsonpath-plus: 10.0.0
       lodash: 4.17.21
       undici: 5.28.4
     transitivePeerDependencies:
@@ -4293,7 +4293,7 @@ packages:
   /axios@1.1.3:
     resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.9
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -7672,16 +7672,6 @@ packages:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
-
   /follow-redirects@1.15.9:
     resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
@@ -9370,11 +9360,6 @@ packages:
       '@jsep-plugin/assignment': 1.2.1(jsep@1.3.9)
       '@jsep-plugin/regex': 1.0.3(jsep@1.3.9)
       jsep: 1.3.9
-    dev: false
-
-  /jsonpath-plus@4.0.0:
-    resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
-    engines: {node: '>=10.0'}
     dev: false
 
   /jsonpath@1.1.1:


### PR DESCRIPTION
## Summary

This PR fixes the final adaptors from #782.

This is the final fix to #781

## Details

Now that we've released common 1.15.2 in #784, this PR updates the small number of adaptors with fixed dependencies

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
