### PR TITLE
`mssql` Improve error logs

### DIFF
--- a/.changeset/cool-news-train.md
+++ b/.changeset/cool-news-train.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-mssql': patch
+---
+
+improve logging error message

--- a/.changeset/cool-news-train.md
+++ b/.changeset/cool-news-train.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-mssql': patch
----
-
-improve logging error message

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Patch Changes
 
-- d3ac969: use reject instead of throwwq
+- d3ac969: use reject instead of throw
 
 ## 5.0.3
 

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-mssql
 
+## 5.0.6
+
+### Patch Changes
+
+- d8d84d3: improve logging error message
+
 ## 5.0.5
 
 ### Patch Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mssql",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -165,7 +165,7 @@ function queryHandler(state, query, callback, options) {
 
     const request = new Request(query, (err, rowCount, rows) => {
       if (err) {
-        console.error(err.message);
+        console.error(err);
         reject(err);
       } else {
         console.log(`Finished: ${rowCount} row(s).`);


### PR DESCRIPTION
## Summary

Fix typo in changelog and log entire error message 

## Details

When the job fail on lightning the logs does not contain any useful information that could help with debugging, See example error message 👇🏽  
```
T Failed step Upsert feedback table on Azure after 2.348s
R/T {
  "details": {},
  "message": "",
  "name": "AdaptorError",
  "severity": "fail",
  "source": "runtime"
}
R/T Check state.errors.b1de9d3b-ba65-49cf-8fff-147759b09736 for details.
R/T Run complete with status: fail
AdaptorError: unknown
```

This PR makes sure we log the whole error message when we have an error 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?