### PR TITLE
fhir-jembi: Fix build

### DIFF
--- a/.changeset/lovely-books-help.md
+++ b/.changeset/lovely-books-help.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-fhir-ndr-et': patch
----
-
-Adjust build process to fix docs

--- a/.changeset/lovely-books-help.md
+++ b/.changeset/lovely-books-help.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-fhir-ndr-et': patch
+---
+
+Adjust build process to fix docs

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-fhir-ndr-et
 
+## 0.1.4
+
+### Patch Changes
+
+- 47bf58f: Adjust build process to fix docs
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/fhir-ndr-et/README.md
+++ b/packages/fhir-ndr-et/README.md
@@ -3,9 +3,6 @@
 An OpenFn **_adaptor_** for building integration jobs for use with the FHIR API
 for NDR Ethopia.
 
-**Builds are DISABLED in CI and local development at the moment - see
-https://github.com/OpenFn/adaptors/issues/776**
-
 ## Documentation
 
 This adaptor is largely auto-generated from the spec at

--- a/packages/fhir-ndr-et/README.md
+++ b/packages/fhir-ndr-et/README.md
@@ -3,7 +3,8 @@
 An OpenFn **_adaptor_** for building integration jobs for use with the FHIR API
 for NDR Ethopia.
 
-**Builds are DISABLED in CI and local development at the moment - see https://github.com/OpenFn/adaptors/issues/776**
+**Builds are DISABLED in CI and local development at the moment - see
+https://github.com/OpenFn/adaptors/issues/776**
 
 ## Documentation
 
@@ -30,7 +31,14 @@ To generate the adaptor source, run `pnpm build:src`. This will generate the
 builder functions and typings, but not generate all the other adaptor stuff,
 like docs and dist.
 
-Run `pnpm build` to generate source AND build the actual adaptor.
+The source is NOT rebuilt in CI or during a general repo build (because a change
+to the remote spec can result in a diff in the source, and a diff in the source
+creates problems all over)
+
+The standard `pnpm build` will generate docs and typedefs and stuff, but NOT the
+source.
+
+So locally, run `pnpm build:src` to rebuild the adaptor code.
 
 The first time the source build runs, a new "spec" file will be downloaded. To
 force a new download (ie to update the spec) delete `./spec/spec.json`

--- a/packages/fhir-ndr-et/package.json
+++ b/packages/fhir-ndr-et/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-fhir-ndr-et",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenFn fhir adaptor for NDR HIV in Ehtiopia",
   "type": "module",
   "exports": {

--- a/packages/fhir-ndr-et/package.json
+++ b/packages/fhir-ndr-et/package.json
@@ -20,7 +20,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "_build": "pnpm clean && esno build/build.ts && build-adaptor fhir-ndr-et",
+    "build": "pnpm clean build-adaptor fhir-ndr-et",
     "build:src": "esno build/build.ts",
     "build:adaptor": "pnpm build-adaptor fhir-ndr-et",
     "build:schema": "esno build/generate-schema.ts",


### PR DESCRIPTION
## Summary

This PR fixes the jembi build so that:
- `pnpm build` does not rebuild the source
- CI builds therefore do not rebuild the source
- Local devs use `build:src` to build the source

Fixes #790 #776

This might even fix #763, if the last build failed to generate typings properly.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
