### PR TITLE
dhis2: Implement breaking version warnings

### DIFF
--- a/.changeset/wild-dodos-rush.md
+++ b/.changeset/wild-dodos-rush.md
@@ -1,4 +1,0 @@
----
-'@openfn/language-dhis2': patch
----
-Removed support for DHIS2 v42

--- a/.changeset/wild-dodos-rush.md
+++ b/.changeset/wild-dodos-rush.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-dhis2': patch
+---
+
+Add warning for breaking versions

--- a/.changeset/wild-dodos-rush.md
+++ b/.changeset/wild-dodos-rush.md
@@ -1,5 +1,4 @@
 ---
 '@openfn/language-dhis2': patch
 ---
-
-Add warning for breaking versions
+Removed support for DHIS2 v42

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-dhis2
 
+## 5.0.7
+
+### Patch Changes
+
+- 6cb5377: Removed support for DHIS2 v42
+
 ## 5.0.6
 
 ### Patch Changes

--- a/packages/dhis2/README.md
+++ b/packages/dhis2/README.md
@@ -15,9 +15,9 @@ core execute \
 ```
 
 > **Important Note:**  
-> This adaptor uses the old tracker version. For the new version, use 6.0. The
-> API versions that might work are any version <42. See
-> [documentation](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html)
+> This adaptor uses the old tracker version. For the new version, use adaptor 6.0+. The
+> Any API version less than 42 WILL work. See
+> [dhis2 documentation](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html)
 > for more information.
 
 ## Documentation

--- a/packages/dhis2/README.md
+++ b/packages/dhis2/README.md
@@ -15,9 +15,10 @@ core execute \
 ```
 
 > **Important Note:**  
-> This adaptor uses the old tracker version. For the new version, use 6.0. 
-> The API versions that might work are any version <42. See [docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html) for more information.
-
+> This adaptor uses the old tracker version. For the new version, use 6.0. The
+> API versions that might work are any version <42. See
+> [documentation](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html)
+> for more information.
 
 ## Documentation
 

--- a/packages/dhis2/README.md
+++ b/packages/dhis2/README.md
@@ -15,7 +15,7 @@ core execute \
 ```
 
 > **Important Note:**  
-> This adaptor uses the old tracker version. For the new version, use tracker version 6.0.
+> This adaptor uses the old tracker version. For the new version, use 6.0.
 
 
 ## Documentation

--- a/packages/dhis2/README.md
+++ b/packages/dhis2/README.md
@@ -14,6 +14,10 @@ core execute \
  -o ./tmp/output.json
 ```
 
+> **Important Note:**  
+> This adaptor uses the old tracker version. For the new version, use tracker version 6.0.
+
+
 ## Documentation
 
 View the [docs site](https://docs.openfn.org/adaptors/packages/dhis2-docs) for

--- a/packages/dhis2/README.md
+++ b/packages/dhis2/README.md
@@ -16,7 +16,7 @@ core execute \
 
 > **Important Note:**  
 > This adaptor uses the old tracker version. For the new version, use 6.0. 
-> The API versions that might work are any version <42. See [docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html) for more information
+> The API versions that might work are any version <42. See [docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html) for more information.
 
 
 ## Documentation

--- a/packages/dhis2/README.md
+++ b/packages/dhis2/README.md
@@ -15,7 +15,8 @@ core execute \
 ```
 
 > **Important Note:**  
-> This adaptor uses the old tracker version. For the new version, use 6.0.
+> This adaptor uses the old tracker version. For the new version, use 6.0. 
+> The API versions that might work are any version <42. See [docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html) for more information
 
 
 ## Documentation

--- a/packages/dhis2/README.md
+++ b/packages/dhis2/README.md
@@ -15,9 +15,10 @@ core execute \
 ```
 
 > **Important Note:**  
-> This adaptor uses the old tracker version. For the new version, use adaptor 6.0+. The
-> Any API version less than 42 WILL work. See
-> [dhis2 documentation](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html)
+> This adaptor uses the old tracker version and is only compatible with DHIS2
+> API versions before 42 (2.42). For later API versions and the new tracker, use
+> adaptor 6.0+. See
+> [DHIS2 documentation](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html)
 > for more information.
 
 ## Documentation

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dhis2",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "DHIS2 Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -38,7 +38,7 @@ export function execute(...operations) {
     const version = state.configuration?.apiVersion;
     if (+version >= 42)
       console.warn(
-        `WARNING:This adaptor is incompatible with DHIS2 API verison 42. (see here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html).`
+        `WARNING:This adaptor is incompatible with DHIS2 API verison 42. See here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html.`
       );
 
     return commonExecute(

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -38,7 +38,7 @@ export function execute(...operations) {
     const version = state.configuration?.apiVersion;
     if (+version >= 42)
       console.warn(
-        `WARNING:This adaptor is incompatible with DHIS2 API verison 42. See here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html.`
+        `WARNING: This adaptor is incompatible with DHIS2 API version 42+. See here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html.`
       );
 
     return commonExecute(

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -36,11 +36,11 @@ export function execute(...operations) {
 
   return state => {
     const version = state.configuration?.apiVersion;
-    if (+version >= 42) {
+    if (+version >= 42)
       console.warn(
-        `This adaptor is incompatible with DHIS2 API verison 42. (see here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html).`
+        `WARNING:This adaptor is incompatible with DHIS2 API verison 42. (see here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html).`
       );
-    }
+
     return commonExecute(
       configMigrationHelper,
       ...operations

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -35,6 +35,12 @@ export function execute(...operations) {
   };
 
   return state => {
+    const version = state.configuration?.apiVersion;
+    if (+version >= 42) {
+      console.warn(
+        `This adaptor is incompatible with DHIS2 API verison 42. (see here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html).`
+      );
+    }
     return commonExecute(
       configMigrationHelper,
       ...operations
@@ -504,7 +510,6 @@ export function upsert(
 
     // NOTE: that these parameters are all expanded by the `get`, `create`, and
     // `update` functions used inside this composed "upsert" function.
-
     return get(
       resourceType,
       query,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,34 +496,6 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
 
-  packages/fhir-jembi:
-    dependencies:
-      '@openfn/language-common':
-        specifier: workspace:*
-        version: link:../common
-    devDependencies:
-      assertion-error:
-        specifier: 2.0.0
-        version: 2.0.0
-      chai:
-        specifier: 4.3.6
-        version: 4.3.6
-      deep-eql:
-        specifier: 4.1.1
-        version: 4.1.1
-      esno:
-        specifier: ^0.16.3
-        version: 0.16.3
-      mocha:
-        specifier: ^10.7.3
-        version: 10.7.3
-      rimraf:
-        specifier: 3.0.2
-        version: 3.0.2
-      undici:
-        specifier: ^5.22.1
-        version: 5.28.4
-
   packages/fhir-ndr-et:
     dependencies:
       '@openfn/language-common':


### PR DESCRIPTION
## Summary

Add warning and update readMe on the API version update

Fixes #754

## Details

Nothing has been changed, only a warning has been added when the adaptor loads and the readMe updated with the same warning

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?