### PR TITLE
Collections: restrict set to batches of 1000

### DIFF
--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-collections
 
+## 0.5.1
+
+### Patch Changes
+
+- set() will now upsert items in batches of 1000
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-collections",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OpenFn collections adaptor",
   "type": "module",
   "exports": {

--- a/packages/collections/src/mock.js
+++ b/packages/collections/src/mock.js
@@ -73,6 +73,9 @@ export function API() {
   const asJSON = (name, key) => {
     return JSON.parse(collections[name][key]);
   };
+  const count = name => {
+    return Object.keys(collections[name]).length;
+  };
 
   // TODO strictly speaking this should support patterns
   // but keeping it super simple in the mock for now
@@ -103,6 +106,7 @@ export function API() {
     remove,
     byKey,
     asJSON,
+    count,
   };
 
   return api;

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -372,7 +372,7 @@ describe('set', () => {
   });
 
   // TODO: there's no actual test of pagination here, save the logs
-  it.only('should set several batches of items', async () => {
+  it('should set several batches of items', async () => {
     const { state } = init();
 
     // the collection has one item by default

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -370,6 +370,23 @@ describe('set', () => {
     const y = api.asJSON(COLLECTION, items[1].id);
     expect(y).to.eql(items[1]);
   });
+
+  // TODO: there's no actual test of pagination here, save the logs
+  it.only('should set several batches of items', async () => {
+    const { state } = init();
+
+    // the collection has one item by default
+    expect(api.count(COLLECTION)).to.equal(1);
+
+    const items = new Array(2499).fill(1).map((_item, idx) => ({
+      id: `${idx}`,
+    }));
+    const keygen = item => item.id;
+
+    await collections.set(COLLECTION, keygen, items)(state);
+
+    expect(api.count(COLLECTION)).to.equal(2500);
+  });
 });
 
 describe('remove', () => {


### PR DESCRIPTION
## Summary

This PR restricts `set()` to upsert 1000 items at a time.

This helps avoid database limits at the database end.

This is a bit of a temporary fix and we will soon add smarter streaming APIs and backend batching.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
