### PR TITLE
Collections: patch for streaming JSON

### DIFF
--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-collections
 
+## 0.5.2
+
+### Patch Changes
+
+- Fix an issue where sometimes the JSON stream would skip tokens and result in a
+  smaller payload being returned
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-collections",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "OpenFn collections adaptor",
   "type": "module",
   "exports": {

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -29,7 +29,6 @@
   ],
   "dependencies": {
     "@openfn/language-common": "workspace:*",
-    "stream-chain": "^3.3.2",
     "stream-json": "^1.8.0",
     "undici": "^5.22.1"
   },

--- a/packages/collections/src/collections.js
+++ b/packages/collections/src/collections.js
@@ -376,7 +376,6 @@ export const streamResponse = async (response, onValue) => {
       });
 
       await waitFor('endObject');
-      debug = false;
     }
     if (isInsideItems && token.name === 'endArray') {
       // This doesn't really matter but, just for the record, let's close out the array

--- a/packages/collections/src/collections.js
+++ b/packages/collections/src/collections.js
@@ -1,11 +1,7 @@
 import nodepath from 'node:path';
 import undici from 'undici';
 import { throwError, expandReferences } from '@openfn/language-common/util';
-import chain from 'stream-chain';
 import parser from 'stream-json';
-import Pick from 'stream-json/filters/Pick';
-import streamArray from 'stream-json/streamers/StreamArray';
-import streamValues from 'stream-json/streamers/StreamValues';
 
 import { createServer } from './mock';
 
@@ -300,7 +296,6 @@ export function each(name, query = {}, callback = () => {}) {
         query: q,
       });
 
-      // build a response array
       cursor = await streamResponse(response, async ({ key, value }) => {
         batchSize++;
         await callback(state, JSON.parse(value), key);
@@ -321,7 +316,7 @@ export function each(name, query = {}, callback = () => {}) {
 }
 
 export const streamResponse = async (response, onValue) => {
-  const pipeline = chain([response.body, parser()]);
+  const pipeline = response.body.pipe(parser());
 
   let isInsideItems = false;
   let cursor;
@@ -359,9 +354,7 @@ export const streamResponse = async (response, onValue) => {
       }
     }
 
-    // This lock will parse a key/value pair
-    // the streamer make a lot of assumptuions about this data structure
-    // So if it ever changes, we'll need to come back and modify it
+    // Parse an item object
     // TODO can we leverage json-stream to just generically parse an object at this point?
     if (isInsideItems && token.name === 'startObject') {
       let key;
@@ -382,13 +375,15 @@ export const streamResponse = async (response, onValue) => {
         value: value.value.value,
       });
 
-      waitFor('endObject');
+      await waitFor('endObject');
+      debug = false;
     }
     if (isInsideItems && token.name === 'endArray') {
       // This doesn't really matter but, just for the record, let's close out the array
       isInsideItems = false;
     }
   }
+
   return cursor;
 };
 

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -71,6 +71,27 @@ describe('each', () => {
     expect(count).to.eql(3);
   });
 
+  it('should iterate over many many items', async () => {
+    const items = new Array(1e4)
+      .fill(0)
+      .map((v, idx) => [`${idx}`, { id: `item-${idx}` }]);
+
+    const { state } = init(items);
+
+    let count = 0;
+
+    await collections.each(COLLECTION, '*', (state, value, key) => {
+      count++;
+      expect(state).to.eql(state);
+
+      const item = JSON.parse(api.byKey(COLLECTION, key));
+      expect(item).not.to.be.undefined;
+      expect(item).to.eql(value);
+    })(state);
+
+    expect(count).to.eql(items.length);
+  });
+
   it('should iterate over some items with a key pattern', async () => {
     const { state } = init([
       ['az', { id: 'a' }],

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -588,30 +588,3 @@ describe('streamResponse', () => {
     expect(callbackValue).to.eql('str');
     expect(cursor).to.equal('b');
   });
-
-  // maybe should handle very large arrays?
-  // it('should handle key value pairs in a different order', async () => {
-  //   client.intercept({ path: '/collections/my-collection' }).reply(200, {
-  //     items: [
-  //       {
-  //         value: 'str',
-  //         key: 'a',
-  //       },
-  //     ],
-  //     cursor: 'b',
-  //   });
-
-  //   const response = await client.request({
-  //     method: 'GET',
-  //     path: '/collections/my-collection',
-  //   });
-
-  //   let callbackValue;
-  //   const cursor = await streamResponse(response, ({ key, value }) => {
-  //     callbackValue = value;
-  //   });
-
-  //   expect(callbackValue).to.eql('str');
-  //   expect(cursor).to.equal('b');
-  // });
-});

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -588,4 +588,30 @@ describe('streamResponse', () => {
     expect(callbackValue).to.eql('str');
     expect(cursor).to.equal('b');
   });
+
+  // maybe should handle very large arrays?
+  // it('should handle key value pairs in a different order', async () => {
+  //   client.intercept({ path: '/collections/my-collection' }).reply(200, {
+  //     items: [
+  //       {
+  //         value: 'str',
+  //         key: 'a',
+  //       },
+  //     ],
+  //     cursor: 'b',
+  //   });
+
+  //   const response = await client.request({
+  //     method: 'GET',
+  //     path: '/collections/my-collection',
+  //   });
+
+  //   let callbackValue;
+  //   const cursor = await streamResponse(response, ({ key, value }) => {
+  //     callbackValue = value;
+  //   });
+
+  //   expect(callbackValue).to.eql('str');
+  //   expect(cursor).to.equal('b');
+  // });
 });

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -588,3 +588,4 @@ describe('streamResponse', () => {
     expect(callbackValue).to.eql('str');
     expect(cursor).to.equal('b');
   });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,9 +251,6 @@ importers:
       '@openfn/language-common':
         specifier: workspace:*
         version: link:../common
-      stream-chain:
-        specifier: ^3.3.2
-        version: 3.3.2
       stream-json:
         specifier: ^1.8.0
         version: 1.8.0
@@ -12318,10 +12315,6 @@ packages:
 
   /stream-chain@2.2.5:
     resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
-    dev: false
-
-  /stream-chain@3.3.2:
-    resolution: {integrity: sha512-YvRznt2X9tLSQlQXkYxp9FGcp6uUwBG9VAyjgo53Ov+Ctk36R49xB6NUia37T7owHyi3UtvI6achAj4ufBSaNg==}
     dev: false
 
   /stream-connect@1.0.2:


### PR DESCRIPTION
## Summary

I forgot an await in the streaming parser, which caused inconsistent issues when streaming data down. 

Fixes #829

## Details

I've also removed a little bit of code we don't need.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
