### PR TITLE
fhir-fr typings

### DIFF
--- a/packages/fhir-fr/CHANGELOG.md
+++ b/packages/fhir-fr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-fhir-fr
 
+## 1.0.1
+
+### Patch Changes
+
+- Fix typings
+
 ## 1.0.0
 
 Initial release.

--- a/packages/fhir-fr/package.json
+++ b/packages/fhir-fr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-fhir-fr",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenFn fhir-fr adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-fr",

--- a/packages/fhir-fr/src/index.ts
+++ b/packages/fhir-fr/src/index.ts
@@ -1,0 +1,8 @@
+import './builders';
+
+import * as Adaptor from './Adaptor';
+
+export * as util from './utils';
+
+export * as builders from './builders';
+export * as b from './builders';

--- a/tools/generate-fhir/template/package_json
+++ b/tools/generate-fhir/template/package_json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-{{NAME}}",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "OpenFn {{NAME}} adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor {{NAME}}",

--- a/tools/generate-fhir/template/src/index.ts
+++ b/tools/generate-fhir/template/src/index.ts
@@ -1,0 +1,8 @@
+import './builders';
+
+import * as Adaptor from './Adaptor';
+
+export * as util from './utils';
+
+export * as builders from './builders';
+export * as b from './builders';


### PR DESCRIPTION
## Summary

The type exports for fhir-fr aren't quite right

This PR updates them for the adaptor itself but also for the template

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
