### PR TITLE
fhir-fr: Extensions

### DIFF
--- a/packages/fhir-fr/package.json
+++ b/packages/fhir-fr/package.json
@@ -21,7 +21,7 @@
     "webUrl": "https://hl7.fr/ig/fhir/core",
     "specDate": "2024-03-25",
     "specUrl": "https://hl7.fr/ig/fhir/core/2.0.0/definitions.json.zip",
-    "adaptorGeneratedDate": "2024-11-30T12:30:54.911Z",
+    "adaptorGeneratedDate": "2024-11-30T18:07:29.724Z",
     "generatorVersion": "0.2.1"
   },
   "dependencies": {

--- a/packages/fhir-fr/src/builders.js
+++ b/packages/fhir-fr/src/builders.js
@@ -39,6 +39,10 @@ function address_fr_core_address(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.inseeCode)) {
+        resource.inseeCode = props.inseeCode;
+    }
+
     if (!_.isNil(props.use)) {
         resource.use = props.use;
     }
@@ -133,6 +137,10 @@ function appointment_fr_core_appointment(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.appointmentOperator)) {
+        resource.appointmentOperator = props.appointmentOperator;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -308,6 +316,10 @@ function contactPoint_fr_core_contact_point(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.emailType)) {
+        resource.emailType = props.emailType;
+    }
+
     if (!_.isNil(props.system)) {
         resource.system = props.system;
     }
@@ -382,6 +394,10 @@ function encounter_fr_core_encounter(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.estimatedDischargeDate)) {
+        resource.estimatedDischargeDate = props.estimatedDischargeDate;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -1034,6 +1050,26 @@ function extension_fr_core_identity_reliability(props) {
 
             resource.extension.push(_extension);
         }
+    }
+
+    if (!_.isNil(props.methodCollection)) {
+        resource.methodCollection = props.methodCollection;
+    }
+
+    if (!_.isNil(props.dateCollection)) {
+        resource.dateCollection = props.dateCollection;
+    }
+
+    if (!_.isNil(props.identityStatus)) {
+        resource.identityStatus = props.identityStatus;
+    }
+
+    if (!_.isNil(props.validationDate)) {
+        resource.validationDate = props.validationDate;
+    }
+
+    if (!_.isNil(props.validationMode)) {
+        resource.validationMode = props.validationMode;
     }
 
     if (!_.isNil(props.url)) {
@@ -1824,6 +1860,14 @@ function extension_fr_core_patient_nationality(props) {
         }
     }
 
+    if (!_.isNil(props.code)) {
+        resource.code = props.code;
+    }
+
+    if (!_.isNil(props.period)) {
+        resource.period = props.period;
+    }
+
     if (!_.isNil(props.url)) {
         resource.url = props.url;
     }
@@ -1984,6 +2028,90 @@ function extension_fr_core_schedule_availability_time(props) {
         }
     }
 
+    if (!_.isNil(props.type)) {
+        resource.type = props.type;
+    }
+
+    if (!_.isNil(props.rrule)) {
+        resource.rrule = props.rrule;
+    }
+
+    if (!_.isNil(props.freq)) {
+        resource.freq = props.freq;
+    }
+
+    if (!_.isNil(props.until)) {
+        resource.until = props.until;
+    }
+
+    if (!_.isNil(props.count)) {
+        resource.count = props.count;
+    }
+
+    if (!_.isNil(props.interval)) {
+        resource.interval = props.interval;
+    }
+
+    if (!_.isNil(props.bySecond)) {
+        resource.bySecond = props.bySecond;
+    }
+
+    if (!_.isNil(props.byMinute)) {
+        resource.byMinute = props.byMinute;
+    }
+
+    if (!_.isNil(props.byHour)) {
+        resource.byHour = props.byHour;
+    }
+
+    if (!_.isNil(props.byDay)) {
+        resource.byDay = props.byDay;
+    }
+
+    if (!_.isNil(props.byMonthDay)) {
+        resource.byMonthDay = props.byMonthDay;
+    }
+
+    if (!_.isNil(props.byYearDay)) {
+        resource.byYearDay = props.byYearDay;
+    }
+
+    if (!_.isNil(props.byWeekNo)) {
+        resource.byWeekNo = props.byWeekNo;
+    }
+
+    if (!_.isNil(props.byMonth)) {
+        resource.byMonth = props.byMonth;
+    }
+
+    if (!_.isNil(props.wkst)) {
+        resource.wkst = props.wkst;
+    }
+
+    if (!_.isNil(props.start)) {
+        resource.start = props.start;
+    }
+
+    if (!_.isNil(props.end)) {
+        resource.end = props.end;
+    }
+
+    if (!_.isNil(props.identifier)) {
+        resource.identifier = props.identifier;
+    }
+
+    if (!_.isNil(props.unavailabilityReason)) {
+        resource.unavailabilityReason = props.unavailabilityReason;
+    }
+
+    if (!_.isNil(props.created)) {
+        resource.created = props.created;
+    }
+
+    if (!_.isNil(props.priority)) {
+        resource.priority = props.priority;
+    }
+
     if (!_.isNil(props.url)) {
         resource.url = props.url;
     }
@@ -2037,6 +2165,14 @@ function extension_fr_core_service_type_duration(props) {
 
             resource.extension.push(_extension);
         }
+    }
+
+    if (!_.isNil(props.serviceType)) {
+        resource.serviceType = props.serviceType;
+    }
+
+    if (!_.isNil(props.duration)) {
+        resource.duration = props.duration;
     }
 
     if (!_.isNil(props.url)) {
@@ -2169,6 +2305,10 @@ function healthcareService_fr_core_healthcare_service(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.serviceTypeDuration)) {
+        resource.serviceTypeDuration = props.serviceTypeDuration;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -2433,6 +2573,10 @@ function humanName_fr_core_human_name(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.assemblyOrder)) {
+        resource.assemblyOrder = props.assemblyOrder;
+    }
+
     if (!_.isNil(props.use)) {
         resource.use = props.use;
     }
@@ -2515,6 +2659,10 @@ function location_fr_core_location(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.usePeriod)) {
+        resource.usePeriod = props.usePeriod;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -2641,14 +2789,6 @@ function location_fr_core_location(props) {
             _partOf.id = src.id;
         }
 
-        if (!_.isNil(src.positionRoom)) {
-            util.addExtension(
-                _partOf,
-                "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-location-position-room",
-                src.positionRoom
-            );
-        }
-
         if (!_.isNil(src.reference)) {
             _partOf.reference = src.reference;
         }
@@ -2666,6 +2806,10 @@ function location_fr_core_location(props) {
         }
 
         resource.partOf = _partOf;
+    }
+
+    if (!_.isNil(props.positionRoom)) {
+        resource.positionRoom = props.positionRoom;
     }
 
     if (!_.isNil(props.hoursOfOperation)) {
@@ -2980,6 +3124,10 @@ function observation_fr_core_observation_bmi(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.supportingInfo)) {
+        resource.supportingInfo = props.supportingInfo;
+    }
+
     if (!_.isNil(props.modifierExtension)) {
         resource.modifierExtension = props.modifierExtension;
     }
@@ -3233,6 +3381,14 @@ function observation_fr_core_observation_body_height(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.bodyposition)) {
+        resource.bodyposition = props.bodyposition;
+    }
+
+    if (!_.isNil(props.supportingInfo)) {
+        resource.supportingInfo = props.supportingInfo;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -3492,6 +3648,14 @@ function observation_fr_core_observation_body_temperature(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.levelOfExertion)) {
+        resource.levelOfExertion = props.levelOfExertion;
+    }
+
+    if (!_.isNil(props.supportingInfo)) {
+        resource.supportingInfo = props.supportingInfo;
+    }
+
     if (!_.isNil(props.modifierExtension)) {
         resource.modifierExtension = props.modifierExtension;
     }
@@ -3747,6 +3911,10 @@ function observation_fr_core_observation_body_weight(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.supportingInfo)) {
+        resource.supportingInfo = props.supportingInfo;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -4006,6 +4174,10 @@ function observation_fr_core_observation_bp(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.supportingInfo)) {
+        resource.supportingInfo = props.supportingInfo;
+    }
+
     if (!_.isNil(props.modifierExtension)) {
         resource.modifierExtension = props.modifierExtension;
     }
@@ -4259,6 +4431,10 @@ function observation_fr_core_observation_head_circum(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.supportingInfo)) {
+        resource.supportingInfo = props.supportingInfo;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -4516,6 +4692,18 @@ function observation_fr_core_observation_heartrate(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.levelOfExertion)) {
+        resource.levelOfExertion = props.levelOfExertion;
+    }
+
+    if (!_.isNil(props.bodyPosition)) {
+        resource.bodyPosition = props.bodyPosition;
+    }
+
+    if (!_.isNil(props.supportingInfo)) {
+        resource.supportingInfo = props.supportingInfo;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -4805,6 +4993,18 @@ function observation_fr_core_observation_resp_rate(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.bodyPosition)) {
+        resource.bodyPosition = props.bodyPosition;
+    }
+
+    if (!_.isNil(props.levelOfExertion)) {
+        resource.levelOfExertion = props.levelOfExertion;
+    }
+
+    if (!_.isNil(props.supportingInfo)) {
+        resource.supportingInfo = props.supportingInfo;
+    }
+
     if (!_.isNil(props.modifierExtension)) {
         resource.modifierExtension = props.modifierExtension;
     }
@@ -5060,6 +5260,10 @@ function observation_fr_core_observation_saturation_oxygen(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.supportingInfoAdministrationOxygen)) {
+        resource.supportingInfoAdministrationOxygen = props.supportingInfoAdministrationOxygen;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -5364,6 +5568,18 @@ function organization_fr_core_organization(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.shortName)) {
+        resource.shortName = props.shortName;
+    }
+
+    if (!_.isNil(props.description)) {
+        resource.description = props.description;
+    }
+
+    if (!_.isNil(props.usePeriod)) {
+        resource.usePeriod = props.usePeriod;
+    }
+
     if (!_.isNil(props.modifierExtension)) {
         resource.modifierExtension = props.modifierExtension;
     }
@@ -5562,6 +5778,22 @@ function organization_fr_core_organization_pole(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.shortName)) {
+        resource.shortName = props.shortName;
+    }
+
+    if (!_.isNil(props.description)) {
+        resource.description = props.description;
+    }
+
+    if (!_.isNil(props.budgetLetter)) {
+        resource.budgetLetter = props.budgetLetter;
+    }
+
+    if (!_.isNil(props.usePeriod)) {
+        resource.usePeriod = props.usePeriod;
+    }
+
     if (!_.isNil(props.modifierExtension)) {
         resource.modifierExtension = props.modifierExtension;
     }
@@ -5742,6 +5974,18 @@ function organization_fr_core_organization_uac(props) {
         resource.extension = props.extension;
     }
 
+    if (!_.isNil(props.shortName)) {
+        resource.shortName = props.shortName;
+    }
+
+    if (!_.isNil(props.description)) {
+        resource.description = props.description;
+    }
+
+    if (!_.isNil(props.usePeriod)) {
+        resource.usePeriod = props.usePeriod;
+    }
+
     if (!_.isNil(props.modifierExtension)) {
         resource.modifierExtension = props.modifierExtension;
     }
@@ -5918,6 +6162,54 @@ function organization_fr_core_organization_uf(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.shortName)) {
+        resource.shortName = props.shortName;
+    }
+
+    if (!_.isNil(props.description)) {
+        resource.description = props.description;
+    }
+
+    if (!_.isNil(props.budgetLetter)) {
+        resource.budgetLetter = props.budgetLetter;
+    }
+
+    if (!_.isNil(props.equipmentField)) {
+        resource.equipmentField = props.equipmentField;
+    }
+
+    if (!_.isNil(props.activityField)) {
+        resource.activityField = props.activityField;
+    }
+
+    if (!_.isNil(props.external)) {
+        resource.external = props.external;
+    }
+
+    if (!_.isNil(props.accomodationSpace)) {
+        resource.accomodationSpace = props.accomodationSpace;
+    }
+
+    if (!_.isNil(props.applicantAct)) {
+        resource.applicantAct = props.applicantAct;
+    }
+
+    if (!_.isNil(props.executantAct)) {
+        resource.executantAct = props.executantAct;
+    }
+
+    if (!_.isNil(props.analysisSection)) {
+        resource.analysisSection = props.analysisSection;
+    }
+
+    if (!_.isNil(props.activityType)) {
+        resource.activityType = props.activityType;
+    }
+
+    if (!_.isNil(props.usePeriod)) {
+        resource.usePeriod = props.usePeriod;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -6111,6 +6403,26 @@ function patient_fr_core_patient(props) {
         }
     }
 
+    if (!_.isNil(props.nationality)) {
+        resource.nationality = props.nationality;
+    }
+
+    if (!_.isNil(props.identityReliability)) {
+        resource.identityReliability = props.identityReliability;
+    }
+
+    if (!_.isNil(props.deathPlace)) {
+        resource.deathPlace = props.deathPlace;
+    }
+
+    if (!_.isNil(props.birthdateUpdateIndicator)) {
+        resource.birthdateUpdateIndicator = props.birthdateUpdateIndicator;
+    }
+
+    if (!_.isNil(props.birthPlace)) {
+        resource.birthPlace = props.birthPlace;
+    }
+
     if (!_.isNil(props.modifierExtension)) {
         resource.modifierExtension = props.modifierExtension;
     }
@@ -6172,14 +6484,6 @@ function patient_fr_core_patient(props) {
                 _name.id = item.id;
             }
 
-            if (!_.isNil(item["birth-list-given-name"])) {
-                util.addExtension(
-                    _name,
-                    "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-patient-birth-list-given-name",
-                    item["birth-list-given-name"]
-                );
-            }
-
             if (!_.isNil(item.use)) {
                 _name.use = item.use;
             }
@@ -6210,6 +6514,10 @@ function patient_fr_core_patient(props) {
 
             resource.name.push(_name);
         }
+    }
+
+    if (!_.isNil(props["birth-list-given-name"])) {
+        resource["birth-list-given-name"] = props.birth-list-given-name;
     }
 
     if (!_.isNil(props.telecom)) {
@@ -6256,22 +6564,6 @@ function patient_fr_core_patient(props) {
                 _contact.id = item.id;
             }
 
-            if (!_.isNil(item.contactIdentifier)) {
-                util.addExtension(
-                    _contact,
-                    "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-patient-contact-identifier",
-                    item.contactIdentifier
-                );
-            }
-
-            if (!_.isNil(item.comment)) {
-                util.addExtension(
-                    _contact,
-                    "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-comment",
-                    item.comment
-                );
-            }
-
             if (!_.isNil(item.modifierExtension)) {
                 _contact.modifierExtension = item.modifierExtension;
             }
@@ -6306,6 +6598,14 @@ function patient_fr_core_patient(props) {
 
             resource.contact.push(_contact);
         }
+    }
+
+    if (!_.isNil(props.contactIdentifier)) {
+        resource.contactIdentifier = props.contactIdentifier;
+    }
+
+    if (!_.isNil(props.comment)) {
+        resource.comment = props.comment;
     }
 
     if (!_.isNil(props.communication)) {
@@ -6434,6 +6734,30 @@ function patient_fr_core_patient_ins(props) {
         }
     }
 
+    if (!_.isNil(props.nationality)) {
+        resource.nationality = props.nationality;
+    }
+
+    if (!_.isNil(props.identityReliability)) {
+        resource.identityReliability = props.identityReliability;
+    }
+
+    if (!_.isNil(props.deathPlace)) {
+        resource.deathPlace = props.deathPlace;
+    }
+
+    if (!_.isNil(props.birthdateUpdateIndicator)) {
+        resource.birthdateUpdateIndicator = props.birthdateUpdateIndicator;
+    }
+
+    if (!_.isNil(props.birthPlace)) {
+        resource.birthPlace = props.birthPlace;
+    }
+
+    if (!_.isNil(props.inseeCode)) {
+        util.composite(resource, "inseeCode", props.inseeCode);
+    }
+
     if (!_.isNil(props.modifierExtension)) {
         resource.modifierExtension = props.modifierExtension;
     }
@@ -6497,14 +6821,6 @@ function patient_fr_core_patient_ins(props) {
                 _name.id = item.id;
             }
 
-            if (!_.isNil(item["birth-list-given-name"])) {
-                util.addExtension(
-                    _name,
-                    "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-patient-birth-list-given-name",
-                    item["birth-list-given-name"]
-                );
-            }
-
             if (!_.isNil(item.use)) {
                 _name.use = item.use;
             }
@@ -6535,6 +6851,10 @@ function patient_fr_core_patient_ins(props) {
 
             resource.name.push(_name);
         }
+    }
+
+    if (!_.isNil(props["birth-list-given-name"])) {
+        resource["birth-list-given-name"] = props.birth-list-given-name;
     }
 
     if (!_.isNil(props.telecom)) {
@@ -6581,22 +6901,6 @@ function patient_fr_core_patient_ins(props) {
                 _contact.id = item.id;
             }
 
-            if (!_.isNil(item.contactIdentifier)) {
-                util.addExtension(
-                    _contact,
-                    "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-patient-contact-identifier",
-                    item.contactIdentifier
-                );
-            }
-
-            if (!_.isNil(item.comment)) {
-                util.addExtension(
-                    _contact,
-                    "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-comment",
-                    item.comment
-                );
-            }
-
             if (!_.isNil(item.modifierExtension)) {
                 _contact.modifierExtension = item.modifierExtension;
             }
@@ -6631,6 +6935,14 @@ function patient_fr_core_patient_ins(props) {
 
             resource.contact.push(_contact);
         }
+    }
+
+    if (!_.isNil(props.contactIdentifier)) {
+        resource.contactIdentifier = props.contactIdentifier;
+    }
+
+    if (!_.isNil(props.comment)) {
+        resource.comment = props.comment;
     }
 
     if (!_.isNil(props.communication)) {
@@ -6752,6 +7064,10 @@ function practitioner_fr_core_practitioner(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.specialty)) {
+        resource.specialty = props.specialty;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -6922,6 +7238,10 @@ function practitionerRole_fr_core_practitioner_role_exercice(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.serviceTypeDuration)) {
+        resource.serviceTypeDuration = props.serviceTypeDuration;
     }
 
     if (!_.isNil(props.modifierExtension)) {
@@ -7160,14 +7480,6 @@ function practitionerRole_fr_core_practitioner_role_profession(props) {
                 _code.id = item.id;
             }
 
-            if (!_.isNil(item.professionnalCategory)) {
-                util.addExtension(
-                    _code,
-                    "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-role-code-categorie-professionnelle",
-                    item.professionnalCategory
-                );
-            }
-
             if (!_.isNil(item.coding)) {
                 _code.coding = item.coding;
             }
@@ -7178,6 +7490,10 @@ function practitionerRole_fr_core_practitioner_role_profession(props) {
 
             resource.code.push(_code);
         }
+    }
+
+    if (!_.isNil(props.professionnalCategory)) {
+        resource.professionnalCategory = props.professionnalCategory;
     }
 
     if (!_.isNil(props.specialty)) {
@@ -7480,6 +7796,14 @@ function schedule_fr_core_schedule(props) {
 
     if (!_.isNil(props.extension)) {
         resource.extension = props.extension;
+    }
+
+    if (!_.isNil(props.serviceTypeDuration)) {
+        resource.serviceTypeDuration = props.serviceTypeDuration;
+    }
+
+    if (!_.isNil(props.availabilityTime)) {
+        resource.availabilityTime = props.availabilityTime;
     }
 
     if (!_.isNil(props.modifierExtension)) {

--- a/packages/fhir-fr/types/builders.d.ts
+++ b/packages/fhir-fr/types/builders.d.ts
@@ -11,9 +11,13 @@ type Address_fr_core_address_Props = {
      *  */
     id: string;
     /**
-     * Code COG de la ville
+     * Additional content defined by implementations
      *  */
     extension: Extension;
+    /**
+     * Code COG de la ville
+     *  */
+    inseeCode: Extension;
     /**
      * home | work | temp | old | billing - purpose of this address
      *  */
@@ -182,7 +186,7 @@ type Extension_fr_core_identity_reliability_Props = {
      *  */
     id: string;
     /**
-     * Spécifie le type de document qui a été contrôlé par l'agent d'admission pour justifier le statut de l'identité. Seuls certains types de pièces définis dans le RNIV permettent de valider une identité (CN | PA | CS | ... )
+     * Additional content defined by implementations
      *  */
     extension: {
         /**
@@ -198,6 +202,26 @@ type Extension_fr_core_identity_reliability_Props = {
          *  */
         value: Coding;
     };
+    /**
+     * The way the INS identity is collected | Mode d'obtention de l'INS (SM, CV, INSI, ...)
+     *  */
+    methodCollection: Extension;
+    /**
+     * INS collection date| date d'interrogation du téléservice INSi
+     *  */
+    dateCollection: Extension;
+    /**
+     * Il s'agit du statut de l'identité (VALI | PROV | FICT | DOUT | ...). Dans certains cas il peut également être nécessaire de véhiculer, la notion d’attribut d’identité. Les combinaisons autorisées entre statuts et attributs sont décrites dans le Référentiel National d’Identito-Vigilance.
+     *  */
+    identityStatus: Extension;
+    /**
+     * Date de vérification de l'identité
+     *  */
+    validationDate: Extension;
+    /**
+     * Spécifie le type de document qui a été contrôlé par l'agent d'admission pour justifier le statut de l'identité. Seuls certains types de pièces définis dans le RNIV permettent de valider une identité (CN | PA | CS | ... )
+     *  */
+    validationMode: Extension;
     /**
      * identifies the meaning of the extension
      *  */
@@ -613,7 +637,7 @@ type Extension_fr_core_patient_nationality_Props = {
      *  */
     id: string;
     /**
-     * Nationality Period
+     * Additional content defined by implementations
      *  */
     extension: {
         /**
@@ -629,6 +653,14 @@ type Extension_fr_core_patient_nationality_Props = {
          *  */
         value: Period;
     };
+    /**
+     * Nationality Code
+     *  */
+    code: Extension;
+    /**
+     * Nationality Period
+     *  */
+    period: Extension;
     /**
      * identifies the meaning of the extension
      *  */
@@ -732,6 +764,90 @@ type Extension_fr_core_schedule_availability_time_Props = {
         value: number;
     };
     /**
+     * Extension
+     *  */
+    type: Extension;
+    /**
+     * Recurrent caracteristic of the Schedule | Caractère récurrent du Schedule
+     *  */
+    rrule: Extension;
+    /**
+     * The value set comes from iCalendar | Le jeu de valeur est issu de iCalendar
+     *  */
+    freq: Extension;
+    /**
+     * Extension
+     *  */
+    until: Extension;
+    /**
+     * Number of occurrences | Nombre d'occurences
+     *  */
+    count: Extension;
+    /**
+     * How often the recurrence rule repeats | répétition de la règle de récurrence
+     *  */
+    interval: Extension;
+    /**
+     * List of seconds within a minute | Liste de secondes dans une minute
+     *  */
+    bySecond: Extension;
+    /**
+     * List of minutes within an hour | Liste de minutes dans une heure
+     *  */
+    byMinute: Extension;
+    /**
+     * List of hours of the day | Liste des heures du jour
+     *  */
+    byHour: Extension;
+    /**
+     * List of days of the week | Liste des jours de la semaine
+     *  */
+    byDay: Extension;
+    /**
+     * List of days of the month | Liste des jours dans le mois
+     *  */
+    byMonthDay: Extension;
+    /**
+     * List of days of the year | liste des jours de l'année (1 à 366)
+     *  */
+    byYearDay: Extension;
+    /**
+     * List of weeks of the year | Liste des semaines de l'année
+     *  */
+    byWeekNo: Extension;
+    /**
+     * List of months of the year | Liste des mois de l'année
+     *  */
+    byMonth: Extension;
+    /**
+     * First day of the workweek | Premier jour de la semaine de travail
+     *  */
+    wkst: Extension;
+    /**
+     * Start of the period | Début de la période
+     *  */
+    start: Extension;
+    /**
+     * End of the period | Fin de la période
+     *  */
+    end: Extension;
+    /**
+     * Availability/non-availabilty identifier | Identifiant des disponibilités/non disponibilités
+     *  */
+    identifier: Extension;
+    /**
+     * Non-availability resaon | Raison de l'indisponibilité
+     *  */
+    unavailabilityReason: Extension;
+    /**
+     * The date/time the period was created | Date de création de la période
+     *  */
+    created: Extension;
+    /**
+     * Extension
+     *  */
+    priority: Extension;
+    /**
      * identifies the meaning of the extension
      *  */
     url: string;
@@ -747,7 +863,7 @@ type Extension_fr_core_service_type_duration_Props = {
      *  */
     id: string;
     /**
-     * Duration of the service | durée du service
+     * Extension
      *  */
     extension: {
         /**
@@ -763,6 +879,14 @@ type Extension_fr_core_service_type_duration_Props = {
          *  */
         value: Duration;
     };
+    /**
+     * Type of the service that has to be performed during the appointment | Typedu service à assurer durant le RDV
+     *  */
+    serviceType: Extension;
+    /**
+     * Duration of the service | durée du service
+     *  */
+    duration: Extension;
     /**
      * identifies the meaning of the extension
      *  */
@@ -907,9 +1031,13 @@ type Appointment_fr_core_appointment_Props = {
      *  */
     contained: Resource;
     /**
-     * FR Core Appointment Operator Extension
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Appointment Operator Extension
+     *  */
+    appointmentOperator: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -1045,9 +1173,13 @@ type ContactPoint_fr_core_contact_point_Props = {
      *  */
     id: string;
     /**
-     * Type of email | type de messagerie électronique
+     * Additional content defined by implementations
      *  */
     extension: Extension;
+    /**
+     * Type of email | type de messagerie électronique
+     *  */
+    emailType: Extension;
     /**
      * phone | fax | email | pager | url | sms | other
      *  */
@@ -1131,9 +1263,13 @@ type Encounter_fr_core_encounter_Props = {
      *  */
     contained: Resource;
     /**
-     * Estimated discharge date | Date de sortie estimée
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * Estimated discharge date | Date de sortie estimée
+     *  */
+    estimatedDischargeDate: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -1493,9 +1629,13 @@ type HealthcareService_fr_core_healthcare_service_Props = {
      *  */
     contained: Resource;
     /**
-     * FR Core Service Type Duration Extension
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Service Type Duration Extension
+     *  */
+    serviceTypeDuration: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -1698,9 +1838,13 @@ type HumanName_fr_core_human_name_Props = {
      *  */
     id: string;
     /**
-     * Preferred display order of name parts
+     * Additional content defined by implementations
      *  */
     extension: Extension;
+    /**
+     * Preferred display order of name parts
+     *  */
+    assemblyOrder: Extension;
     /**
      * usual | official | temp | nickname | anonymous | old | maiden
      *  */
@@ -1792,9 +1936,13 @@ type Location_fr_core_location_Props = {
      *  */
     contained: Resource;
     /**
-     * FR Core Use Period Extension
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Use Period Extension
+     *  */
+    usePeriod: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -1910,10 +2058,6 @@ type Location_fr_core_location_Props = {
          *  */
         id: string;
         /**
-         * FR Core Location Part Of Position Room Extension
-         *  */
-        positionRoom: any;
-        /**
          * Literal reference, Relative, internal or absolute URL
          *  */
         reference: string;
@@ -1930,6 +2074,10 @@ type Location_fr_core_location_Props = {
          *  */
         display: string;
     };
+    /**
+     * FR Core Location Part Of Position Room Extension
+     *  */
+    positionRoom: Extension;
     /**
      * What days/times during a week is this location usually open
      *  */
@@ -2239,9 +2387,13 @@ type Observation_fr_core_observation_bmi_Props = {
      *  */
     contained: Resource;
     /**
-     * Other information that may be relevant to this event.
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * Other information that may be relevant to this event.
+     *  */
+    supportingInfo: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -2508,9 +2660,17 @@ type Observation_fr_core_observation_body_height_Props = {
      *  */
     contained: Resource;
     /**
-     * Other information that may be relevant to this event.
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Observation Height Body Position Extension
+     *  */
+    bodyposition: Extension;
+    /**
+     * Other information that may be relevant to this event.
+     *  */
+    supportingInfo: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -2777,9 +2937,17 @@ type Observation_fr_core_observation_body_temperature_Props = {
      *  */
     contained: Resource;
     /**
-     * Other information that may be relevant to this event.
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Observation Level Of Exertion Extension
+     *  */
+    levelOfExertion: Extension;
+    /**
+     * Other information that may be relevant to this event.
+     *  */
+    supportingInfo: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -3046,9 +3214,13 @@ type Observation_fr_core_observation_body_weight_Props = {
      *  */
     contained: Resource;
     /**
-     * Other information that may be relevant to this event.
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * Other information that may be relevant to this event.
+     *  */
+    supportingInfo: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -3315,9 +3487,13 @@ type Observation_fr_core_observation_bp_Props = {
      *  */
     contained: Resource;
     /**
-     * Other information that may be relevant to this event.
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * Other information that may be relevant to this event.
+     *  */
+    supportingInfo: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -3559,9 +3735,13 @@ type Observation_fr_core_observation_head_circum_Props = {
      *  */
     contained: Resource;
     /**
-     * Other information that may be relevant to this event.
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * Other information that may be relevant to this event.
+     *  */
+    supportingInfo: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -3828,9 +4008,21 @@ type Observation_fr_core_observation_heartrate_Props = {
      *  */
     contained: Resource;
     /**
-     * Other information that may be relevant to this event.
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Observation Level Of Exertion Extension
+     *  */
+    levelOfExertion: Extension;
+    /**
+     * FR Core Observation Body Position Ext Extension
+     *  */
+    bodyPosition: Extension;
+    /**
+     * Other information that may be relevant to this event.
+     *  */
+    supportingInfo: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -4123,9 +4315,21 @@ type Observation_fr_core_observation_resp_rate_Props = {
      *  */
     contained: Resource;
     /**
-     * Other information that may be relevant to this event.
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Observation Body Position Ext Extension
+     *  */
+    bodyPosition: Extension;
+    /**
+     * FR Core Observation Level Of Exertion Extension
+     *  */
+    levelOfExertion: Extension;
+    /**
+     * Other information that may be relevant to this event.
+     *  */
+    supportingInfo: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -4392,9 +4596,13 @@ type Observation_fr_core_observation_saturation_oxygen_Props = {
      *  */
     contained: Resource;
     /**
-     * Other information that may be relevant to this event.
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * Other information that may be relevant to this event.
+     *  */
+    supportingInfoAdministrationOxygen: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -4700,6 +4908,18 @@ type Organization_fr_core_organization_Props = {
      *  */
     extension: Extension;
     /**
+     * FR Core Organization Short Name Extension
+     *  */
+    shortName: Extension;
+    /**
+     * FR Core Organization Description Extension
+     *  */
+    description: Extension;
+    /**
+     * Extension
+     *  */
+    usePeriod: Extension;
+    /**
      * Extensions that cannot be ignored
      *  */
     modifierExtension: Extension;
@@ -4892,6 +5112,22 @@ type Organization_fr_core_organization_pole_Props = {
      *  */
     extension: Extension;
     /**
+     * FR Core Organization Short Name Extension
+     *  */
+    shortName: Extension;
+    /**
+     * FR Core Organization Description Extension
+     *  */
+    description: Extension;
+    /**
+     * FR Core Organization Budget Letter Extension
+     *  */
+    budgetLetter: Extension;
+    /**
+     * Extension
+     *  */
+    usePeriod: Extension;
+    /**
      * Extensions that cannot be ignored
      *  */
     modifierExtension: Extension;
@@ -5070,6 +5306,18 @@ type Organization_fr_core_organization_uac_Props = {
      * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Organization Short Name Extension
+     *  */
+    shortName: Extension;
+    /**
+     * FR Core Organization Description Extension
+     *  */
+    description: Extension;
+    /**
+     * Extension
+     *  */
+    usePeriod: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -5250,6 +5498,54 @@ type Organization_fr_core_organization_uf_Props = {
      *  */
     extension: Extension;
     /**
+     * FR Core Organization Short Name Extension
+     *  */
+    shortName: Extension;
+    /**
+     * FR Core Organization Description Extension
+     *  */
+    description: Extension;
+    /**
+     * FR Core Organization Budget Letter Extension
+     *  */
+    budgetLetter: Extension;
+    /**
+     * FR Core Organization Field Extension
+     *  */
+    equipmentField: Extension;
+    /**
+     * FR Core Organization Activity Field Extension
+     *  */
+    activityField: Extension;
+    /**
+     * FR Core Organization External Extension
+     *  */
+    external: Extension;
+    /**
+     * FR Core Organization Total Number Of Theorical Accomodation Space Extension
+     *  */
+    accomodationSpace: Extension;
+    /**
+     * FR Core Organization Applicant Act Extension
+     *  */
+    applicantAct: Extension;
+    /**
+     * FR Core Organization Executant Extension
+     *  */
+    executantAct: Extension;
+    /**
+     * FR Core Organization Analysis Section Extension
+     *  */
+    analysisSection: Extension;
+    /**
+     * FR Core Organization Activity Type Extension
+     *  */
+    activityType: Extension;
+    /**
+     * Extension
+     *  */
+    usePeriod: Extension;
+    /**
      * Extensions that cannot be ignored
      *  */
     modifierExtension: Extension;
@@ -5413,7 +5709,7 @@ type Patient_fr_core_patient_Props = {
      *  */
     contained: Resource;
     /**
-     * Place of Birth for patient
+     * Extension
      *  */
     extension: {
         /**
@@ -5429,6 +5725,26 @@ type Patient_fr_core_patient_Props = {
          *  */
         value: Address;
     };
+    /**
+     * Nationality
+     *  */
+    nationality: Extension;
+    /**
+     * Reliabilility of the identity | Fiabilité de l'identité
+     *  */
+    identityReliability: Extension;
+    /**
+     * FR Core Patient Death Place Extension
+     *  */
+    deathPlace: Extension;
+    /**
+     * FR Core Patient Birthdate Update Indicator Extension
+     *  */
+    birthdateUpdateIndicator: Extension;
+    /**
+     * Place of Birth for patient
+     *  */
+    birthPlace: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -5479,10 +5795,6 @@ type Patient_fr_core_patient_Props = {
          *  */
         id: string;
         /**
-         * Dans le cas d’une identité créée ou modifiée par un appel au téléservice INSi, il s’agit de la liste des prénoms retournée par le téléservice. Ce composant contient tous les prénoms du patient, y compris le premier, que l'on retrouve également dans le champ name.given. Il s'agit de la liste des prénoms du patient, qu'elle soit issue d'une saisie locale ou du retour à l'appel au téléservice INSi. Conformément aux spécifications INS, cette liste est constituée des prénoms, séparés par des espaces.
-         *  */
-        "birth-list-given-name": any;
-        /**
          * usual | official | temp | nickname | anonymous | old | maiden
          *  */
         use: "usual" | "official" | "temp" | "nickname" | "anonymous" | "old";
@@ -5511,6 +5823,10 @@ type Patient_fr_core_patient_Props = {
          *  */
         period: Period;
     };
+    /**
+     * Dans le cas d’une identité créée ou modifiée par un appel au téléservice INSi, il s’agit de la liste des prénoms retournée par le téléservice. Ce composant contient tous les prénoms du patient, y compris le premier, que l'on retrouve également dans le champ name.given. Il s'agit de la liste des prénoms du patient, qu'elle soit issue d'une saisie locale ou du retour à l'appel au téléservice INSi. Conformément aux spécifications INS, cette liste est constituée des prénoms, séparés par des espaces.
+     *  */
+    birth-list-given-name: Extension;
     /**
      * Details of a Technology mediated contact point (phone, fax, email, etc.)
      *  */
@@ -5552,14 +5868,6 @@ type Patient_fr_core_patient_Props = {
          *  */
         id: string;
         /**
-         * Contact identifier in the patient resource | Identifiant de contact dans la ressource Patient
-         *  */
-        contactIdentifier: any;
-        /**
-         * Comment on a dataElement | Commentaire sur un dataElement
-         *  */
-        comment: any;
-        /**
          * Extensions that cannot be ignored even if unrecognized
          *  */
         modifierExtension: Extension;
@@ -5592,6 +5900,14 @@ type Patient_fr_core_patient_Props = {
          *  */
         period: Period;
     };
+    /**
+     * Contact identifier in the patient resource | Identifiant de contact dans la ressource Patient
+     *  */
+    contactIdentifier: Extension;
+    /**
+     * Comment on a dataElement | Commentaire sur un dataElement
+     *  */
+    comment: Extension;
     /**
      * A language which may be used to communicate with the patient about his or her health
      *  */
@@ -5699,7 +6015,7 @@ type Patient_fr_core_patient_ins_Props = {
      *  */
     contained: Resource;
     /**
-     * Place of Birth for patient
+     * Extension
      *  */
     extension: {
         /**
@@ -5715,6 +6031,30 @@ type Patient_fr_core_patient_ins_Props = {
          *  */
         value: Period;
     };
+    /**
+     * Nationality
+     *  */
+    nationality: Extension;
+    /**
+     * Reliabilility of the identity | Fiabilité de l'identité
+     *  */
+    identityReliability: Extension;
+    /**
+     * FR Core Patient Death Place Extension
+     *  */
+    deathPlace: Extension;
+    /**
+     * FR Core Patient Birthdate Update Indicator Extension
+     *  */
+    birthdateUpdateIndicator: Extension;
+    /**
+     * Place of Birth for patient
+     *  */
+    birthPlace: Extension;
+    /**
+     * FR Core Address Insee Code Extension
+     *  */
+    inseeCode: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -5765,10 +6105,6 @@ type Patient_fr_core_patient_ins_Props = {
          *  */
         id: string;
         /**
-         * Dans le cas d’une identité créée ou modifiée par un appel au téléservice INSi, il s’agit de la liste des prénoms retournée par le téléservice. Ce composant contient tous les prénoms du patient, y compris le premier, que l'on retrouve également dans le champ name.given. Il s'agit de la liste des prénoms du patient, qu'elle soit issue d'une saisie locale ou du retour à l'appel au téléservice INSi. Conformément aux spécifications INS, cette liste est constituée des prénoms, séparés par des espaces.
-         *  */
-        "birth-list-given-name": any;
-        /**
          * usual | official | temp | nickname | anonymous | old | maiden
          *  */
         use: "usual" | "official" | "temp" | "nickname" | "anonymous" | "old";
@@ -5797,6 +6133,10 @@ type Patient_fr_core_patient_ins_Props = {
          *  */
         period: Period;
     };
+    /**
+     * Dans le cas d’une identité créée ou modifiée par un appel au téléservice INSi, il s’agit de la liste des prénoms retournée par le téléservice. Ce composant contient tous les prénoms du patient, y compris le premier, que l'on retrouve également dans le champ name.given. Il s'agit de la liste des prénoms du patient, qu'elle soit issue d'une saisie locale ou du retour à l'appel au téléservice INSi. Conformément aux spécifications INS, cette liste est constituée des prénoms, séparés par des espaces.
+     *  */
+    birth-list-given-name: Extension;
     /**
      * Details of a Technology mediated contact point (phone, fax, email, etc.)
      *  */
@@ -5838,14 +6178,6 @@ type Patient_fr_core_patient_ins_Props = {
          *  */
         id: string;
         /**
-         * Contact identifier in the patient resource | Identifiant de contact dans la ressource Patient
-         *  */
-        contactIdentifier: any;
-        /**
-         * Comment on a dataElement | Commentaire sur un dataElement
-         *  */
-        comment: any;
-        /**
          * Extensions that cannot be ignored even if unrecognized
          *  */
         modifierExtension: Extension;
@@ -5878,6 +6210,14 @@ type Patient_fr_core_patient_ins_Props = {
          *  */
         period: Period;
     };
+    /**
+     * Contact identifier in the patient resource | Identifiant de contact dans la ressource Patient
+     *  */
+    contactIdentifier: Extension;
+    /**
+     * Comment on a dataElement | Commentaire sur un dataElement
+     *  */
+    comment: Extension;
     /**
      * A language which may be used to communicate with the patient about his or her health
      *  */
@@ -5992,9 +6332,13 @@ type Practitioner_fr_core_practitioner_Props = {
      *  */
     contained: Resource;
     /**
-     * FR Core Practitioner Specialty Extension
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Practitioner Specialty Extension
+     *  */
+    specialty: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -6156,9 +6500,13 @@ type PractitionerRole_fr_core_practitioner_role_exercice_Props = {
      *  */
     contained: Resource;
     /**
-     * FR Core Service Type Duration Extension
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Service Type Duration Extension
+     *  */
+    serviceTypeDuration: Extension;
     /**
      * Extensions that cannot be ignored
      *  */
@@ -6383,10 +6731,6 @@ type PractitionerRole_fr_core_practitioner_role_profession_Props = {
          *  */
         id: string;
         /**
-         * Catégorie professionnnelle selon le MOS de l'ANS
-         *  */
-        professionnalCategory: any;
-        /**
          * Code defined by a terminology system
          *  */
         coding: Coding;
@@ -6395,6 +6739,10 @@ type PractitionerRole_fr_core_practitioner_role_profession_Props = {
          *  */
         text: string;
     };
+    /**
+     * Catégorie professionnnelle selon le MOS de l'ANS
+     *  */
+    professionnalCategory: Extension;
     /**
      * Specific specialty of the practitioner
      *  */
@@ -6681,9 +7029,17 @@ type Schedule_fr_core_schedule_Props = {
      *  */
     contained: Resource;
     /**
-     * FR Core Schedule availability time Extension
+     * Extension
      *  */
     extension: Extension;
+    /**
+     * FR Core Service Type Duration Extension
+     *  */
+    serviceTypeDuration: Extension;
+    /**
+     * FR Core Schedule availability time Extension
+     *  */
+    availabilityTime: Extension;
     /**
      * Extensions that cannot be ignored
      *  */

--- a/tools/generate-fhir/src/generate-schema.ts
+++ b/tools/generate-fhir/src/generate-schema.ts
@@ -144,7 +144,17 @@ const generate = async (specPath: string, mappings: MappingSpec = {}) => {
       if (el.path === resourceType) {
         continue;
       }
-      const path = el.path.replace(`${resourceType}\.`, '');
+
+      let path;
+      if (el.type?.at(0)?.code === 'Extension' && el.sliceName) {
+        // If this is an extension type, we work out a the path a bit differently
+        path = el.sliceName;
+        console.log(' >> ', el.id);
+
+        // TODO if there's a profile, look up the type def from that
+      } else {
+        path = el.path.replace(`${resourceType}\.`, '');
+      }
 
       if (path.includes('.')) {
         await parseProp(fullSpec, valuesets, schema, path, el);


### PR DESCRIPTION
## Summary

I wanted a quick look at adding  better extensions to fhir-fr.

At the moment we're not even recognising extension properties - because of how they're encoded they're just ignored.

This PR improves things a little, but doesn't have any intelligence. Really, we need to:

- When parsing an extension which is defined by another structure, go and find that structure definition
- Generate code to create to add an extension properly to the resource, mapping the URL properly

[Patient Example](https://hl7.fr/ig/fhir/core/Patient-ExampleFRCorePatient001.json.html)

The example is acutally quite complex because for some reason, birth-place and identifty-status are mapped very differently.

I need to better study the defintions and work out the mapping rules.

In fhir-ndr-et, we used the mappings file to manually map the extension key. But I really want to do better than that here.

This probably needs a good day's work to figure out.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
