### PR TITLE
Collections: pass state into keygen

### DIFF
--- a/.changeset/calm-spoons-tickle.md
+++ b/.changeset/calm-spoons-tickle.md
@@ -1,0 +1,10 @@
+---
+'@openfn/language-collections': minor
+---
+
+BREAKING: Pass state into the keygen function on `set()`. This allows state to
+be used to calculate keys.
+
+When calling `collections.set(collection, keygen, values)`, the keygen function
+signature has changed from `(value, index) => key` to
+`(value, state, index) => key`.

--- a/.changeset/nice-terms-punch.md
+++ b/.changeset/nice-terms-punch.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-collections': patch
+---
+
+Better error handling if the keygen function is invalid

--- a/packages/collections/src/collections.js
+++ b/packages/collections/src/collections.js
@@ -173,10 +173,20 @@ export function set(name, keyGen, values) {
       // Otherwise we convert the incoming values into an array of key/value pairs
       // Note that we may need to serialize json to string
       // the hardest bit is knowing when to deserialize
-      kvPairs = dataArray.map((value, index) => ({
-        key: keyGenFn(value, index),
-        value: JSON.stringify(value),
-      }));
+      kvPairs = dataArray.map((value, index) => {
+        const key = keyGenFn(value, state, index);
+        if (typeof key !== 'string') {
+          const e = new Error('KEYGEN_ERROR');
+          e.description =
+            'The key generator function returned a non-string value which is not a valid key';
+          e.fix = `The second argument to set() is a key or key-generator function. If you pass a function, make sure the function returns a string (a key). Note that this function is NOT a state reference and does not support lazy state ($)`;
+          throw e;
+        }
+        return {
+          key,
+          value: JSON.stringify(value),
+        };
+      });
     }
 
     while (kvPairs.length) {

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -427,6 +427,32 @@ describe('set', () => {
     expect(err.message).to.eql('ILLEGAL_ARGUMENTS');
   });
 
+  it("should throw keygen doesn't return a string", async () => {
+    const { state } = init();
+    state.configuration = {};
+
+    let err;
+    try {
+      await collections.set(COLLECTION, () => true, { x: 1 })(state);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).to.eql('KEYGEN_ERROR');
+  });
+
+  it('should throw keygen looks like a state refernece', async () => {
+    const { state } = init();
+    state.configuration = {};
+
+    let err;
+    try {
+      await collections.set(COLLECTION, state => state, { x: 1 })(state);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).to.eql('KEYGEN_ERROR');
+  });
+
   it('should set a single item', async () => {
     const { state } = init();
 

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -440,7 +440,7 @@ describe('set', () => {
     expect(err.message).to.eql('KEYGEN_ERROR');
   });
 
-  it('should throw keygen looks like a state refernece', async () => {
+  it('should throw keygen looks like a state reference', async () => {
     const { state } = init();
     state.configuration = {};
 
@@ -486,6 +486,18 @@ describe('set', () => {
     await collections.set(COLLECTION, key, item)(state);
 
     const result = api.asJSON(COLLECTION, key);
+    expect(result).to.eql(item);
+  });
+
+  it('should pass state to the keygen function', async () => {
+    const { state } = init();
+    state.key = 'x';
+
+    const item = { id: 'x' };
+
+    await collections.set(COLLECTION, (_key, state) => state.key, item)(state);
+
+    const result = api.asJSON(COLLECTION, 'x');
     expect(result).to.eql(item);
   });
 


### PR DESCRIPTION
## Summary

This PR passes state into the keygen function (see release notes in the PR).

I've also added richer error handling if the keygen function doesn't return a string, which should catch attempts to use lazy state

Fixes #852

This is technically a breaking change but we're also pre-release and it's a very niche corner of the API (I don't think `index` actually has any value, I only pass it on for the sake of it).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?