### PR TITLE
Fix RegExp in expandReferences

### DIFF
--- a/.changeset/nasty-pumpkins-teach.md
+++ b/.changeset/nasty-pumpkins-teach.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': patch
+---
+
+Ensure that RegExp objects can be safely passed as references

--- a/packages/common/src/util/references.js
+++ b/packages/common/src/util/references.js
@@ -19,7 +19,7 @@ const isStream = value => {
 };
 
 function expandReference(state, value) {
-  if (Buffer.isBuffer(value)) {
+  if (Buffer.isBuffer(value) || value instanceof RegExp) {
     return value;
   }
 

--- a/packages/common/src/util/references.js
+++ b/packages/common/src/util/references.js
@@ -19,7 +19,11 @@ const isStream = value => {
 };
 
 function expandReference(state, value) {
-  if (Buffer.isBuffer(value) || value instanceof RegExp) {
+  if (
+    Buffer.isBuffer(value) ||
+    // Note: there is a weird identity thing in the VM where typeof RegExp will be false ¯\_(ツ)_/¯
+    value?.constructor?.name === 'RegExp'
+  ) {
     return value;
   }
 

--- a/packages/common/test/util/references.test.js
+++ b/packages/common/test/util/references.test.js
@@ -1,5 +1,8 @@
 import { expect } from 'chai';
-import { expandReferences, normalizeOauthConfig } from '../../src/util/index.js';
+import {
+  expandReferences,
+  normalizeOauthConfig,
+} from '../../src/util/index.js';
 
 describe('util expandReferences', () => {
   it('should not modify string references', () => {
@@ -9,6 +12,26 @@ describe('util expandReferences', () => {
     const [resolvedName] = expandReferences(state, name);
 
     expect(resolvedName).to.equal('mulder');
+  });
+
+  it('should ignore regex literals', () => {
+    const regex = /scully/;
+    const state = {};
+
+    const [resolvedRegex] = expandReferences(state, regex);
+
+    expect(resolvedRegex instanceof RegExp).to.be.true;
+    expect(resolvedRegex.test('scully')).to.be.true;
+  });
+
+  it('should ignore regex instances', () => {
+    const regex = new RegExp('scully');
+    const state = {};
+
+    const [resolvedRegex] = expandReferences(state, regex);
+
+    expect(resolvedRegex instanceof RegExp).to.be.true;
+    expect(resolvedRegex.test('scully')).to.be.true;
   });
 
   it('should expand function references', () => {

--- a/packages/gmail/src/Utils.js
+++ b/packages/gmail/src/Utils.js
@@ -1,7 +1,8 @@
 import unzipper from 'unzipper';
 import { google } from 'googleapis';
 
-let gmail = undefined;
+let gmail;
+let isTesting;
 
 export async function fetchMessages(userId, query, lastPageToken) {
   let messagesResponse = null;


### PR DESCRIPTION
This PR fixes an issue where passing a RegExp to expandReferences causes it to be serialised into a plan object

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
