### PR TITLE
`salesforce` Add helper for validating and format input data

### DIFF
--- a/.changeset/good-colts-obey.md
+++ b/.changeset/good-colts-obey.md
@@ -2,10 +2,20 @@
 '@openfn/language-salesforce': minor
 ---
 
-- Add utils functions `assertNoNesting` and `removeNestings`
-- Update `@openfn/langauge-common` package to `workspace:*`
-- Use `throwError` function from common to throw errors for `assertNoNesting`
-  and `removeNestings` functions
-- Asserts input data for `upsert`, `create` and `update` to be an object or
-  array of objects
-- Update `bulk` to use `removeNestings`
+- Enforce that `upsert`, `create` and `update` do not accept dot-notated
+  relationships. Relationships should be nested instead. Eg, do this:
+  ```
+  create('Project', {
+   "Project__r": {
+     "Metrics_ID__c": "value"
+   }
+  })
+  ```
+  Not this:
+  ```
+  create('Project', {
+   "Project__r.Metrics_ID__c": "value"
+  })
+  ```
+- Add support for nested relationships in `bulk` (the adaptor will flatten them
+  to dot-notation for you)

--- a/.changeset/good-colts-obey.md
+++ b/.changeset/good-colts-obey.md
@@ -2,7 +2,7 @@
 '@openfn/language-salesforce': minor
 ---
 
-- Add utils helper `validateNoDotKeys` and `flattenData`
-- Update `bulk` to use `flattenData`
+- Add utils helper `assertNoNesting` and `removeNestings`
+- Update `bulk` to use `removeNestings`
 - Add validation to `upsert`, `create` and `update` to ensure no dots are
   present in the input data

--- a/.changeset/good-colts-obey.md
+++ b/.changeset/good-colts-obey.md
@@ -1,0 +1,8 @@
+---
+'@openfn/language-salesforce': minor
+---
+
+- Add utils helper `validateNoDotKeys` and `flattenData`
+- Update `bulk` to use `flattenData`
+- Add validation to `upsert`, `create` and `update` to ensure no dots are
+  present in the input data

--- a/.changeset/good-colts-obey.md
+++ b/.changeset/good-colts-obey.md
@@ -2,7 +2,10 @@
 '@openfn/language-salesforce': minor
 ---
 
-- Add utils helper `assertNoNesting` and `removeNestings`
+- Add utils functions `assertNoNesting` and `removeNestings`
+- Update `@openfn/langauge-common` package to `workspace:*`
+- Use `throwError` function from common to throw errors for `assertNoNesting`
+  and `removeNestings` functions
+- Asserts input data for `upsert`, `create` and `update` to be an object or
+  array of objects
 - Update `bulk` to use `removeNestings`
-- Add validation to `upsert`, `create` and `update` to ensure no dots are
-  present in the input data

--- a/packages/salesforce/ast.json
+++ b/packages/salesforce/ast.json
@@ -9,7 +9,7 @@
         "options"
       ],
       "docs": {
-        "description": "Create and execute a bulk job.\nThis function uses {@link https://sforce.co/4fDLJnk Bulk API},\nwhich is subject to {@link https://sforce.co/4b6kn6z rate limits}.",
+        "description": "Create and execute a bulk job. Nested relationships will be flattened to dot notation automatically.\nThis function uses {@link https://sforce.co/4fDLJnk Bulk API},\nwhich is subject to {@link https://sforce.co/4b6kn6z rate limits}.",
         "tags": [
           {
             "title": "public",
@@ -25,6 +25,11 @@
             "title": "example",
             "description": "bulk(\n  \"vera__Beneficiary__c\",\n  \"upsert\",\n  [\n    {\n      vera__Reporting_Period__c: 2023,\n      vera__Geographic_Area__c: \"Uganda\",\n      \"vera__Indicator__r.vera__ExtId__c\": 1001,\n      vera__Result_UID__c: \"1001_2023_Uganda\",\n    },\n  ],\n  { extIdField: \"vera__Result_UID__c\" }\n);",
             "caption": "Bulk upsert"
+          },
+          {
+            "title": "example",
+            "description": "bulk(\n  \"vera__Beneficiary__c\",\n  \"upsert\",\n  [\n    {\n      vera__Reporting_Period__c: 2023,\n      \"vera_Project\": {\n        \"Metrics_ID__c\": \"jfh5LAnxu1i4na\"\n      }\n    },\n  ],\n  { extIdField: \"vera__Result_UID__c\" }\n);",
+            "caption": "Bulk upsert with a nested relationship"
           },
           {
             "title": "example",
@@ -158,7 +163,7 @@
         "records"
       ],
       "docs": {
-        "description": "Create one or more new sObject records.",
+        "description": "Create one or more new sObject records. Relationships in the record should be nested and not use dot-notation syntax",
         "tags": [
           {
             "title": "public",
@@ -179,6 +184,11 @@
             "title": "example",
             "description": "create(\"Account\",\n  $.data.map((account) => ({\n    Name: account.label\n  })\n));",
             "caption": "Create records from data on state"
+          },
+          {
+            "title": "example",
+            "description": "create(\"Account\", {\n  Name: \"My Account #1\" ,\n  \"Project__r\": {\n    \"Metrics_ID__c\": \"jfh5LAnxu1i4na\"\n  }\n});",
+            "caption": "Update a record with a relationship"
           },
           {
             "title": "function",
@@ -704,7 +714,7 @@
         "records"
       ],
       "docs": {
-        "description": "Create a new sObject record, or updates it if it already exists.",
+        "description": "Create a new sObject record, or updates it if it already exists. Relationships in the record should be nested and not use dot-notation syntax",
         "tags": [
           {
             "title": "public",
@@ -720,6 +730,11 @@
             "title": "example",
             "description": "upsert(\"UpsertTable__c\", \"ExtId__c\", [\n  { Name: \"Record #1\", ExtId__c : 'ID-0000001' },\n  { Name: \"Record #2\", ExtId__c : 'ID-0000002' },\n]);",
             "caption": "Multiple record upsert"
+          },
+          {
+            "title": "example",
+            "description": "upsert(\"UpsertTable__c\", {\n  Name: \"Record #1\",\n  \"Project__r\": {\n    \"Metrics_ID__c\": \"jfh5LAnxu1i4na\"\n  }\n});",
+            "caption": "Update a record with a relationship"
           },
           {
             "title": "function",
@@ -806,12 +821,17 @@
         "records"
       ],
       "docs": {
-        "description": "Update an sObject record or records.",
+        "description": "Update an sObject record or records. Relationships in the record should be nested and not use dot-notation syntax",
         "tags": [
           {
             "title": "public",
             "description": null,
             "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
           },
           {
             "title": "example",
@@ -824,9 +844,9 @@
             "caption": "Multiple records update"
           },
           {
-            "title": "function",
-            "description": null,
-            "name": null
+            "title": "example",
+            "description": "update(\"Account\", {\n  Id: \"0010500000fxbcuAAA\",\n  \"Project__r\": {\n    \"Metrics_ID__c\": \"jfh5LAnxu1i4na\"\n  }\n});",
+            "caption": "Update a record with a relationship"
           },
           {
             "title": "param",

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -107,7 +107,7 @@ export function execute(...operations) {
 }
 
 /**
- * Create and execute a bulk job.
+ * Create and execute a bulk job. Nested relationships will be flattened to dot notation automatically.
  * This function uses {@link https://sforce.co/4fDLJnk Bulk API},
  * which is subject to {@link https://sforce.co/4b6kn6z rate limits}.
  * @public
@@ -129,6 +129,20 @@ export function execute(...operations) {
  *       vera__Geographic_Area__c: "Uganda",
  *       "vera__Indicator__r.vera__ExtId__c": 1001,
  *       vera__Result_UID__c: "1001_2023_Uganda",
+ *     },
+ *   ],
+ *   { extIdField: "vera__Result_UID__c" }
+ * );
+ * @example <caption>Bulk upsert with a nested relationship</caption>
+ * bulk(
+ *   "vera__Beneficiary__c",
+ *   "upsert",
+ *   [
+ *     {
+ *       vera__Reporting_Period__c: 2023,
+ *       "vera_Project": {
+ *         "Metrics_ID__c": "jfh5LAnxu1i4na"
+ *       }
  *     },
  *   ],
  *   { extIdField: "vera__Result_UID__c" }
@@ -302,7 +316,7 @@ export function bulkQuery(query, options = {}) {
 }
 
 /**
- * Create one or more new sObject records.
+ * Create one or more new sObject records. Relationships in the record should be nested and not use dot-notation syntax
  * @public
  * @example <caption> Single record creation</caption>
  * create("Account", { Name: "My Account #1" });
@@ -314,6 +328,13 @@ export function bulkQuery(query, options = {}) {
  *     Name: account.label
  *   })
  * ));
+ * @example <caption>Update a record with a relationship</caption>
+ * create("Account", {
+ *   Name: "My Account #1" ,
+ *   "Project__r": {
+ *     "Metrics_ID__c": "jfh5LAnxu1i4na"
+ *   }
+ * });
  * @function
  * @param {string} sObjectName - API name of the sObject.
  * @param {(Object|Object[])} records - Field attributes for the new record, or an array of field attributes.
@@ -643,7 +664,7 @@ export function query(query, options = {}) {
 }
 
 /**
- * Create a new sObject record, or updates it if it already exists.
+ * Create a new sObject record, or updates it if it already exists. Relationships in the record should be nested and not use dot-notation syntax
  * @public
  * @example <caption> Single record upsert </caption>
  * upsert("UpsertTable__c", "ExtId__c", { Name: "Record #1", ExtId__c : 'ID-0000001' });
@@ -652,6 +673,13 @@ export function query(query, options = {}) {
  *   { Name: "Record #1", ExtId__c : 'ID-0000001' },
  *   { Name: "Record #2", ExtId__c : 'ID-0000002' },
  * ]);
+ * @example <caption>Update a record with a relationship</caption>
+ * upsert("UpsertTable__c", {
+ *   Name: "Record #1",
+ *   "Project__r": {
+ *     "Metrics_ID__c": "jfh5LAnxu1i4na"
+ *   }
+ * });
  * @function
  * @param {string} sObjectName - API name of the sObject.
  * @magic sObjectName - $.children[?(!@.meta.system)].name
@@ -687,8 +715,9 @@ export function upsert(sObjectName, externalId, records) {
 }
 
 /**
- * Update an sObject record or records.
+ * Update an sObject record or records. Relationships in the record should be nested and not use dot-notation syntax
  * @public
+ * @function
  * @example <caption> Single record update</caption>
  * update("Account", {
  *   Id: "0010500000fxbcuAAA",
@@ -699,7 +728,13 @@ export function upsert(sObjectName, externalId, records) {
  *   { Id: "0010500000fxbcuAAA", Name: "Updated Account #1" },
  *   { Id: "0010500000fxbcvAAA", Name: "Updated Account #2" },
  * ]);
- * @function
+ * @example <caption>Update a record with a relationship</caption>
+ * update("Account", {
+ *   Id: "0010500000fxbcuAAA",
+ *   "Project__r": {
+ *     "Metrics_ID__c": "jfh5LAnxu1i4na"
+ *   }
+ * });
  * @param {string} sObjectName - API name of the sObject.
  * @param {(object|object[])} records - Field attributes for the new object.
  * @state {SalesforceResultState}

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -165,18 +165,18 @@ export function bulk(sObjectName, operation, records, options = {}) {
       pollInterval = 6000,
     } = resolvedOptions;
 
-    const flattenRecords = util.flattenData(resolvedRecords);
-    if (allowNoOp && flattenRecords.length === 0) {
+    const flatRecords = util.removeNestings(resolvedRecords);
+    if (allowNoOp && flatRecords.length === 0) {
       console.info(
         `No items in ${resolvedSObjectName} array. Skipping bulk ${resolvedOperation} operation.`
       );
       return state;
     }
 
-    if (flattenRecords.length > 10000)
+    if (flatRecords.length > 10000)
       console.log('Your batch is bigger than 10,000 records; chunking...');
 
-    const chunkedBatches = chunk(flattenRecords, 10000);
+    const chunkedBatches = chunk(flatRecords, 10000);
 
     return Promise.all(
       chunkedBatches.map(
@@ -328,7 +328,7 @@ export function create(sObjectName, records) {
       sObjectName,
       records
     );
-    util.validateNoDotKeys(resolvedRecords);
+    util.assertNoNesting(resolvedRecords);
     console.info(`Creating ${resolvedSObjectName}`, resolvedRecords);
 
     return connection
@@ -668,7 +668,7 @@ export function upsert(sObjectName, externalId, records) {
     const [resolvedSObjectName, resolvedExternalId, resolvedRecords] =
       expandReferences(state, sObjectName, externalId, records);
 
-    util.validateNoDotKeys(resolvedRecords);
+    util.assertNoNesting(resolvedRecords);
     console.info(
       `Upserting ${resolvedSObjectName} with externalId`,
       resolvedExternalId,
@@ -713,7 +713,7 @@ export function update(sObjectName, records) {
       sObjectName,
       records
     );
-    util.validateNoDotKeys(resolvedRecords);
+    util.assertNoNesting(resolvedRecords);
     console.info(`Updating ${resolvedSObjectName}`, resolvedRecords);
 
     return connection

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -165,17 +165,18 @@ export function bulk(sObjectName, operation, records, options = {}) {
       pollInterval = 6000,
     } = resolvedOptions;
 
-    if (allowNoOp && resolvedRecords.length === 0) {
+    const flattenRecords = util.flattenData(resolvedRecords);
+    if (allowNoOp && flattenRecords.length === 0) {
       console.info(
         `No items in ${resolvedSObjectName} array. Skipping bulk ${resolvedOperation} operation.`
       );
       return state;
     }
 
-    if (resolvedRecords.length > 10000)
+    if (flattenRecords.length > 10000)
       console.log('Your batch is bigger than 10,000 records; chunking...');
 
-    const chunkedBatches = chunk(resolvedRecords, 10000);
+    const chunkedBatches = chunk(flattenRecords, 10000);
 
     return Promise.all(
       chunkedBatches.map(
@@ -327,6 +328,7 @@ export function create(sObjectName, records) {
       sObjectName,
       records
     );
+    util.validateNoDotKeys(resolvedRecords);
     console.info(`Creating ${resolvedSObjectName}`, resolvedRecords);
 
     return connection
@@ -665,6 +667,8 @@ export function upsert(sObjectName, externalId, records) {
     const { connection } = state;
     const [resolvedSObjectName, resolvedExternalId, resolvedRecords] =
       expandReferences(state, sObjectName, externalId, records);
+
+    util.validateNoDotKeys(resolvedRecords);
     console.info(
       `Upserting ${resolvedSObjectName} with externalId`,
       resolvedExternalId,
@@ -709,6 +713,7 @@ export function update(sObjectName, records) {
       sObjectName,
       records
     );
+    util.validateNoDotKeys(resolvedRecords);
     console.info(`Updating ${resolvedSObjectName}`, resolvedRecords);
 
     return connection

--- a/packages/salesforce/src/util.js
+++ b/packages/salesforce/src/util.js
@@ -250,8 +250,8 @@ export function assertNoNesting(input) {
       if (key.includes('.')) {
         const { first, last } = key.split('.');
         throwError('UNEXPECTED_KEY', {
-          description: `Dot notation (${key}) is not supported in field names`,
-          fix: `Use nested object format instead (e.g., { ${first}: { ${last}: value } })`,
+          description: `Dot notation syntax (i.e., ${key}) is not supported in key names`,
+          fix: `Relationships record should be nested in an object (e.g., { ${first}: { ${last}: value } })`,
         });
       }
     }

--- a/packages/salesforce/src/util.js
+++ b/packages/salesforce/src/util.js
@@ -191,3 +191,69 @@ export function formatResults(input) {
 
   return output;
 }
+
+/**
+ * Flattens an array of nested objects to a maximum of two levels deep.
+ * - Each object in the array is flattened to have dot-separated keys.
+ * - Throws an error if the input is not an array or if a nested object exceeds two levels deep.
+ *
+ * @param {Array<Object>} input - An array of objects to flatten.
+ * @returns {Array<Object>} - An array of flattened objects.
+ * @throws {Error} - Throws an error if the input is not an array of objects or if nesting exceeds two levels.
+ */
+
+export function flattenData(input) {
+  if (!Array.isArray(input)) {
+    throw new Error('Input must be an array of objects.');
+  }
+
+  return input.map(item => flattenSingleObject(item));
+}
+
+const flattenSingleObject = (obj, parentKey = '', currentDepth = 0) => {
+  const result = {};
+  Object.entries(obj).forEach(([key, value]) => {
+    const newKey = parentKey ? `${parentKey}.${key}` : key;
+
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      if (currentDepth < 1) {
+        Object.assign(
+          result,
+          flattenSingleObject(value, newKey, currentDepth + 1)
+        );
+      } else {
+        throw new Error(
+          `Nested object with key ${newKey} exceeds the allowed depth`
+        );
+      }
+    } else {
+      result[newKey] = value;
+    }
+  });
+  return result;
+};
+
+/**
+ * Validates that no keys in the input object or array of objects contain dots ('.').
+ * Throws an error if a key containing a dot is found.
+ *
+ * @param {Object|Array<Object>} input - The object or array of objects to validate.
+ * @throws {Error} - Throws an error if a key containing a dot is found or if the input is invalid.
+ */
+export function validateNoDotKeys(input) {
+  const hasDotInKeys = obj => {
+    for (const key of Object.keys(obj)) {
+      if (key.includes('.')) {
+        throw new Error(`Invalid key "${key}" contains a dot.`);
+      }
+    }
+  };
+
+  if (Array.isArray(input)) {
+    input.forEach(item => hasDotInKeys(item));
+  } else if (typeof input === 'object' && input !== null) {
+    hasDotInKeys(input);
+  } else {
+    throw new Error('Input must be an object or an array of objects.');
+  }
+}

--- a/packages/salesforce/test/util.test.js
+++ b/packages/salesforce/test/util.test.js
@@ -203,7 +203,7 @@ describe('assertNoNesting', () => {
       Metrics_ID__c: 'value2',
     };
     expect(() => assertNoNesting(input)).throw(
-      'UNEXPECTED_KEY: Dot notation (Task__r.Metrics_ID__c) is not supported in field names'
+      'UNEXPECTED_KEY: Dot notation syntax (i.e., Task__r.Metrics_ID__c) is not supported in key names'
     );
   });
 


### PR DESCRIPTION
## Summary

Add utils helper `validateNoDotKeys` and `flattenData` to help with validation of input data when using `upsert`, `update` or `create` and to transform nested object into a dot notation syntax when using `bulk` operation.

Fixes #556 

## Details

When mapping a salesforce data model there is a bit of confusion on when to use the `dot notation` and when not to. Since the best practice when mapping objects is to always use a nested object for relationship, it's important that the adaptor adds a safe check when you forgot and use the `dot notation` to map salesforce relationship. This PR adds two things 

1. A validation step for `upsert`, `update` and `create` function. This is achieved by the new util helper `validateNotDotKeys`
2. A transformer to a dot notation syntax when using `bulk` function. This is done by the `flattenData` util helper

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [x] Strategy / design
- [x] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [x] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?