### PR TITLE
salesforce: move toUTF8 out to utils

### DIFF
--- a/.changeset/good-chicken-leave.md
+++ b/.changeset/good-chicken-leave.md
@@ -1,0 +1,7 @@
+---
+'@openfn/language-salesforce': major
+---
+
+Move `toUTF8()` to `util.UTF8()`. `toUTF8` is not an operation and cannot be
+called at the top level. Moving into the utils namespace should help make the
+usage of the function a little clearer

--- a/packages/salesforce/ast.json
+++ b/packages/salesforce/ast.json
@@ -881,45 +881,6 @@
       "valid": true
     },
     {
-      "name": "toUTF8",
-      "params": [
-        "input"
-      ],
-      "docs": {
-        "description": "Transliterates unicode characters to their best ASCII representation",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "example",
-            "description": "fn((state) => {\n  const s = toUTF8(\"άνθρωποι\");\n  console.log(s); // anthropoi\n  return state;\n});",
-            "caption": "Transliterate `άνθρωποι` to `anthropoi`"
-          },
-          {
-            "title": "param",
-            "description": "A string with unicode characters",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "input"
-          },
-          {
-            "title": "returns",
-            "description": "ASCII representation of input string",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            }
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
       "name": "request",
       "params": [
         "path",
@@ -1473,7 +1434,7 @@
         "operation"
       ],
       "docs": {
-        "description": "Iterates over an array of items and invokes an operation upon each one, where the state\nobject is _scoped_ so that state.data is the item under iteration.\nThe rest of the state object is untouched and can be referenced as usual.\nYou can pass an array directly, or use lazy state or a JSONPath string to\nreference a slice of state.",
+        "description": "Scopes an array of data based on a JSONPath.\nUseful when the source data has `n` items you would like to map to\nan operation.\nThe operation will receive a slice of the data based of each item\nof the JSONPath provided.\n\nIt also ensures the results of an operation make their way back into\nthe state's references.",
         "tags": [
           {
             "title": "public",
@@ -1487,18 +1448,7 @@
           },
           {
             "title": "example",
-            "description": "each(\n  $.data,\n  // Inside the callback operation, `$.data` is scoped to the item under iteration\n  insert(\"patient\", {\n    patient_name: $.data.properties.case_name,\n    patient_id: $.data.case_id,\n  })\n);",
-            "caption": "Using lazy state ($) to iterate over items in state.data and pass each into an \"insert\" operation"
-          },
-          {
-            "title": "example",
-            "description": "each(\n  $.data,\n  insert(\"patient\", (state) => ({\n    patient_id: state.data.case_id,\n    ...state.data\n  }))\n);",
-            "caption": "Iterate over items in state.data and pass each one into an \"insert\" operation"
-          },
-          {
-            "title": "example",
-            "description": "each(\n  \"$.data[*]\",\n  insert(\"patient\", (state) => ({\n    patient_name: state.data.properties.case_name,\n    patient_id: state.data.case_id,\n  }))\n);",
-            "caption": "Using JSON path to iterate over items in state.data and pass each one into an \"insert\" operation"
+            "description": "each(\"$.[*]\",\n  create(\"SObject\",\n    field(\"FirstName\", sourceValue(\"$.firstName\"))\n  )\n)"
           },
           {
             "title": "param",

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -5,7 +5,7 @@ import {
 } from '@openfn/language-common';
 
 import { expandReferences } from '@openfn/language-common/util';
-import * as util from './Utils';
+import * as util from './util';
 
 import flatten from 'lodash/flatten';
 

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -79,16 +79,6 @@ import flatten from 'lodash/flatten';
  * @property {boolean} [autoFetch=false] - When true, automatically fetches next batch of records if available.
  * */
 
-let anyAscii = undefined;
-
-// use a dynamic import because any-ascii is pure ESM and doesn't play well with CJS
-// This promise MUST be resolved by execute before a connection is created
-const loadAnyAscii = state =>
-  import('any-ascii').then(m => {
-    anyAscii = m.default;
-    return state;
-  });
-
 /**
  * Executes an operation.
  * @function
@@ -105,7 +95,7 @@ export function execute(...operations) {
 
   return state => {
     return commonExecute(
-      loadAnyAscii,
+      util.loadAnyAscii,
       util.createConnection,
       ...flatten(operations),
       util.removeConnection
@@ -726,22 +716,6 @@ export function update(sObjectName, records) {
         return composeNextState(state, result);
       });
   };
-}
-
-/**
- * Transliterates unicode characters to their best ASCII representation
- * @public
- * @example <caption>Transliterate `άνθρωποι` to `anthropoi`</caption>
- * fn((state) => {
- *   const s = toUTF8("άνθρωποι");
- *   console.log(s); // anthropoi
- *   return state;
- * });
- * @param {string} input - A string with unicode characters
- * @returns {string} - ASCII representation of input string
- */
-export function toUTF8(input) {
-  return anyAscii(input);
 }
 
 /**

--- a/packages/salesforce/src/Utils.js
+++ b/packages/salesforce/src/Utils.js
@@ -51,6 +51,32 @@ function createAccessTokenConnection(state) {
   };
 }
 
+let anyAscii = undefined;
+
+// use a dynamic import because any-ascii is pure ESM and doesn't play well with CJS
+// This promise MUST be resolved by execute before a connection is created
+export const loadAnyAscii = state =>
+  import('any-ascii').then(m => {
+    anyAscii = m.default;
+    return state;
+  });
+
+/**
+ * Transliterates unicode characters to their best ASCII representation
+ * @public
+ * @example <caption>Transliterate `άνθρωποι` to `anthropoi`</caption>
+ * fn((state) => {
+ *   const s = toUTF8("άνθρωποι");
+ *   console.log(s); // anthropoi
+ *   return state;
+ * });
+ * @param {string} input - A string with unicode characters
+ * @returns {string} - ASCII representation of input string
+ */
+export function toUTF8(input) {
+  return anyAscii(input);
+}
+
 /**
  * Creates a connection to Salesforce using Basic Auth or OAuth.
  * @function createConnection

--- a/packages/salesforce/src/index.js
+++ b/packages/salesforce/src/index.js
@@ -3,5 +3,6 @@ export { metadata };
 
 import * as Adaptor from './Adaptor';
 export default Adaptor;
-
 export * from './Adaptor';
+
+export * as util from './util';

--- a/packages/salesforce/src/util.js
+++ b/packages/salesforce/src/util.js
@@ -66,7 +66,7 @@ export const loadAnyAscii = state =>
  * @public
  * @example <caption>Transliterate `άνθρωποι` to `anthropoi`</caption>
  * fn((state) => {
- *   const s = toUTF8("άνθρωποι");
+ *   const s = util.toUTF8("άνθρωποι");
  *   console.log(s); // anthropoi
  *   return state;
  * });

--- a/packages/salesforce/test/Adaptor.test.js
+++ b/packages/salesforce/test/Adaptor.test.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import sinon from 'sinon';
-import { create, upsert, toUTF8, execute, query, get } from '../src/Adaptor';
+import { create, upsert, query, get } from '../src/Adaptor';
 
 const { expect } = chai;
 
@@ -88,36 +88,6 @@ describe('Adaptor', () => {
         })
         .then(done)
         .catch(done);
-    });
-  });
-
-  describe('toUTF8', () => {
-    it('Transliterate unicode to ASCII representation', async () => {
-      const state = {
-        connection: {},
-      };
-
-      // Run toUTF8 inside an execute block to ensure that any-ascii gets loaded correctly
-      const convert = str => execute(state => toUTF8(str))(state);
-
-      let result = await convert('άνθρωποι');
-      expect(result).to.eql('anthropoi');
-
-      // Misc
-      result = await convert('☆ ♯ ♰ ⚄ ⛌');
-      expect(result).to.equal('* # + 5 X');
-
-      // Emojis
-      result = await convert('👑 🌴');
-      expect(result).to.eql(':crown: :palm_tree:');
-
-      // Letterlike
-      result = await convert('№ ℳ ⅋ ⅍');
-      expect(result).to.eql('No M & A/S');
-
-      // Ordinal coordinator
-      result = await convert('Nhamaonha 6ª Classe 2023-10-09');
-      expect(result).to.eql('Nhamaonha 6a Classe 2023-10-09');
     });
   });
 

--- a/packages/salesforce/test/Utils.test.js
+++ b/packages/salesforce/test/Utils.test.js
@@ -1,0 +1,35 @@
+import chai from 'chai';
+import { execute } from '../src/Adaptor';
+import { toUTF8 } from '../src/Utils';
+
+const { expect } = chai;
+
+describe('toUTF8', () => {
+  it('Transliterate unicode to ASCII representation', async () => {
+    const state = {
+      connection: {},
+    };
+
+    // Run toUTF8 inside an execute block to ensure that any-ascii gets loaded correctly
+    const convert = str => execute(state => toUTF8(str))(state);
+
+    let result = await convert('άνθρωποι');
+    expect(result).to.eql('anthropoi');
+
+    // Misc
+    result = await convert('☆ ♯ ♰ ⚄ ⛌');
+    expect(result).to.equal('* # + 5 X');
+
+    // Emojis
+    result = await convert('👑 🌴');
+    expect(result).to.eql(':crown: :palm_tree:');
+
+    // Letterlike
+    result = await convert('№ ℳ ⅋ ⅍');
+    expect(result).to.eql('No M & A/S');
+
+    // Ordinal coordinator
+    result = await convert('Nhamaonha 6ª Classe 2023-10-09');
+    expect(result).to.eql('Nhamaonha 6a Classe 2023-10-09');
+  });
+});

--- a/packages/salesforce/test/Utils.test.js
+++ b/packages/salesforce/test/Utils.test.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import { execute } from '../src/Adaptor';
-import { toUTF8 } from '../src/Utils';
+import { toUTF8 } from '../src/util';
 
 const { expect } = chai;
 


### PR DESCRIPTION
## Summary

This PR moves to toUTF8 function out into the utils object.

toUTF8 is not an operation and cannot be called at the top level. I am trying to establish a convention where non-operations (regular functions) exist on the util. object. This should make usage clearer across the adaptors.

Fixes #877


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
