### PR TITLE
Support PAT for dhis2

### DIFF
--- a/packages/dhis2/configuration-schema.json
+++ b/packages/dhis2/configuration-schema.json
@@ -46,6 +46,15 @@
       "examples": [
         "v2"
       ]
+    },
+    "personalAccessToken": {
+      "title": "Personal Access Token",
+      "type": "string",
+      "description": "Personal access token",
+      "minLength": 1,
+      "examples": [
+        "d2pat_vreYExmi0yh92Soy8CCF2zHG0wRjID494035128247"
+      ]
     }
   },
   "type": "object",

--- a/packages/dhis2/src/Client.js
+++ b/packages/dhis2/src/Client.js
@@ -7,11 +7,11 @@ import Qs from 'qs';
  * before spreading the rest of the axios configuration, and (3) executes an
  * axios request.
  * @function
- * @param {object} configuration - configuration must have a username and password
+ * @param {object} configuration - configuration can either be a username and password OR a personal access token
  * @param {object} axiosRequest - the axiosRequest contains valid axios params: https://axios-http.com/docs/req_config
  * @returns {Promise} a promise that will resolve to either a response object or an error object.
  */
-export function request({ username, password }, axiosRequest) {
+export function request({ username, password, personalAccessToken }, axiosRequest) {
   const { method, url, params } = axiosRequest;
 
   console.log(`Sending ${method} request to ${url}`);
@@ -22,13 +22,26 @@ export function request({ username, password }, axiosRequest) {
     method.toLowerCase()
   );
 
-  return axios({
-    headers: { 'Content-Type': 'application/json' },
-    responseType: 'json',
-    maxRedirects: safeRedirect ? 5 : 0,
-    auth: { username, password },
-    paramsSerializer: params => Qs.stringify(params, { arrayFormat: 'repeat' }),
-    // Note that providing headers or auth in the request object will overwrite.
-    ...axiosRequest,
-  });
+  // Declare auth property and headers dynamically
+  const headers = { 'Content-Type': 'application/json'}
+  let auth;
+
+  if(personalAccessToken){
+    headers.Authorization = `ApiToken ${personalAccessToken}`
+  } else {
+    auth = { username, password }
+  }
+
+
+  return axios(
+    {
+      headers,
+      responseType: 'json',
+      auth,
+      maxRedirects: safeRedirect ? 5 : 0,
+      paramsSerializer: params => Qs.stringify(params, { arrayFormat: 'repeat' }),
+      // Note that providing headers or auth in the request object will overwrite.
+      ...axiosRequest,
+    }
+  );
 }


### PR DESCRIPTION
## Summary

Add a high-level, single-sentence summary of what this PR changes.

Fixes #697

## Details

1. Added a personalAccessTokenField to the configuration schema for the dhis2 adaptor
2. Added a conditional, that uses the PAT to authenticate if it id provided but defaults back to username/password if it it not

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?