### PR TITLE
Common add assert() function

### DIFF
--- a/.changeset/ninety-paws-own.md
+++ b/.changeset/ninety-paws-own.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-common': minor
+---
+
+Added an 'assert' function that throws an error when an expression or function
+resolves to false

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1545,6 +1545,59 @@
       "valid": false
     },
     {
+      "name": "assert",
+      "params": [
+        "expression",
+        "errorMessage"
+      ],
+      "docs": {
+        "description": "An assert function that throws an error when an expression or function resolves to false.\nOtherwise, it returns true.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "example",
+            "description": "assert('a' === 'b', '\"a\" is not equal to \"b\"')"
+          },
+          {
+            "title": "param",
+            "description": "The expression or function to be evaluated.",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "expression"
+          },
+          {
+            "title": "param",
+            "description": "The error message thrown in case of a failed state.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "errorMessage"
+          },
+          {
+            "title": "returns",
+            "description": "Always returns true if the assertion passes.",
+            "type": {
+              "type": "NameExpression",
+              "name": "boolean"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "map",
       "params": [
         "path",

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -903,3 +903,27 @@ export function cursor(value, options = {}) {
     return state;
   };
 }
+
+/**
+ * An assert function that throws an error when an expression or function resolves to false.
+ * Otherwise, it returns true.
+ * @public
+ * @function
+ * @example
+ * assert("a" === "b")
+ * @param expression
+ * @param errorMessage
+ * @returns {(function(*): (boolean|undefined))|*}
+ */
+export function assert (expression, errorMessage) {
+  return state => {
+    const resolvedValue = expandReferences(expression)(state);
+
+    if(resolvedValue){
+      return true;
+    }
+    else{
+      throw new Error(errorMessage);
+    }
+  }
+}

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -917,7 +917,7 @@ export function cursor(value, options = {}) {
  */
 export function assert (expression, errorMessage) {
   return state => {
-    const resolvedValue = expandReferences(expression)(state);
+    const [resolvedValue] = newExpandReferences(state,expression);
 
     if(!resolvedValue){
       throw new Error(errorMessage);

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -910,10 +910,10 @@ export function cursor(value, options = {}) {
  * @public
  * @function
  * @example
- * assert("a" === "b")
- * @param expression
- * @param errorMessage
- * @returns {(function(*): (boolean|undefined))|*}
+ * assert('a' === 'b', '"a" is not equal to "b"')
+ * @param {any} expression  - The expression or function to be evaluated.
+ * @param {string} errorMessage - The error message thrown in case of a failed state.
+ * @returns {boolean} Always returns true if the assertion passes.
  */
 export function assert (expression, errorMessage) {
   return state => {

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -920,7 +920,7 @@ export function assert (expression, errorMessage) {
     const [resolvedValue] = newExpandReferences(state,expression);
 
     if(!resolvedValue){
-      throw new Error(errorMessage);
+      throw new Error(errorMessage || `assertion statement failed with ${resolvedValue}`);
     }
 
     return state;

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -919,11 +919,10 @@ export function assert (expression, errorMessage) {
   return state => {
     const resolvedValue = expandReferences(expression)(state);
 
-    if(resolvedValue){
-      return true;
-    }
-    else{
+    if(!resolvedValue){
       throw new Error(errorMessage);
     }
+
+    return true;
   }
 }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -913,7 +913,7 @@ export function cursor(value, options = {}) {
  * assert('a' === 'b', '"a" is not equal to "b"')
  * @param {any} expression  - The expression or function to be evaluated.
  * @param {string} errorMessage - The error message thrown in case of a failed state.
- * @returns {boolean} Always returns true if the assertion passes.
+ * @returns {operation}
  */
 export function assert (expression, errorMessage) {
   return state => {
@@ -923,6 +923,6 @@ export function assert (expression, errorMessage) {
       throw new Error(errorMessage);
     }
 
-    return true;
+    return state;
   }
 }

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -1092,4 +1092,15 @@ describe("assert", () => {
     assert.equal(result, state);
   });
 
+  it("falls back to the generic message if no 'errorMessage' argument is passed", () => {
+   let error;
+
+   try {
+     assertCommon(("a" === "b"))({});
+    } catch (e) {
+      error = e;
+    }
+
+    assert.equal(error.message, `assertion statement failed with false`);
+  });
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -30,6 +30,7 @@ import {
   splitKeys,
   toArray,
   validate,
+  assert as assertCommon
 } from '../src/Adaptor';
 import { startOfToday } from 'date-fns';
 
@@ -1045,4 +1046,48 @@ describe('group', () => {
 
     expect(result.data).eql({ a: [{ x: 'a', y: { z: 'a' } }] });
   });
+});
+
+describe("assert", () => {
+  it("throws an error when a function returns false", () => {
+    let error;
+
+    const testFunction = function(){
+      return "a" === "b"
+    }
+
+    const errorMessage = "a is not equal to b";
+
+    try {
+     assertCommon(testFunction, errorMessage)({});
+    } catch(e) {
+      error = e
+    }
+
+    assert.equal(error.message, errorMessage)
+  })
+
+  it("throws an error when an expression evaluates to false", () => {
+    let error;
+    const errorMessage = "a is not equal to b";
+
+    try {
+     assertCommon(("a"==="b"), errorMessage)({});
+    } catch(e) {
+      error = e
+    }
+
+    assert.equal(error.message, errorMessage)
+  });
+
+  it("returns true when an expression evaluates to true", () => {
+    const result = assertCommon(("a"==="a"), "a is not equal to a")({});
+    assert.equal(result, true);
+  });
+
+  it("returns true when an argument is neither an expression nor a function", () => {
+    const result = assertCommon(("a"), "a is not equal to b")({});
+    assert.equal(result, true);
+  });
+
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -1081,13 +1081,15 @@ describe("assert", () => {
   });
 
   it("returns true when an expression evaluates to true", () => {
-    const result = assertCommon(("a"==="a"), "a is not equal to a")({});
-    assert.equal(result, true);
+    const state = { name: "Jane" }
+    const result = assertCommon(("a"==="a"), "a is not equal to a")(state);
+    assert.equal(result, state);
   });
 
   it("returns true when an argument is neither an expression nor a function", () => {
-    const result = assertCommon(("a"), "a is not equal to b")({});
-    assert.equal(result, true);
+    const state = { name: "Jane" }
+    const result = assertCommon(("a"), "a is not equal to b")(state);
+    assert.equal(result, state);
   });
 
 });


### PR DESCRIPTION
## Summary

Added an 'assert' function to  the common adaptor

Fixes #876

## Details

Created an assert function that aborts  execution when it fails. 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?