### PR TITLE
Common: expandReferences should ignore regex objects

### DIFF
--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -372,7 +372,7 @@ export function expandReferences(value, skipFilter) {
       return value.map(v => expandReferences(v)(state));
     }
 
-    if (typeof value == 'object' && !!value) {
+    if (typeof value == 'object' && !!value && !(value instanceof RegExp)) {
       return Object.keys(value).reduce((acc, key) => {
         return { ...acc, [key]: expandReferences(value[key])(state) };
       }, {});

--- a/packages/common/src/util/references.js
+++ b/packages/common/src/util/references.js
@@ -27,7 +27,7 @@ function expandReference(state, value) {
     return value.map(v => expandReference(state, v));
   }
 
-  if (typeof value == 'object' && !!value && !isStream(value)) {
+  if (typeof value == 'object' && !!value && !isStream(value) && !(value instanceof RegExp)) {
     return Object.keys(value).reduce((acc, key) => {
       return { ...acc, [key]: expandReference(state, value[key]) };
     }, {});

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -190,6 +190,12 @@ describe('expandReferences', () => {
 
     expect(result).to.eql([2, { c: 3 }, 3]);
   });
+
+  it('resolves regex objects', () => {
+    let result = expandReferences(/foobar/i)({});
+
+    expect(result).to.eql(/foobar/i);
+  });
 });
 
 describe('field', () => {

--- a/packages/common/test/util/references.test.js
+++ b/packages/common/test/util/references.test.js
@@ -63,6 +63,14 @@ describe('util expandReferences', () => {
     expect(resolvedName.first).to.equal('fox');
     expect(resolvedName.second).to.equal('mulder');
   });
+
+  it('should expand regular expressions', () => {
+    const regex = /xy+z/;
+    const state = {};
+
+    const [result] = expandReferences(state, regex)
+    expect(result).to.equal(regex)
+  });
 });
 
 describe('util normalizeOauthConfig', () => {


### PR DESCRIPTION
## Summary

The expandReferences function should ignore regex objects instead of pasring them as standard javascript objects.

Fixes #874

## Details

I added conditionals to exclude any regular expressions from blocks meant for standard javascript objects

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?