### PR TITLE
Common util encode should take an object and stringify

### DIFF
--- a/.changeset/light-spiders-move.md
+++ b/.changeset/light-spiders-move.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-common': minor
+---
+
+Common util functions `encode` and `decode` can now take a JavaScript object and
+stringify

--- a/packages/common/src/util/base64.js
+++ b/packages/common/src/util/base64.js
@@ -1,13 +1,17 @@
 /**
- * Encodes a given string into Base64 format.
+ * Encodes a given string or Javascript object into Base64 format.
  * @function
  * @public
  * @namespace util
- * @param {string} data - The string to be encoded.
+ * @param {string | object} data - The string or object to be encoded.
  * @returns {string} - The Base64 encoded string.
  * @example <caption>Encode a string</caption>
- * const encoded = encode('Hello World');
+ * const encodedString = encode('Hello World');
  * console.log(encoded); // Output: SGVsbG8gV29ybGQ=
+ * @example <caption>Encode an object</caption>
+ * const encodedObject = encode({name: 'Jane Doe'})
+ * console.log(encodedObject); //output eyJuYW1lIjoiSmFuZSBEb2UifQ==
+ *
  */
 export const encode = data => {
   let str = data;

--- a/packages/common/src/util/base64.js
+++ b/packages/common/src/util/base64.js
@@ -30,5 +30,13 @@ export const encode = data => {
  * const decoded = decode('SGVsbG8gV29ybGQ=');
  * console.log(decoded); // Output: Hello World
  */
-export const decode = base64Data =>
-  Buffer.from(base64Data, 'base64').toString('utf-8');
+export const decode = base64Data =>{
+  let decodedObject = Buffer.from(base64Data, 'base64').toString('utf-8');
+
+  if(['[', '{'].includes(decodedObject[0])){
+    decodedObject = JSON.parse(decodedObject);
+  }
+
+  return decodedObject;
+}
+

--- a/packages/common/src/util/base64.js
+++ b/packages/common/src/util/base64.js
@@ -9,9 +9,17 @@
  * const encoded = encode('Hello World');
  * console.log(encoded); // Output: SGVsbG8gV29ybGQ=
  */
-export const encode = data => Buffer.from(data, 'utf-8').toString('base64');
+export const encode = data => {
+  let str = data;
 
-/**
+  if(typeof str === "object" && str !== null && Object.keys(str).length > 0){
+    str = JSON.stringify(str);
+  }
+
+  return Buffer.from(str, 'utf-8').toString('base64');
+}
+
+/**4
  * Decodes a Base64 encoded string back to its original format.
  * @function
  * @public

--- a/packages/common/src/util/base64.js
+++ b/packages/common/src/util/base64.js
@@ -33,10 +33,12 @@ export const encode = data => {
  * @public
  * @namespace util
  * @param {string} base64Data - The Base64 encoded string.
- * @returns {string} - The decoded string.
+ * @returns {string | object} - The decoded string or JavaScript Object.
  * @example <caption>Decode a Base64 string</caption>
  * const decoded = decode('SGVsbG8gV29ybGQ=');
- * console.log(decoded); // Output: Hello World
+ * @example <caption>Decode a Base64 JSON object to a standard JavaScript object</caption>
+ * const decoded = decode('eyJuYW1lIjoiSmFuZSBEb2UifQ==');
+ * console.log(decoded); // Output: {name: 'Jane Doe'}
  */
 export const decode = base64Data =>{
   let decodedObject = Buffer.from(base64Data, 'base64').toString('utf-8');

--- a/packages/common/src/util/base64.js
+++ b/packages/common/src/util/base64.js
@@ -48,16 +48,16 @@ export const encode = (data, options = {parseJson: true}) => {
  * const decodedString = decode('Hello World', {parseJson: false})
  */
 export const decode = (base64Data, options = {parseJson: true}) =>{
-  let decodedObject = Buffer.from(base64Data, 'base64').toString('utf-8');
+  let decodedValue = Buffer.from(base64Data, 'base64').toString('utf-8');
 
-  if((_.startsWith(decodedObject, '[') || _.startsWith(decodedObject, '{')) && options.parseJson) {
+  if((_.startsWith(decodedValue, '[') || _.startsWith(decodedValue, '{')) && options.parseJson) {
     try {
-      decodedObject = JSON.parse(decodedObject);
+      decodedValue = JSON.parse(decodedValue);
     } catch (e) {
       console.log(e.message);
     }
   }
 
-  return decodedObject;
+  return decodedValue;
 }
 

--- a/packages/common/src/util/base64.js
+++ b/packages/common/src/util/base64.js
@@ -17,7 +17,11 @@ export const encode = data => {
   let str = data;
 
   if(typeof data !== "string"){
-    str = JSON.stringify(str);
+    try {
+      str = JSON.stringify(str);
+    } catch (e){
+      console.log(e.message);
+    }
   }
 
   return Buffer.from(str, 'utf-8').toString('base64');

--- a/packages/common/src/util/base64.js
+++ b/packages/common/src/util/base64.js
@@ -12,7 +12,7 @@
 export const encode = data => {
   let str = data;
 
-  if(typeof str === "object" && str !== null && Object.keys(str).length > 0){
+  if(typeof data !== "string"){
     str = JSON.stringify(str);
   }
 

--- a/packages/common/src/util/base64.js
+++ b/packages/common/src/util/base64.js
@@ -1,9 +1,12 @@
+import _ from 'lodash';
+
 /**
  * Encodes a given string or Javascript object into Base64 format.
  * @function
  * @public
  * @namespace util
  * @param {string | object} data - The string or object to be encoded.
+ * @param {object} options - Options.
  * @returns {string} - The Base64 encoded string.
  * @example <caption>Encode a string</caption>
  * const encodedString = encode('Hello World');
@@ -11,12 +14,13 @@
  * @example <caption>Encode an object</caption>
  * const encodedObject = encode({name: 'Jane Doe'})
  * console.log(encodedObject); //output eyJuYW1lIjoiSmFuZSBEb2UifQ==
- *
+ * @example <caption>To skip the JSON stringification step</caption>
+ * const encodedObject = encode('Hello World', {parseJson: false})
  */
-export const encode = data => {
+export const encode = (data, options = {parseJson: true}) => {
   let str = data;
 
-  if(typeof data !== "string"){
+  if(typeof data !== "string" && options.parseJson){
     try {
       str = JSON.stringify(str);
     } catch (e){
@@ -33,18 +37,25 @@ export const encode = data => {
  * @public
  * @namespace util
  * @param {string} base64Data - The Base64 encoded string.
+ * @param {object} options - Options.
  * @returns {string | object} - The decoded string or JavaScript Object.
  * @example <caption>Decode a Base64 string</caption>
  * const decoded = decode('SGVsbG8gV29ybGQ=');
  * @example <caption>Decode a Base64 JSON object to a standard JavaScript object</caption>
  * const decoded = decode('eyJuYW1lIjoiSmFuZSBEb2UifQ==');
  * console.log(decoded); // Output: {name: 'Jane Doe'}
+ * @example <caption>To skip the JSON stringification step</caption>
+ * const decodedString = decode('Hello World', {parseJson: false})
  */
-export const decode = base64Data =>{
+export const decode = (base64Data, options = {parseJson: true}) =>{
   let decodedObject = Buffer.from(base64Data, 'base64').toString('utf-8');
 
-  if(['[', '{'].includes(decodedObject[0])){
-    decodedObject = JSON.parse(decodedObject);
+  if((_.startsWith(decodedObject, '[') || _.startsWith(decodedObject, '{')) && options.parseJson) {
+    try {
+      decodedObject = JSON.parse(decodedObject);
+    } catch (e) {
+      console.log(e.message);
+    }
   }
 
   return decodedObject;

--- a/packages/common/test/util/index.test.js
+++ b/packages/common/test/util/index.test.js
@@ -61,4 +61,8 @@ describe('decode', () => {
   it('should decode an empty Base64 string', () => {
     expect(decode('')).to.eql('');
   });
+  it('should decode a JSON object into a standard javascript object', () => {
+    const obj = {name: "Jane Doe"}
+    expect(decode('eyJuYW1lIjoiSmFuZSBEb2UifQ==')).to.eql(obj);
+  });
 });

--- a/packages/common/test/util/index.test.js
+++ b/packages/common/test/util/index.test.js
@@ -29,15 +29,11 @@ describe('encode', () => {
   it('should encode emoji to Base64', () => {
     expect(encode('😀')).to.eql('8J+YgA==');
   });
-  it('should throw an error if the string is not a string', () => {
-    expect(() => encode(123)).to.throw(errorMsg);
-    expect(() => encode(true)).to.throw(errorMsg);
-    expect(() => encode(null)).to.throw(errorMsg);
+  it('should throw an error if a function is passed', () => {
     expect(() => encode(() => {})).to.throw(errorMsg);
   });
   it('should encode a javascript object', () => {
     const obj = {"name": "Jane Doe"}
-
     expect(encode(obj)).to.eql("eyJuYW1lIjoiSmFuZSBEb2UifQ==");
   });
 });

--- a/packages/common/test/util/index.test.js
+++ b/packages/common/test/util/index.test.js
@@ -36,6 +36,11 @@ describe('encode', () => {
     expect(() => encode({})).to.throw(errorMsg);
     expect(() => encode(() => {})).to.throw(errorMsg);
   });
+  it('should encode a javascript object', () => {
+    const obj = {"name": "Jane Doe"}
+
+    expect(encode(obj)).to.eql("eyJuYW1lIjoiSmFuZSBEb2UifQ==");
+  });
 });
 
 describe('decode', () => {

--- a/packages/common/test/util/index.test.js
+++ b/packages/common/test/util/index.test.js
@@ -33,7 +33,6 @@ describe('encode', () => {
     expect(() => encode(123)).to.throw(errorMsg);
     expect(() => encode(true)).to.throw(errorMsg);
     expect(() => encode(null)).to.throw(errorMsg);
-    expect(() => encode({})).to.throw(errorMsg);
     expect(() => encode(() => {})).to.throw(errorMsg);
   });
   it('should encode a javascript object', () => {

--- a/packages/common/test/util/index.test.js
+++ b/packages/common/test/util/index.test.js
@@ -22,6 +22,9 @@ describe('encode', () => {
   it('should encode a string to Base64', () => {
     expect(encode('Hello World')).to.eql('SGVsbG8gV29ybGQ=');
   });
+  it('should encode a string to Base64 while skipping the JSON stringification step', () => {
+    expect(encode('Hello World', {parseJson: false})).to.eql('SGVsbG8gV29ybGQ=');
+  });
 
   it('should encode an empty string to Base64', () => {
     expect(encode('')).to.eql('');
@@ -51,6 +54,9 @@ describe('decode', () => {
   });
   it('should decode a Base64 string back to its original string', () => {
     expect(decode('SGVsbG8gV29ybGQ=')).to.eql('Hello World');
+  });
+  it('should decode a Base64 string back to its original string without needing to JSON parse', () => {
+    expect(decode('SGVsbG8gV29ybGQ=', {parseJson: false})).to.eql('Hello World');
   });
 
   it('should decode an empty Base64 string', () => {


### PR DESCRIPTION
## Summary

Adds functionality to encode and decode JSON objects in the encode and decode util functions

Fixes #794

## Details

Added a conditional in the `encode` util to check for objects and stringify them first before encoding them.
Added functionality to `decode` that handles JSON objects and parses them to standard JavaScript objects.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?