### PR TITLE
salesforce: bump to 5.0.2

### DIFF
--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-salesforce
 
-## 5.0.0
+## 5.0.2
 
 Major modernization of the Salesforce adaptor, focusing on standardized state
 handling (ie,`state.data` over on `state.references`) and a cleaner API.
@@ -113,6 +113,9 @@ changes to be compatible - see the Migration Guide.
   - Rename `attrs` to `records` in docs
 - Update `@openfn/language-common` to `workspace:*`
 - Add integration tests
+
+Note: due to a conflict in the npm registry this 5.0.0 build has been released
+with version number 5.0.2.
 
 ## 4.8.6
 

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "5.0.0",
+  "version": "5.0.2",
   "description": "OpenFn Salesforce adaptor",
   "homepage": "https://docs.openfn.org",
   "exports": {


### PR DESCRIPTION
## Summary

Due to an earlier error, we're unable to release salesforce 5 as 5.0.0, so we're releasing as 5.0.2 instead. It's a bit weird but it doesn't really matter.

Fixes https://github.com/OpenFn/adaptors/issues/902

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
