### PR TITLE
`salesforce` Add support for `asyncMode` in bulk operation

### DIFF
--- a/.changeset/moody-crabs-fly.md
+++ b/.changeset/moody-crabs-fly.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-salesforce': minor
+---
+
+Add `asyncMode` option in `bulk()` function

--- a/packages/salesforce/ast.json
+++ b/packages/salesforce/ast.json
@@ -85,6 +85,10 @@
             "description": "{SalesforceResultState}"
           },
           {
+            "title": "state",
+            "description": "data.batches - Array of batch Infomation"
+          },
+          {
             "title": "returns",
             "description": null,
             "type": {

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -66,7 +66,7 @@ import flatten from 'lodash/flatten';
  * @property {boolean} [failOnError=false] - Fail the operation on error.
  * @property {integer} [pollTimeout=240000] - Polling timeout in milliseconds.
  * @property {integer} [pollInterval=6000] - Polling interval in milliseconds.
- * @property {boolean} [asynMode=true] - Asynchronous mode.
+ * @property {boolean} [asynMode=false] - Use asyn mode.
  */
 
 /**

--- a/packages/salesforce/test/integration.js
+++ b/packages/salesforce/test/integration.js
@@ -17,12 +17,13 @@ describe('Integration tests', () => {
     before(async () => {
       state.data = [{ name: 'Coco', vera__Active__c: 'No' }];
     });
-    it.only('should return batchInfo if asyncMode: false', async () => {
+    it('should return batchInfo if asyncMode: true', async () => {
       const { data } = await execute(
-        bulk('Account', 'insert', state => state.data, { asyncMode: false })
+        bulk('Account', 'insert', state => state.data, { asyncMode: true })
       )(state);
-      console.log(data);
-      // expect(data.batchInfo).to.be.an('object');
+
+      expect(data.batches.length).to.eql(1);
+      expect(data.success).to.eql(true);
     }).timeout(10000);
     it('should create multiple sobjects', async () => {
       const { data } = await execute(

--- a/packages/salesforce/test/integration.js
+++ b/packages/salesforce/test/integration.js
@@ -17,6 +17,13 @@ describe('Integration tests', () => {
     before(async () => {
       state.data = [{ name: 'Coco', vera__Active__c: 'No' }];
     });
+    it.only('should return batchInfo if asyncMode: false', async () => {
+      const { data } = await execute(
+        bulk('Account', 'insert', state => state.data, { asyncMode: false })
+      )(state);
+      console.log(data);
+      // expect(data.batchInfo).to.be.an('object');
+    }).timeout(10000);
     it('should create multiple sobjects', async () => {
       const { data } = await execute(
         bulk('Account', 'insert', state => state.data)


### PR DESCRIPTION
## Summary

Add `asyncMode` option in bulk operation. If you don't provided this extra `asyncMode` option, we return all record info to `state.data` as we currently do.

Fixes #286 

## Details

- If `asyncMode` is `true` we return `batchInfo`
- Formatted the results to `{ success: true, batches: [], errors: []}` if `asyncMode: true`
- Add docs for `state.data.batches`
- Add integration test when `asyncMode: true`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?