### PR TITLE
commcare: Update request documentation for query params and fix response body error

### DIFF
--- a/.changeset/yellow-lions-double.md
+++ b/.changeset/yellow-lions-double.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-commcare': patch
----
-
-Update commcare request docs to read query parameters instead of options, and fix the empty body response received when specific requests are made.

--- a/.changeset/yellow-lions-double.md
+++ b/.changeset/yellow-lions-double.md
@@ -2,4 +2,4 @@
 '@openfn/language-commcare': patch
 ---
 
-Update commcare request docs to read query parameters instead of options
+Update commcare request docs to read query parameters instead of options, and fix the empty body response received when specific requests are made.

--- a/.changeset/yellow-lions-double.md
+++ b/.changeset/yellow-lions-double.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-commcare': patch
+---
+
+Update commcare request docs to read query parameters instead of options

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-commcare
 
+## 3.2.9
+
+### Patch Changes
+
+- 3b166c9: Update commcare request docs to read query parameters instead of
+  options, and fix the empty body response received when specific requests are
+  made.
+
 ## 3.2.8
 
 ### Patch Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-commcare",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Commcare Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -318,23 +318,25 @@ export function fetchReportData(reportId, params, postUrl) {
  * Make a general HTTP request against the Commcare server. Use this to make any request to Commcare REST API.
  * @example <caption>Get a resource. Equivalent to `<baseUrl>/a/asri/api/v0.5/case`</caption>
  * request("GET", "/a/asri/api/v0.5/case");
+ * @example <caption>Get a resource using query parameters. Equivalent to `<baseUrl>/case?offset=0&limit=20`</caption>
+ * request("GET", "/case", {}, { offset:0, limit: 20 })
  * @function
  * @public
  * @param {string} method - HTTP method to use
  * @param {string} path - Path to resource
  * @param {object} body - Object which will be attached to the body
- * @param {RequestOptions} options - Optional request params
+ * @param {object} params - An object of query parameters to be encoded into the URL
  * @returns {Operation}
  * @state {CommcareHttpState}
  */
-export function request(method, path, body, options = {}) {
+export function request(method, path, body, params = {}) {
   return async state => {
-    const [resolvedMethod, resolvedPath, resolvedBody, resolvedOptions] =
-      expandReferences(state, method, path, body, options);
+    const [resolvedMethod, resolvedPath, resolvedBody, resolvedParams] =
+      expandReferences(state, method, path, body, params);
     const response = await util.request(state.configuration, resolvedPath, {
       method: resolvedMethod,
       data: resolvedBody,
-      params: resolvedOptions,
+      params: resolvedParams,
       contentType: 'application/json',
     });
 

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -24,8 +24,8 @@ export const configureAuth = (auth, headers = {}) => {
 export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
   const nextState = {
-    ...composeNextState(state, body.objects ?? body),
-    response: { ...responseWithoutBody, ...{ meta: body.meta } },
+    ...composeNextState(state, body?.objects ?? body),
+    response: { ...responseWithoutBody, ...{ meta: body?.meta } },
   };
 
   return callback(nextState);


### PR DESCRIPTION
## Summary

Updated the `options` sections in the `request` function to query parameters, and fix the response body when result is undefined.

Fixes #903 

## Details

The `options` section in the docs is misleading as the items are passed to the URL, and therefore changed to `params`. When a request is made and the response is an empty body, an error is thrown. Therefore a fix for handling the undefined aspect in the body was implemented

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?