### PR TITLE
Common add as() function

### DIFF
--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -932,3 +932,35 @@ export function assert(expression, errorMessage) {
     return state;
   };
 }
+
+
+/**
+ * Runs an operation and saves the return value to a pre-defined key in state
+ * @public
+ * @function
+ * @example
+ * as('lookup_table.option_set', get('fixture/?fixture_type=option_set_mapping'));
+ * @param {string} key - The key used to store the return value in the state object
+ * @param {any} op - The operation being executed
+ * @returns {operation}
+ */
+export function as (key, op) {
+  return async state => {
+    const data = state.data; // save incoming state before it is mutated by the operation
+
+    const [resolvedKey] = newExpandReferences(state, key);
+    try {
+      const result = await op(state);
+
+      const [resolvedResult] = newExpandReferences(state, result);
+
+      state[resolvedKey] = resolvedResult;
+    } catch (e) {
+      console.log(`Error executing operation: ${e.message}`);
+    } finally {
+      state.data = data;
+    }
+
+    return state;
+  }
+}


### PR DESCRIPTION
## Summary

Performs and operation and saves the result in a pre-defined key while preserving any values in the `data` key.

Fixes #800

## Details

I save the initial state `data` value in a variable then after I perform the operation I return that value bak in the `data` key in state.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?