### PR TITLE
fix template request, close #924

### DIFF
--- a/tools/generate/template/src/Adaptor.js
+++ b/tools/generate/template/src/Adaptor.js
@@ -80,7 +80,7 @@ export function request(method, path, body, options = {}) {
       resolvedMethod,
       resolvedPath,
       {
-        data: resolvedData,
+        body: resolvedData,
         ...resolvedoptions,
       }
     );


### PR DESCRIPTION
Fixes #924 

## Details

@mtuchi points out that the new `commonRequest` doesn't use `data`, it uses `body`.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?