### PR TITLE
Googlesheets dont run update or append if there is no data

### DIFF
--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -99,6 +99,10 @@ export function appendValues(params, callback = s => s) {
     const [resolvedParams] = expandReferences(state, params);
     const { spreadsheetId, range, values } = resolvedParams;
 
+    if (!values || values.length === 0) {
+      return state;
+    }
+
     return new Promise((resolve, reject) => {
       client.spreadsheets.values.append(
         {
@@ -162,6 +166,10 @@ export function batchUpdateValues(params, callback = s => s) {
       valueInputOption = 'USER_ENTERED',
       values,
     } = resolvedParams;
+
+    if (!values || values.length === 0) {
+      return state;
+    }
 
     const resource = {
       data: [

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -100,6 +100,7 @@ export function appendValues(params, callback = s => s) {
     const { spreadsheetId, range, values } = resolvedParams;
 
     if (!values || values.length === 0) {
+      console.log('Warning: empty values array');
       return state;
     }
 
@@ -168,6 +169,7 @@ export function batchUpdateValues(params, callback = s => s) {
     } = resolvedParams;
 
     if (!values || values.length === 0) {
+      console.log('Warning: empty values array');
       return state;
     }
 

--- a/packages/googlesheets/test/index.js
+++ b/packages/googlesheets/test/index.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { execute } from '../src';
+import { appendValues, batchUpdateValues } from '../src';
 
 describe('execute', () => {
   it('executes each operation in sequence', done => {
@@ -34,5 +35,36 @@ describe('execute', () => {
         data: null,
       });
     });
+  });
+});
+
+
+describe('append', () =>{
+  it('should  return early if the values array is undefined or nullish', async() => {
+    const state = {
+      data: [],
+    }
+
+    const result = await appendValues({
+      spreadsheetId: '123-456-789',
+      range: 'Sheet!A1:E1',
+      values: state.values,
+    })(state);
+    expect(result).to.eql(state);
+  });
+});
+
+describe('batchUpdateValues', () =>{
+  it('should  return early if the values array is undefined or nullish', async() => {
+    const state = {
+      data: [],
+    }
+
+    const result = await batchUpdateValues({
+      spreadsheetId: '123-456-789',
+      range: 'Sheet!A1:E1',
+      values: state.values,
+    })(state);
+    expect(result).to.eql(state);
   });
 });


### PR DESCRIPTION
## Summary

The `batchUpdateValues` and `append` functions return early in the event of an empty or undefined array

Fixes #576

## Details

- Added unit tests to test this functionality
- Added conditionals to check the values param

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?