### PR TITLE
Gmail adaptor - Added reasonable result limits

### DIFF
--- a/.changeset/fifty-mails-melt.md
+++ b/.changeset/fifty-mails-melt.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-gmail': minor
+---
+
+Added options.maxResults field to limit excessive data transfer.

--- a/.changeset/fifty-mails-melt.md
+++ b/.changeset/fifty-mails-melt.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-gmail': minor
----
-
-Added options.maxResults field to limit excessive data transfer.

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-gmail
 
+## 1.1.0
+
+### Minor Changes
+
+- 8203e90: Added options.maxResults field to limit excessive data transfer.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/gmail/README.md
+++ b/packages/gmail/README.md
@@ -10,7 +10,7 @@ A number of options are available to isolated the desired messages and to custom
 
 ## Options
 
-Optional parameters include: `contents`, `query`, `email`, `processedIds`
+Optional parameters include: `contents`, `query`, `email`, `processedIds`, `maxResults`
 
 ### options.contents
 
@@ -116,12 +116,17 @@ options.processedIds = [
 ];
 ```
 
+### options.maxResults
+
+To prevent inadventant massive retrieval of messages, the maximum number of results to return is limited. The default value is 50. If you need more than this limit, you can specify a larger value, up to 1,000, for this parameter.
+
 ## Example jobs
 
 ```js
 const query = 'in:inbox newer_than:2d';
 const contents = ['body'];
-getContentsFromMessages({ query, contents });
+const maxLimit = 200;
+getContentsFromMessages({ query, contents, maxLimit });
 ```
 
 ```js

--- a/packages/gmail/README.md
+++ b/packages/gmail/README.md
@@ -118,7 +118,7 @@ options.processedIds = [
 
 ### options.maxResults
 
-To prevent inadventant massive retrieval of messages, the maximum number of results to return is limited. The default value is 50. If you need more than this limit, you can specify a larger value, up to 1,000, for this parameter.
+To prevent inadventant massive retrieval of messages, you can limit the number of results returned. The default value is 1000.
 
 This works in conjuction with the `options.processedIds` parameter. For example:
 

--- a/packages/gmail/README.md
+++ b/packages/gmail/README.md
@@ -120,13 +120,20 @@ options.processedIds = [
 
 To prevent inadventant massive retrieval of messages, the maximum number of results to return is limited. The default value is 50. If you need more than this limit, you can specify a larger value, up to 1,000, for this parameter.
 
+This works in conjuction with the `options.processedIds` parameter. For example:
+
+- account contains messages [1, 2, 3]
+- `options.processedIds = [1];`
+- `options.maxResults = 1;`
+- this will skip message #1 and resulting dataset will contain a single message #2
+
 ## Example jobs
 
 ```js
 const query = 'in:inbox newer_than:2d';
 const contents = ['body'];
-const maxLimit = 200;
-getContentsFromMessages({ query, contents, maxLimit });
+const maxResults = 200;
+getContentsFromMessages({ query, contents, maxResults });
 ```
 
 ```js

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-gmail",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "OpenFn gmail adaptor",
   "type": "module",
   "exports": {

--- a/packages/gmail/src/Adaptor.js
+++ b/packages/gmail/src/Adaptor.js
@@ -39,7 +39,7 @@ import {
  *   An array of strings or MessageContent objects used to specify which parts of the message to retrieve.
  * @property {Array<string>} [processedIds] - Ignore message ids which have already been processed.
  * @property {string?} [email] - The user account to retrieve messages from. Defaults to the authenticated user.
- * @property {int?} [maxResults] - Maximum number of messages to process per request. Hard limit of 1000. Defaults to 50.
+ * @property {int?} [maxResults] - Maximum number of messages to process per request. Default is 1000.
  */
 
 /**
@@ -74,7 +74,7 @@ export function getContentsFromMessages(options) {
     const defaultOptions = {
       contents: ['from', 'date', 'subject'],
       userId: 'me',
-      maxResults: 50,
+      maxResults: 1000,
     };
 
     const opts = {
@@ -83,12 +83,6 @@ export function getContentsFromMessages(options) {
       processedIds: resolvedOptions.processedIds,
       maxResults: resolvedOptions.maxResults ?? defaultOptions.maxResults,
     };
-
-    if (opts.maxResults > 1000) {
-      throw new Error(
-        'The maximum number of results is 1000. Please reduce the number of results.'
-      );
-    }
 
     const contentIndicators = getContentIndicators(
       defaultOptions.contents,


### PR DESCRIPTION
## Summary

Added options.maxResults field to limit excessive data transfer.

Fixes #928

## Details

With options.query being optional, it's possible to (inadvertently) & unnecessarily process and download 10ks of messages. Now we have a default limit of 50 and a hard limit of 1000. Updated README.md with supporting documentation and an example.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
