### PR TITLE
Public annotation for `RequestOptions` typedef

### DIFF
--- a/.changeset/large-socks-punch.md
+++ b/.changeset/large-socks-punch.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-openmrs': minor
+---
+
+Added `RequestOptions` typedef to docs

--- a/packages/openmrs/src/http.js
+++ b/packages/openmrs/src/http.js
@@ -3,7 +3,8 @@ import * as util from './Utils';
 
 /**
  * Options object
- * @typedef {Object} OpenMRSOptions
+ * @public
+ * @typedef {Object} RequestOptions
  * @property {object} query - An object of query parameters to be encoded into the URL
  * @property {object} headers - An object of all request headers
  * @property {object} body - The request body (as JSON)
@@ -24,7 +25,7 @@ import * as util from './Utils';
  * @public
  * @param {string} method - HTTP method to use
  * @param {string} path - Path to resource
- * @param {OpenMRSOptions}  [options={}] - An object containing query, headers, and body for the request
+ * @param {RequestOptions}  [options={}] - An object containing query, headers, and body for the request
  * @returns {Operation}
  */
 export function request(method, path, options = {}, callback = s => s) {


### PR DESCRIPTION
## Summary

`OpenMRSOptions` typef was missing in docs

Fixes #937 

## Details

- Added a public annotation to the typedef
- Also renamed it from `OpenMRSOptions` to `RequestOptions`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
