### PR TITLE
Fix ghana json

### DIFF
--- a/packages/ghana-bdr/src/mock.js
+++ b/packages/ghana-bdr/src/mock.js
@@ -1,11 +1,10 @@
 import { MockAgent } from 'undici';
 import Ajv from 'ajv';
 
+import reqSchema from './schema/request.json' assert { type: 'json' };
+
 // Generated from sample with https://www.jsongenerator.io/schema
 // But!! I had to replace $schema with $id
-// Note: use import() or ele src build breaks
-const reqSchemaString = import('./schema/request.json');
-const reqSchema = JSON.parse(reqSchemaString);
 const validate = new Ajv().compile(reqSchema);
 
 const birthNotificationResponse = {

--- a/packages/ghana-nia/src/mock.js
+++ b/packages/ghana-nia/src/mock.js
@@ -1,12 +1,10 @@
 import { MockAgent } from 'undici';
 import Ajv from 'ajv';
 
+import reqSchema from './schema/request.json' assert { type: 'json' };
+
 // Generated from sample with https://www.jsongenerator.io/schema
 // But!! I had to replace $schema with $id
-// Note: use import() or ele src build breaks
-const reqSchemaString = import('./schema/request.json');
-const reqSchema = JSON.parse(reqSchemaString);
-
 const validate = new Ajv().compile(reqSchema);
 
 const nationalIdSampleResponse = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2167,6 +2167,12 @@ importers:
       acorn:
         specifier: ^8.11.3
         version: 8.11.3
+      acorn-import-assertions:
+        specifier: ^1.9.0
+        version: 1.9.0(acorn@8.11.3)
+      acorn-import-attributes:
+        specifier: ^1.9.5
+        version: 1.9.5(acorn@8.11.3)
       chokidar:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4362,6 +4368,23 @@ packages:
     engines: {node: '>=6.5'}
     dependencies:
       event-target-shim: 5.0.1
+    dev: false
+
+  /acorn-import-assertions@1.9.0(acorn@8.11.3):
+    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    deprecated: package has been renamed to acorn-import-attributes
+    peerDependencies:
+      acorn: ^8
+    dependencies:
+      acorn: 8.11.3
+    dev: false
+
+  /acorn-import-attributes@1.9.5(acorn@8.11.3):
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+    dependencies:
+      acorn: 8.11.3
     dev: false
 
   /acorn-jsx@5.3.2(acorn@8.8.1):

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -15,6 +15,8 @@
     "@openfn/simple-ast": "0.4.1",
     "@types/node": "18.17.5",
     "acorn": "^8.11.3",
+    "acorn-import-assertions": "^1.9.0",
+    "acorn-import-attributes": "^1.9.5",
     "chokidar": "^3.6.0",
     "esno": "0.16.3",
     "file-set": "^5.1.3",

--- a/tools/build/src/commands/src.ts
+++ b/tools/build/src/commands/src.ts
@@ -4,7 +4,7 @@ import type { Options } from '../pipeline';
 
 const config: TsupOptions = {
   format: ['esm', 'cjs'],
-  target: 'node14',
+  target: 'node18',
   platform: 'node',
   clean: true,
   splitting: false,

--- a/tools/build/src/util/extract-exports.ts
+++ b/tools/build/src/util/extract-exports.ts
@@ -1,7 +1,9 @@
 import * as acorn from 'acorn';
+// TODO: need to replace with import assertions soon
+import { importAssertions } from 'acorn-import-assertions';
 
 export default (source: string) => {
-  const ast = acorn.parse(source, {
+  const ast = acorn.Parser.extend(importAssertions).parse(source, {
     sourceType: 'module',
     ecmaVersion: 'latest',
     locations: false,


### PR DESCRIPTION
Fix to import assertions in ghana adaptors

import() doesn't work, and fs.readFile doesn't work. Crazy.

Bit worried about how this will work in node 22 (import assert is replaced by import with), but I'll have to fix that later