### PR TITLE
dhis2 helper: findingAttributeValuebyId

### DIFF
--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dhis2
 
+## 6.3.0
+
+### Minor Changes
+
+- Added a 'findAttributeValueById' function; GHS points out that this is more
+  durable than the display names used by 'findAttributeValue'
+
 ## 6.2.0
 
 ### Minor Changes

--- a/packages/dhis2/ast.json
+++ b/packages/dhis2/ast.json
@@ -892,6 +892,59 @@
       "valid": true
     },
     {
+      "name": "findAttributeValueById",
+      "params": [
+        "trackedEntity",
+        "attributeUid"
+      ],
+      "docs": {
+        "description": "Gets an attribute value by its uid",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "findAttributeValueById(state.tei, 'y1w2R6leVmh')"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "A tracked entity instance (TEI) object",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "trackedEntity"
+          },
+          {
+            "title": "param",
+            "description": "The uid to search for in the TEI's attributes",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "attributeUid"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "findAttributeValue",
       "params": [
         "trackedEntity",

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dhis2",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "DHIS2 Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -869,6 +869,21 @@ export function destroy(
 }
 
 /**
+ * Gets an attribute value by its uid
+ * @public
+ * @example
+ * findAttributeValueById(state.tei, 'y1w2R6leVmh')
+ * @function
+ * @param {Object} trackedEntity - A tracked entity instance (TEI) object
+ * @param {string} attributeUid - The uid to search for in the TEI's attributes
+ * @returns {string}
+ */
+export function findAttributeValueById(trackedEntity, attributeUid) {
+  return trackedEntity?.attributes?.find(a => a?.attribute == attributeUid)
+    ?.value;
+}
+
+/**
  * Gets an attribute value by its case-insensitive display name
  * @public
  * @example

--- a/packages/dhis2/test/index.test.js
+++ b/packages/dhis2/test/index.test.js
@@ -1,5 +1,13 @@
 import chai from 'chai';
-import { execute, create, update, get, upsert } from '../src/Adaptor';
+import {
+  execute,
+  create,
+  update,
+  get,
+  upsert,
+  findAttributeValue,
+  findAttributeValueById,
+} from '../src/Adaptor';
 import { dataValue } from '@openfn/language-common';
 import {
   buildUrl,
@@ -691,5 +699,49 @@ describe('ensureArray', () => {
     const body = ensureArray(state.data, 'events');
 
     expect(body).to.eql({ events: [{ b: 2 }] });
+  });
+});
+
+describe('findAttributeValueById', () => {
+  it('returns the value of an attribute when provided with a TEI', async () => {
+    const tei = {
+      attributes: [
+        {
+          attribute: 'y1w2R6leVmh',
+          displayName: 'First Name',
+          value: 'Test',
+        },
+        {
+          attribute: 'Rslz2y06aBf',
+          displayName: 'Surname',
+          value: 'McTesterson',
+        },
+      ],
+    };
+
+    const theValue = findAttributeValueById(tei, 'Rslz2y06aBf');
+    expect(theValue).to.eql('McTesterson');
+  });
+});
+
+describe('findAttributeValue', () => {
+  it('returns the value of an attribute by display name when provided with a TEI', async () => {
+    const tei = {
+      attributes: [
+        {
+          attribute: 'y1w2R6leVmh',
+          displayName: 'First Name',
+          value: 'Test',
+        },
+        {
+          attribute: 'Rslz2y06aBf',
+          displayName: 'Surname',
+          value: 'McTesterson',
+        },
+      ],
+    };
+
+    const theValue = findAttributeValue(tei, 'Surname');
+    expect(theValue).to.eql('McTesterson');
   });
 });


### PR DESCRIPTION
## Summary

This introduces a `findAttributeValueById(tei, uid)` function, as GHS points out that this is more durable than finding attribute values by display name (`findAttributeValue(tei, attributeDisplayName)`.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
