### PR TITLE
kobotoolbox: migrate to common2.0

### DIFF
--- a/packages/kobotoolbox/ast.json
+++ b/packages/kobotoolbox/ast.json
@@ -3,7 +3,7 @@
     {
       "name": "getForms",
       "params": [
-        "params",
+        "options",
         "callback"
       ],
       "docs": {
@@ -25,12 +25,16 @@
           },
           {
             "title": "param",
-            "description": "Query, Headers and Authentication parameters",
+            "description": "Optional headers and query for the request",
             "type": {
-              "type": "NameExpression",
-              "name": "object"
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "RequestOptions"
+              }
             },
-            "name": "params"
+            "name": "options",
+            "default": "{}"
           },
           {
             "title": "param",
@@ -437,7 +441,7 @@
         "operation"
       ],
       "docs": {
-        "description": "Scopes an array of data based on a JSONPath.\nUseful when the source data has `n` items you would like to map to\nan operation.\nThe operation will receive a slice of the data based of each item\nof the JSONPath provided.\n\nIt also ensures the results of an operation make their way back into\nthe state's references.",
+        "description": "Iterates over an array of items and invokes an operation upon each one, where the state\nobject is _scoped_ so that state.data is the item under iteration.\nThe rest of the state object is untouched and can be referenced as usual.\nYou can pass an array directly, or use lazy state or a JSONPath string to\nreference a slice of state.",
         "tags": [
           {
             "title": "public",
@@ -451,7 +455,18 @@
           },
           {
             "title": "example",
-            "description": "each(\"$.[*]\",\n  create(\"SObject\",\n    field(\"FirstName\", sourceValue(\"$.firstName\"))\n  )\n)"
+            "description": "each(\n  $.data,\n  // Inside the callback operation, `$.data` is scoped to the item under iteration\n  insert(\"patient\", {\n    patient_name: $.data.properties.case_name,\n    patient_id: $.data.case_id,\n  })\n);",
+            "caption": "Using lazy state ($) to iterate over items in state.data and pass each into an \"insert\" operation"
+          },
+          {
+            "title": "example",
+            "description": "each(\n  $.data,\n  insert(\"patient\", (state) => ({\n    patient_id: state.data.case_id,\n    ...state.data\n  }))\n);",
+            "caption": "Iterate over items in state.data and pass each one into an \"insert\" operation"
+          },
+          {
+            "title": "example",
+            "description": "each(\n  \"$.data[*]\",\n  insert(\"patient\", (state) => ({\n    patient_name: state.data.properties.case_name,\n    patient_id: state.data.case_id,\n  }))\n);",
+            "caption": "Using JSON path to iterate over items in state.data and pass each one into an \"insert\" operation"
           },
           {
             "title": "param",

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -25,7 +25,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.15.2"
+    "@openfn/language-common": "workspace:*"
   },
   "devDependencies": {
     "@openfn/simple-ast": "0.4.1",

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -1,9 +1,15 @@
-import {
-  execute as commonExecute,
-  composeNextState,
-  expandReferences,
-  http, // IMPORTANT: this is the OLD axios-based HTTP
-} from '@openfn/language-common';
+import { execute as commonExecute } from '@openfn/language-common';
+import { expandReferences } from '@openfn/language-common/util';
+
+import * as util from './Utils';
+
+/**
+ * Options object
+ * @typedef {Object} RequestOptions
+ * @property {object} query - An object of query parameters to be encoded into the URL
+ * @property {object} headers - An object of all request headers
+ * @property {string} [parseAs='json'] - The response format to parse (e.g., 'json', 'text', or 'stream')
+ */
 
 /**
  * Execute a sequence of operations.
@@ -40,33 +46,19 @@ export function execute(...operations) {
  *    return state;
  * });
  * @function
- * @param {object} params - Query, Headers and Authentication parameters
+ * @param {RequestOptions} [options={}] - Optional headers and query for the request
  * @param {function} callback - (Optional) Callback function to execute after fetching form list
  * @returns {Operation}
  */
-export function getForms(params, callback) {
-  return state => {
-    const resolvedParams = expandReferences(params)(state);
+export function getForms(options = {}, callback) {
+  return async state => {
+    const [resolvedOptions] = expandReferences(state, options);
 
-    const { baseURL, apiVersion, username, password } = state.configuration;
+    const url = `/assets/?format=json`;
 
-    const url = `${baseURL}/api/${apiVersion}/assets/?format=json`;
-    const auth = { username, password };
-
-    const config = {
-      url,
-      params: resolvedParams,
-      auth,
-    };
-
-    return http
-      .get(config)(state)
-      .then(response => {
-        console.log('✓', response.data.count, 'forms fetched.');
-        const nextState = composeNextState(state, response.data);
-        if (callback) return callback(nextState);
-        return nextState;
-      });
+    const response = await util.request(state, 'GET', url, resolvedOptions);
+    console.log('✓', response.data.count, 'forms fetched.');
+    return util.prepareNextState(state, response, callback);
   };
 }
 
@@ -84,30 +76,16 @@ export function getForms(params, callback) {
  * @returns {Operation}
  */
 export function getSubmissions(params, callback) {
-  return state => {
-    const resolvedParams = expandReferences(params)(state);
+  return async state => {
+    const [resolvedParams] = expandReferences(state, params);
 
-    const { baseURL, apiVersion, username, password } = state.configuration;
     const { formId } = resolvedParams;
 
-    const url = `${baseURL}/api/${apiVersion}/assets/${formId}/data/?format=json`;
-    const auth = { username, password };
+    const url = `/assets/${formId}/data/?format=json`;
 
-    const config = {
-      url,
-      params: resolvedParams.query,
-      auth,
-    };
-
-    return http
-      .get(config)(state)
-      .then(response => {
-        console.log('✓', response.data.count, 'submissions fetched.');
-
-        const nextState = composeNextState(state, response.data);
-        if (callback) return callback(nextState);
-        return nextState;
-      });
+    const response = await util.request(state, 'GET', url, resolvedParams);
+    console.log('✓', response.data.count, 'forms fetched.');
+    return util.prepareNextState(state, response, callback);
   };
 }
 
@@ -125,30 +103,16 @@ export function getSubmissions(params, callback) {
  * @returns {Operation}
  */
 export function getDeploymentInfo(params, callback) {
-  return state => {
-    const resolvedParams = expandReferences(params)(state);
+  return async state => {
+    const [resolvedParams] = expandReferences(state, params);
 
-    const { baseURL, apiVersion, username, password } = state.configuration;
     const { formId } = resolvedParams;
 
-    const url = `${baseURL}/api/${apiVersion}/assets/${formId}/deployment/?format=json`;
-    const auth = { username, password };
+    const url = `/assets/${formId}/deployment/?format=json`;
 
-    const config = {
-      url,
-      params: resolvedParams.query,
-      auth,
-    };
-
-    return http
-      .get(config)(state)
-      .then(response => {
-        console.log('✓', 'deployment information fetched.');
-
-        const nextState = composeNextState(state, response.data);
-        if (callback) return callback(nextState);
-        return nextState;
-      });
+    const response = await util.request(state, 'GET', url, resolvedParams);
+    console.log('✓', 'deployment information fetched.');
+    return util.prepareNextState(state, response, callback);
   };
 }
 
@@ -162,7 +126,7 @@ export {
   fields,
   fn,
   fnIf,
-  http, // IMPORTANT: this is the OLD axios-based HTTP. The public documentation for this will be wrong.
+  http, 
   group,
   lastReferenceValue,
   merge,

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -57,7 +57,7 @@ export function getForms(options = {}, callback) {
     const url = `/assets/?format=json`;
 
     const response = await util.request(state, 'GET', url, resolvedOptions);
-    console.log('✓', response.data.count, 'forms fetched.');
+    console.log('✓', response.body.count, 'forms fetched.');
     return util.prepareNextState(state, response, callback);
   };
 }
@@ -84,7 +84,7 @@ export function getSubmissions(params, callback) {
     const url = `/assets/${formId}/data/?format=json`;
 
     const response = await util.request(state, 'GET', url, resolvedParams);
-    console.log('✓', response.data.count, 'forms fetched.');
+    console.log('✓', response.body.count, 'forms fetched.');
     return util.prepareNextState(state, response, callback);
   };
 }

--- a/packages/kobotoolbox/src/Utils.js
+++ b/packages/kobotoolbox/src/Utils.js
@@ -30,7 +30,6 @@ export async function request(state, method, path, opts) {
     },
     query,
     parseAs,
-    maxRedirections: 1,
     baseUrl: `${baseURL}/api/${apiVersion}`,
   };
 

--- a/packages/kobotoolbox/src/Utils.js
+++ b/packages/kobotoolbox/src/Utils.js
@@ -7,30 +7,24 @@ import {
 
 export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
- const nextState = {
+  const nextState = {
     ...composeNextState(state, response.body),
     response: responseWithoutBody,
   };
   return callback(nextState);
 };
 
-
 export async function request(state, method, path, opts) {
   const { baseURL, apiVersion, username, password } = state.configuration;
 
-  const {
-    data = {},
-    query = {},
-    headers = {},
-    parseAs = 'json',
-  } = opts;
+  const { data = {}, query = {}, headers = {}, parseAs = 'json' } = opts;
 
   const authHeaders = makeBasicAuthHeader(username, password);
-
 
   const options = {
     body: data,
     headers: {
+      'Content-Type': 'application/json',
       ...authHeaders,
       ...headers,
     },

--- a/packages/kobotoolbox/src/Utils.js
+++ b/packages/kobotoolbox/src/Utils.js
@@ -1,0 +1,44 @@
+import { composeNextState } from '@openfn/language-common';
+import {
+  request as commonRequest,
+  makeBasicAuthHeader,
+  logResponse,
+} from '@openfn/language-common/util';
+
+export const prepareNextState = (state, response, callback = s => s) => {
+  const { body, ...responseWithoutBody } = response;
+ const nextState = {
+    ...composeNextState(state, response.body),
+    response: responseWithoutBody,
+  };
+  return callback(nextState);
+};
+
+
+export async function request(state, method, path, opts) {
+  const { baseURL, apiVersion, username, password } = state.configuration;
+
+  const {
+    data = {},
+    query = {},
+    headers = {},
+    parseAs = 'json',
+  } = opts;
+
+  const authHeaders = makeBasicAuthHeader(username, password);
+
+
+  const options = {
+    body: data,
+    headers: {
+      ...authHeaders,
+      ...headers,
+    },
+    query,
+    parseAs,
+    maxRedirections: 1,
+    baseUrl: `${baseURL}/api/${apiVersion}`,
+  };
+
+  return commonRequest(method, path, options).then(logResponse);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,8 +889,8 @@ importers:
   packages/kobotoolbox:
     dependencies:
       '@openfn/language-common':
-        specifier: 1.15.2
-        version: 1.15.2
+        specifier: workspace:*
+        version: link:../common
     devDependencies:
       '@openfn/simple-ast':
         specifier: 0.4.1


### PR DESCRIPTION
## Summary

The `kobotoolbox` currently uses the old `http` implementation with `axios` and there was need to update it to the current version of `common` being used

Fixes #695 


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
