### PR TITLE
bugfix: ContentIndicator validation should be on "name", not on "type".

### DIFF
--- a/.changeset/perfect-kids-divide.md
+++ b/.changeset/perfect-kids-divide.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-gmail': patch
----
-
-Fixed bug which prevented multiple content of the same "type" and now correctly
-works to prevent multiple of the same "name".

--- a/.changeset/perfect-kids-divide.md
+++ b/.changeset/perfect-kids-divide.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-gmail': patch
+---
+
+Fixed bug which prevented multiple content of the same "type" and now correctly
+works to prevent multiple of the same "name".

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
   "globals": {
     "FormData": "readonly",
     "Map": "readonly",
+    "Set": "readonly",
     "Symbol": "readonly",
     "ReadableStream": "readonly",
     "Promise": "readonly"

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-gmail
 
+## 1.1.1
+
+### Patch Changes
+
+- 658971a: Fixed bug which prevented multiple content of the same "type" and now
+  correctly works to prevent multiple of the same "name".
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-gmail",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenFn gmail adaptor",
   "type": "module",
   "exports": {

--- a/packages/gmail/src/Utils.js
+++ b/packages/gmail/src/Utils.js
@@ -37,19 +37,17 @@ export async function getMessageResult(userId, messageId) {
 }
 
 export function getContentIndicators(defaultContentRequests, contentRequests) {
-  const indicators = new Map();
+  defaultContentRequests = defaultContentRequests ?? [];
+  contentRequests = contentRequests ?? [];
 
-  const requests = [
-    ...(defaultContentRequests || []),
-    ...(contentRequests || []),
-  ];
+  const contentIndicators = contentRequests.map(getContentIndicator);
+  const contentNames = new Set(contentIndicators.map(({ name }) => name));
 
-  for (const request of requests) {
-    const indicator = getContentIndicator(request);
-    indicators.set(indicator.type, indicator);
-  }
+  const defaultContentIndicators = defaultContentRequests
+    .map(getContentIndicator)
+    .filter(({ name }) => !contentNames.has(name));
 
-  return Array.from(indicators.values());
+  return [...defaultContentIndicators, ...contentIndicators];
 }
 
 function getContentIndicator(contentRequest) {

--- a/packages/gmail/src/Utils.js
+++ b/packages/gmail/src/Utils.js
@@ -36,10 +36,10 @@ export async function getMessageResult(userId, messageId) {
   };
 }
 
-export function getContentIndicators(defaultContentRequests, contentRequests) {
-  defaultContentRequests = defaultContentRequests ?? [];
-  contentRequests = contentRequests ?? [];
-
+export function getContentIndicators(
+  defaultContentRequests = [],
+  contentRequests = []
+) {
   const contentIndicators = contentRequests.map(getContentIndicator);
   const contentNames = new Set(contentIndicators.map(({ name }) => name));
 


### PR DESCRIPTION
Prior implementation was ensuring only one indicator "type" per collection which is not correct.

The goal is to have:
- all the items from contentIndicators
- all the items from defaultContentIndicators that aren't in contentIndicators
- the defaultContentIndicators should be first

This PR produces the correct calculation.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [x] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
