### PR TITLE
Googlesheets expose the client directly

### DIFF
--- a/packages/googlesheets/ast.json
+++ b/packages/googlesheets/ast.json
@@ -252,35 +252,33 @@
         ]
       },
       "valid": true
-    }
-  ],
-  "exports": [],
-  "common": [
+    },
     {
       "name": "fn",
       "params": [
         "func"
       ],
       "docs": {
-        "description": "Creates a custom step (or operation) for more flexible job writing.",
+        "description": "Execute an arbitrary function against state. The Google Sheets adaptor\nalso exposes a {@link https://googleapis.dev/nodejs/googleapis/latest/sheets/classes/Resource$Spreadsheets.html | googlesheets client} instance.",
         "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
           {
             "title": "function",
             "description": null,
             "name": null
           },
           {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
             "title": "example",
-            "description": "fn(state => {\n  // do some things to state\n  return state;\n});"
+            "description": "fn((state, sheets) => {\n  // make any request with the sheets client\n  const response  = await sheets.values.batchUpdate({\n    spreadsheetId: 'abc',\n    resource: {data: [{ range: state.range, values: state.values }]}\n  });\n  // return a new state object\n  return {...state, data: response.data }\n}",
+            "caption": "Use the Sheets client directly"
           },
           {
             "title": "param",
-            "description": "is the function",
+            "description": "The function to execute. Must return state.",
             "type": {
               "type": "NameExpression",
               "name": "Function"
@@ -298,7 +296,10 @@
         ]
       },
       "valid": true
-    },
+    }
+  ],
+  "exports": [],
+  "common": [
     {
       "name": "fnIf",
       "params": [

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -252,8 +252,8 @@ export function getValues(spreadsheetId, range, callback = s => s) {
  * @returns {Operation}
  */
 export function fn(func) {
-  return (state, sheetsClient) => {
-    return func(state, sheetsClient)
+  return state => {
+    return func(state, client)
   }
 }
 

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -18,6 +18,7 @@ function createConnection(state) {
   auth.credentials = { access_token: accessToken };
 
   client = google.sheets({ version: 'v4', auth });
+  console.log(' >> created client');
   return state;
 }
 
@@ -253,7 +254,7 @@ export function getValues(spreadsheetId, range, callback = s => s) {
  */
 export function fn(func) {
   return state => {
-    return func(state, client?.sheets);
+    return func(state, client?.spreadsheets);
   };
 }
 

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -233,6 +233,30 @@ export function getValues(spreadsheetId, range, callback = s => s) {
   };
 }
 
+
+/**
+ * Exposes the googlesheets client for more flexible job writing
+ * @function
+ * @public
+ * @example
+ * fn((state, sheets) => {
+ *  // make any request with the client
+ *   const response  = await sheetsClient.values.batchUpdate({
+ *     spreadsheetId: 'abc',
+ *     resource: {data: [{ range, values }]}
+ *   });
+ *   // return a new state object
+ *   return {...state, data: response.data }
+ * }
+ * @param {Function} func is the function
+ * @returns {Operation}
+ */
+export function fn(func) {
+  return (state, sheetsClient) => {
+    return func(state, sheetsClient)
+  }
+}
+
 export {
   alterState,
   combine,
@@ -242,7 +266,6 @@ export {
   each,
   field,
   fields,
-  fn,
   fnIf,
   http,
   lastReferenceValue,

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -233,28 +233,28 @@ export function getValues(spreadsheetId, range, callback = s => s) {
   };
 }
 
-
 /**
- * Exposes the googlesheets client for more flexible job writing
+ * Execute an arbitrary function against state. The Google Sheets adaptor
+ * also exposes a {@link https://googleapis.dev/nodejs/googleapis/latest/sheets/classes/Resource$Spreadsheets.html | googlesheets client} instance.
  * @function
  * @public
- * @example
+ * @example <caption>Use the Sheets client directly</caption>
  * fn((state, sheets) => {
- *  // make any request with the client
- *   const response  = await sheetsClient.values.batchUpdate({
+ *   // make any request with the sheets client
+ *   const response  = await sheets.values.batchUpdate({
  *     spreadsheetId: 'abc',
- *     resource: {data: [{ range, values }]}
+ *     resource: {data: [{ range: state.range, values: state.values }]}
  *   });
  *   // return a new state object
  *   return {...state, data: response.data }
  * }
- * @param {Function} func is the function
+ * @param {Function} func The function to execute. Must return state.
  * @returns {Operation}
  */
 export function fn(func) {
   return state => {
-    return func(state, client)
-  }
+    return func(state, client?.sheets);
+  };
 }
 
 export {

--- a/packages/googlesheets/test/index.js
+++ b/packages/googlesheets/test/index.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { execute } from '../src';
+import { execute, fn } from '../src';
 import { appendValues, batchUpdateValues } from '../src';
 
 describe('execute', () => {
@@ -66,5 +66,50 @@ describe('batchUpdateValues', () =>{
       values: state.values,
     })(state);
     expect(result).to.eql(state);
+  });
+});
+
+describe('fn function', () => {
+  let mockFunc, mockState, mockSheetsClient, mockReturnValue;
+
+  beforeEach(()=> {
+    // mock call back function
+    mockFunc = (state, sheetsClient) => {
+          sheetsClient.values.get({
+          spreadsheetId: 'abc',
+          range: 'Sheet1!A1:E1'
+        });
+          return mockReturnValue;
+    };
+
+    // mock return value
+    mockReturnValue = [
+      ['From expression', '$15', '2', '3/15/2016'],
+      ['Really now!', '$100', '1', '3/20/2016'],
+    ];
+
+    mockState = { key: 'value' };
+
+    // simulate values.get function on Google sheets
+    mockSheetsClient = {
+      values: {
+        get: ({spreadsheetId, range}) => {
+          return {
+            values: mockReturnValue
+          }
+        }
+      }
+    }
+  });
+
+  it('should return an operation', () => {
+    const operation = fn(mockFunc)
+    expect(operation).to.be.a('Function')
+  });
+
+  it('should call the passed function with state and sheetsClient', () => {
+    const operation = fn(mockFunc);
+    const result = operation(mockState, mockSheetsClient);
+    expect(result).to.eql(mockReturnValue)
   });
 });


### PR DESCRIPTION
## Summary

Expose `googlesheets` client for more flexible job writing

Fixes #575

## Details

Override the common `fn` function that takes the `state` and the `sheetsClient` as arguments in the callback

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
