### PR TITLE
kobotoolbox: switch baseURL to baseUrl

### DIFF
--- a/packages/kobotoolbox/ast.json
+++ b/packages/kobotoolbox/ast.json
@@ -4,7 +4,7 @@
       "name": "getForms",
       "params": [],
       "docs": {
-        "description": "Make a request to fetch all survey forms accessible to the user's API token. The url is `/assets/?asset_type=survey`.",
+        "description": "Make a request to fetch all survey forms accessible to the user's API token. Calls `/api/v2/assets/?asset_type=survey`.",
         "tags": [
           {
             "title": "public",
@@ -19,6 +19,10 @@
             "title": "function",
             "description": null,
             "name": null
+          },
+          {
+            "title": "state",
+            "description": "data - an array of form objects"
           },
           {
             "title": "returns",
@@ -39,7 +43,7 @@
         "options"
       ],
       "docs": {
-        "description": "Get submissions for a specific form",
+        "description": "Get submissions for a specific form. Calls `/api/v2/assets/<id>/data/`.",
         "tags": [
           {
             "title": "example",
@@ -84,6 +88,10 @@
             "default": "{}"
           },
           {
+            "title": "state",
+            "description": "data - an array of submission objects"
+          },
+          {
             "title": "returns",
             "description": null,
             "type": {
@@ -101,7 +109,7 @@
         "formId"
       ],
       "docs": {
-        "description": "Get deployment information for a specific form",
+        "description": "Get deployment information for a specific form. Calls `/api/v2/assets/<id>/deployment/`.",
         "tags": [
           {
             "title": "example",
@@ -125,6 +133,10 @@
               "name": "string"
             },
             "name": "formId"
+          },
+          {
+            "title": "state",
+            "description": "data - an object containing deployment information"
           },
           {
             "title": "returns",

--- a/packages/kobotoolbox/configuration-schema.json
+++ b/packages/kobotoolbox/configuration-schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
-        "baseURL": {
-            "title": "Base URL",
+        "baseUrl": {
+            "title": "Base Url",
             "type": "string",
             "default": "https://kf.kobotoolbox.org",
             "description": "Kobotoolbox URL",
@@ -46,7 +46,7 @@
     "additionalProperties": true,
     "required": [
         "username",
-        "baseURL",
+        "baseUrl",
         "password",
         "apiVersion"
     ]

--- a/packages/kobotoolbox/src/Utils.js
+++ b/packages/kobotoolbox/src/Utils.js
@@ -15,7 +15,15 @@ export const prepareNextState = (state, response) => {
 };
 
 export async function request(state, method, path, opts) {
-  const { baseURL, apiVersion, username, password } = state.configuration;
+  const { baseUrl, apiVersion, username, password } = state.configuration;
+
+  let baseURL = baseUrl || state.configuration.baseURL;
+
+  if (!baseUrl) {
+    console.warn(
+      'No baseUrl found in state.configuration. baseURL will be used instead, but this will be deprecated in the future.'
+    );
+  }
 
   const {
     data = {},

--- a/packages/kobotoolbox/test/index.js
+++ b/packages/kobotoolbox/test/index.js
@@ -22,7 +22,7 @@ const configuration = {
   username: 'test',
   password: 'strongpassword',
   apiVersion: 'v2',
-  baseURL: 'https://test.kobotoolbox.org',
+  baseUrl: 'https://test.kobotoolbox.org',
 };
 
 const defaultObjects = [


### PR DESCRIPTION
## Summary

Switch from using `baseURL` to `baseUrl` in `kobotoolbox`

Fixes #

## Details

All adaptors use `baseUrl` as opposed to `kobotoolbox` that uses `baseURL`. We have switched to `baseUrl` but still allow users to send requests with `baseURL` but log a warning.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
