### PR TITLE
Fix kobo submissions

### DIFF
--- a/.changeset/small-cheetahs-tap.md
+++ b/.changeset/small-cheetahs-tap.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-kobotoolbox': patch
+---
+
+Fix results handling for getSubmissions

--- a/.changeset/small-cheetahs-tap.md
+++ b/.changeset/small-cheetahs-tap.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-kobotoolbox': patch
----
-
-Fix results handling for getSubmissions

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-kobotoolbox
 
+## 3.0.1
+
+### Patch Changes
+
+- a8b91d2: Fix results handling for getSubmissions
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-kobotoolbox",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A Kobo Toolbox Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -1,4 +1,7 @@
-import { execute as commonExecute } from '@openfn/language-common';
+import {
+  execute as commonExecute,
+  composeNextState,
+} from '@openfn/language-common';
 import { expandReferences } from '@openfn/language-common/util';
 
 import * as util from './Utils';
@@ -88,12 +91,13 @@ export function getSubmissions(formId, options = {}) {
       }
     }
 
-    const response = await util.request(state, 'GET', url, {
+    const { results } = await util.request(state, 'GET', url, {
       paginate: true,
       query,
     });
-    console.log('✓', response.results.length, 'submissions fetched.');
-    return util.prepareNextState(state, response);
+
+    console.log('✓', results.length, 'submissions fetched.');
+    return composeNextState(state, results);
   };
 }
 

--- a/packages/kobotoolbox/test/index.js
+++ b/packages/kobotoolbox/test/index.js
@@ -293,6 +293,11 @@ describe('getSubmissions', () => {
         { ...jsonHeaders }
       );
     const state = { configuration };
+    // This unit test looks wrong
+    // why are we asserting against response, and not state.data?
+    // ~95% of users only care about state.data
+    // Note that the fix on this branch should be causing the tests to fail now,
+    // because we no longer return response from getSubmissions
     const { response } = await execute(getSubmissions(formId))(state);
     expect(response.results[0]['First_Name_of_Patient']).to.eql('Kwothe');
   });

--- a/packages/kobotoolbox/test/index.js
+++ b/packages/kobotoolbox/test/index.js
@@ -293,13 +293,8 @@ describe('getSubmissions', () => {
         { ...jsonHeaders }
       );
     const state = { configuration };
-    //  This unit test looks wrong
-    //  why are we asserting against response, and not state.data?
-    //  ~95% of users only care about state.data
-    //  Note that the fix on this branch should be causing the tests to fail now,
-    //  because we no longer return response from getSubmissions
-    const { response } = await execute(getSubmissions(formId))(state);
-    expect(response.results[0]['First_Name_of_Patient']).to.eql('Kwothe');
+    const { data } = await execute(getSubmissions(formId))(state);
+    expect(data[0]['First_Name_of_Patient']).to.eql('Kwothe');
   });
 
   it('should get a list of submissions with a query', async () => {
@@ -322,12 +317,12 @@ describe('getSubmissions', () => {
         { ...jsonHeaders }
       );
     const state = { configuration };
-    const { response } = await execute(
+    const { data } = await execute(
       getSubmissions(formId, {
         query: { _submission_time: { $gte: '2022-06-12T21:54:20' } },
       })
     )(state);
-    expect(response.results[0]['First_Name_of_Patient']).to.eql('Kwothe');
+    expect(data[0]['First_Name_of_Patient']).to.eql('Kwothe');
   });
 });
 

--- a/packages/kobotoolbox/test/index.js
+++ b/packages/kobotoolbox/test/index.js
@@ -293,11 +293,11 @@ describe('getSubmissions', () => {
         { ...jsonHeaders }
       );
     const state = { configuration };
-    // This unit test looks wrong
-    // why are we asserting against response, and not state.data?
-    // ~95% of users only care about state.data
-    // Note that the fix on this branch should be causing the tests to fail now,
-    // because we no longer return response from getSubmissions
+    //  This unit test looks wrong
+    //  why are we asserting against response, and not state.data?
+    //  ~95% of users only care about state.data
+    //  Note that the fix on this branch should be causing the tests to fail now,
+    //  because we no longer return response from getSubmissions
     const { response } = await execute(getSubmissions(formId))(state);
     expect(response.results[0]['First_Name_of_Patient']).to.eql('Kwothe');
   });


### PR DESCRIPTION
## Summary

`getSubmissions()` is failing to return submission data to `state.data`.

When we added the pagination stuff, we changed the result of `util.request`. Instead of returning a Response, it returns a `{ results [] }` array when paginate is true.

This PR is a quick fix, but I'd like to look at why the unit tests didn't fail

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
