### PR TITLE
http: change body signature in functions

### DIFF
--- a/.changeset/khaki-walls-burn.md
+++ b/.changeset/khaki-walls-burn.md
@@ -2,4 +2,31 @@
 '@openfn/language-http': major
 ---
 
-Change `put` and `post` function signatures to have body data seperate
+Add a `data` argument to `put()`, `patch()` and `post()`
+
+## Migration Guide
+
+`put()`, `patch()` and `post()` have had their signatures changed from
+`post(path, options)` to `post(path, data, options)`.
+
+The payload attached to the body, which in 6.0 was passed on the options object
+as `body`, is now the second argument to the function, and options is passed
+third.
+
+So if you used to do this:
+
+```js
+post('/patient', { body: $.patient });
+```
+
+You must edit your code to do this:
+
+```js
+post('/patient', $.patient);
+```
+
+You can still pass options to the request via the third argument:
+
+```js
+post('/patient', $.patient, { query: $.query, headers: $.headers });
+```

--- a/.changeset/khaki-walls-burn.md
+++ b/.changeset/khaki-walls-burn.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-http': major
+---
+
+Change `put` and `post` function signatures to have body data seperate

--- a/.changeset/khaki-walls-burn.md
+++ b/.changeset/khaki-walls-burn.md
@@ -2,7 +2,8 @@
 '@openfn/language-http': major
 ---
 
-Add a `data` argument to `put()`, `patch()` and `post()`
+- Add a `data` argument to `put()`, `patch()` and `post()`
+- Remove the deprecated `json` property on `RequestOptions`
 
 ## Migration Guide
 

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -18,7 +18,7 @@
           },
           {
             "title": "example",
-            "description": "request(\n  'GET',\n  '/myEndpoint',\n   {\n     query: {foo: 'bar', a: 1},\n     headers: {'content-type': 'application/json'},\n   }\n)"
+            "description": "request(\n  'GET',\n  '/patient',\n   {\n     query: {foo: 'bar', a: 1},\n     headers: {'content-type': 'application/json'},\n   }\n)"
           },
           {
             "title": "function",
@@ -94,7 +94,7 @@
           },
           {
             "title": "example",
-            "description": "get('/myEndpoint', {\n  query: {foo: 'bar', a: 1},\n  headers: {'content-type': 'application/json'},\n})"
+            "description": "get('/patient', {\n  query: {foo: 'bar', a: 1},\n  headers: {'content-type': 'application/json'},\n})"
           },
           {
             "title": "function",
@@ -162,8 +162,13 @@
           },
           {
             "title": "example",
-            "description": "post('/myEndpoint',\n $.data\n{\n   headers: {'content-type': 'application/json'},\n })",
-            "caption": "Create a resource with data"
+            "description": "post('/patient' $.data)",
+            "caption": "POST a resource with from state"
+          },
+          {
+            "title": "example",
+            "description": "post('/patient' $.data, {\n  headers: { 'content-type': 'application/fhir+json' },\n})",
+            "caption": "POST a resource with custom headers"
           },
           {
             "title": "function",
@@ -240,7 +245,13 @@
           },
           {
             "title": "example",
-            "description": "put('/myEndpoint', {'foo': 'bar'},\n{\n   headers: {'content-type': 'application/json'},\n })"
+            "description": "put('/patient', $.data)",
+            "caption": "PUT a resource from state"
+          },
+          {
+            "title": "example",
+            "description": "put('/patient', $.data, {\n  headers: { 'content-type': 'application/fhir+json' },\n})",
+            "caption": "PUT a resource with custom headers"
           },
           {
             "title": "function",
@@ -317,7 +328,13 @@
           },
           {
             "title": "example",
-            "description": "patch('/myEndpoint', {'foo': 'bar'}, {\n   headers: {'content-type': 'application/json'},\n })"
+            "description": "patch('/patient', $.data)",
+            "caption": "PATCH a resource from state"
+          },
+          {
+            "title": "example",
+            "description": "patch('/patient', $.data, {\n  headers: { 'content-type': 'application/fhir+json' },\n})",
+            "caption": "PATCH a resource with custom headers"
           },
           {
             "title": "function",
@@ -393,7 +410,7 @@
           },
           {
             "title": "example",
-            "description": "del(`/myendpoint/${state => state.data.id}`, {\n   headers: {'content-type': 'application/json'}\n })"
+            "description": "del(`/myendpoint/${$.data.id}`)"
           },
           {
             "title": "function",

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -45,16 +45,7 @@
           },
           {
             "title": "param",
-            "description": "Body data to append to the request. JSON will be converted to a string.",
-            "type": {
-              "type": "NameExpression",
-              "name": "object"
-            },
-            "name": "data"
-          },
-          {
-            "title": "param",
-            "description": "Query, Headers and Authentication parameters",
+            "description": "Body, Query, Headers and Authentication parameters",
             "type": {
               "type": "NameExpression",
               "name": "RequestOptions"
@@ -84,7 +75,7 @@
           }
         ]
       },
-      "valid": false
+      "valid": true
     },
     {
       "name": "get",

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -5,7 +5,6 @@
       "params": [
         "method",
         "path",
-        "data",
         "options",
         "callback"
       ],
@@ -19,7 +18,7 @@
           },
           {
             "title": "example",
-            "description": "request(\n  'GET',\n  '/myEndpoint',\n  {},\n   {\n     query: {foo: 'bar', a: 1},\n     headers: {'content-type': 'application/json'},\n   }\n)"
+            "description": "request(\n  'GET',\n  '/myEndpoint',\n   {\n     query: {foo: 'bar', a: 1},\n     headers: {'content-type': 'application/json'},\n   }\n)"
           },
           {
             "title": "function",
@@ -85,7 +84,7 @@
           }
         ]
       },
-      "valid": true
+      "valid": false
     },
     {
       "name": "get",
@@ -127,7 +126,7 @@
               "type": "NameExpression",
               "name": "RequestOptions"
             },
-            "name": "Options"
+            "name": "options"
           },
           {
             "title": "param",
@@ -152,7 +151,7 @@
           }
         ]
       },
-      "valid": false
+      "valid": true
     },
     {
       "name": "post",
@@ -172,7 +171,8 @@
           },
           {
             "title": "example",
-            "description": "post('/myEndpoint',\n {'foo': 'bar'},\n{\n   headers: {'content-type': 'application/json'},\n })"
+            "description": "post('/myEndpoint',\n $.data\n{\n   headers: {'content-type': 'application/json'},\n })",
+            "caption": "Create a resource with data"
           },
           {
             "title": "function",
@@ -249,7 +249,7 @@
           },
           {
             "title": "example",
-            "description": "put('/myEndpoint',  {'foo': 'bar'},{\n   headers: {'content-type': 'application/json'},\n })"
+            "description": "put('/myEndpoint', {'foo': 'bar'},\n{\n   headers: {'content-type': 'application/json'},\n })"
           },
           {
             "title": "function",

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -5,7 +5,8 @@
       "params": [
         "method",
         "path",
-        "params",
+        "data",
+        "options",
         "callback"
       ],
       "docs": {
@@ -18,7 +19,7 @@
           },
           {
             "title": "example",
-            "description": "request(\n  'GET',\n  '/myEndpoint',\n   {\n     query: {foo: 'bar', a: 1},\n     headers: {'content-type': 'application/json'},\n   }\n)"
+            "description": "request(\n  'GET',\n  '/myEndpoint',\n  {},\n   {\n     query: {foo: 'bar', a: 1},\n     headers: {'content-type': 'application/json'},\n   }\n)"
           },
           {
             "title": "function",
@@ -45,12 +46,21 @@
           },
           {
             "title": "param",
+            "description": "Body data to append to the request. JSON will be converted to a string.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "data"
+          },
+          {
+            "title": "param",
             "description": "Query, Headers and Authentication parameters",
             "type": {
               "type": "NameExpression",
               "name": "RequestOptions"
             },
-            "name": "params"
+            "name": "options"
           },
           {
             "title": "param",
@@ -81,7 +91,7 @@
       "name": "get",
       "params": [
         "path",
-        "params",
+        "options",
         "callback"
       ],
       "docs": {
@@ -112,12 +122,12 @@
           },
           {
             "title": "param",
-            "description": "Query, Headers and Authentication parameters",
+            "description": "Body, Query, Headers and Authentication parameters",
             "type": {
               "type": "NameExpression",
               "name": "RequestOptions"
             },
-            "name": "params"
+            "name": "Options"
           },
           {
             "title": "param",
@@ -142,13 +152,14 @@
           }
         ]
       },
-      "valid": true
+      "valid": false
     },
     {
       "name": "post",
       "params": [
         "path",
-        "params",
+        "data",
+        "options",
         "callback"
       ],
       "docs": {
@@ -161,7 +172,7 @@
           },
           {
             "title": "example",
-            "description": "post('/myEndpoint', {\n   body: {'foo': 'bar'},\n   headers: {'content-type': 'application/json'},\n })"
+            "description": "post('/myEndpoint',\n {'foo': 'bar'},\n{\n   headers: {'content-type': 'application/json'},\n })"
           },
           {
             "title": "function",
@@ -179,12 +190,21 @@
           },
           {
             "title": "param",
-            "description": "Body, Query, Headers and Authentication parameters",
+            "description": "Body data to append to the request. JSON will be converted to a string.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "data"
+          },
+          {
+            "title": "param",
+            "description": "Query, Headers and Authentication parameters",
             "type": {
               "type": "NameExpression",
               "name": "RequestOptions"
             },
-            "name": "params"
+            "name": "options"
           },
           {
             "title": "param",
@@ -215,7 +235,8 @@
       "name": "put",
       "params": [
         "path",
-        "params",
+        "data",
+        "options",
         "callback"
       ],
       "docs": {
@@ -228,7 +249,7 @@
           },
           {
             "title": "example",
-            "description": "put('/myEndpoint', {\n   body: {'foo': 'bar'},\n   headers: {'content-type': 'application/json'},\n })"
+            "description": "put('/myEndpoint',  {'foo': 'bar'},{\n   headers: {'content-type': 'application/json'},\n })"
           },
           {
             "title": "function",
@@ -246,12 +267,21 @@
           },
           {
             "title": "param",
-            "description": "Body, Query, Headers and Auth parameters",
+            "description": "Body data to append to the request. JSON will be converted to a string.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "data"
+          },
+          {
+            "title": "param",
+            "description": "Query, Headers and Auth parameters",
             "type": {
               "type": "NameExpression",
               "name": "RequestOptions"
             },
-            "name": "params"
+            "name": "options-null"
           },
           {
             "title": "param",
@@ -276,13 +306,14 @@
           }
         ]
       },
-      "valid": true
+      "valid": false
     },
     {
       "name": "patch",
       "params": [
         "path",
-        "params",
+        "data",
+        "options",
         "callback"
       ],
       "docs": {
@@ -295,7 +326,7 @@
           },
           {
             "title": "example",
-            "description": "patch('/myEndpoint', {\n   body: {'foo': 'bar'},\n   headers: {'content-type': 'application/json'},\n })"
+            "description": "patch('/myEndpoint', {'foo': 'bar'}, {\n   headers: {'content-type': 'application/json'},\n })"
           },
           {
             "title": "function",
@@ -313,12 +344,21 @@
           },
           {
             "title": "param",
-            "description": "Body, Query, Headers and Auth parameters",
+            "description": "Body data to append to the request. JSON will be converted to a string.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "data"
+          },
+          {
+            "title": "param",
+            "description": "Query, Headers and Auth parameters",
             "type": {
               "type": "NameExpression",
               "name": "RequestOptions"
             },
-            "name": "params"
+            "name": "options"
           },
           {
             "title": "param",
@@ -349,7 +389,7 @@
       "name": "del",
       "params": [
         "path",
-        "params",
+        "options",
         "callback"
       ],
       "docs": {
@@ -380,12 +420,12 @@
           },
           {
             "title": "param",
-            "description": "Body, Query, Headers and Auth parameters",
+            "description": "Query, Headers and Auth parameters",
             "type": {
               "type": "NameExpression",
               "name": "RequestOptions"
             },
-            "name": "params"
+            "name": "options"
           },
           {
             "title": "param",
@@ -415,7 +455,7 @@
     {
       "name": "parseXML",
       "params": [
-        "body",
+        "data",
         "script",
         "callback"
       ],
@@ -433,7 +473,7 @@
           },
           {
             "title": "example",
-            "description": "parseXML(\n  (state) => state.response,\n  ($) => {\n    return $(\"table[class=your_table]\").parsetable(true, true, true);\n  },\n  (next) => ({ ...next, results: next.data.body })\n);",
+            "description": "parseXML(\n  (state) => state.response,\n  ($) => {\n    return $(\"table[class=your_table]\").parsetable(true, true, true);\n  },\n  (next) => ({ ...next, results: next.data.data })\n);",
             "caption": "Using parseXML with a callback"
           },
           {
@@ -443,12 +483,12 @@
           },
           {
             "title": "param",
-            "description": "data string to be parsed",
+            "description": "Body string to be parsed",
             "type": {
               "type": "NameExpression",
               "name": "String"
             },
-            "name": "body"
+            "name": "data"
           },
           {
             "title": "param",

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -6,7 +6,7 @@ import { request as sendRequest, xmlParser } from './util';
  * @typedef {Object} RequestOptions
  * @public
  * @property {object} errors - Map of errorCodes -> error messages, ie, `{ 404: 'Resource not found;' }`. Pass `false` to suppress errors for this code.
- * @property {boolean} form - True/False if the body data is multipart HTML form (as FormData).
+ * @property {boolean} form - Set to `true` if the body data is multipart HTML form (as FormData).
  * @property {object|string} body - body data to append to the request. JSON will be converted to a string (but a content-type header will not be attached to the request).This is only applicable to the request function
  * @property {object} query - An object of query parameters to be encoded into the URL.
  * @property {object} headers - An object of headers to append to the request.

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -7,6 +7,7 @@ import { request as sendRequest, xmlParser } from './util';
  * @public
  * @property {object} errors - Map of errorCodes -> error messages, ie, `{ 404: 'Resource not found;' }`. Pass `false` to suppress errors for this code.
  * @property {boolean} form - True/False if the body data is multipart HTML form (as FormData).
+ * @property {object|string} body - body data to append to the request. JSON will be converted to a string (but a content-type header will not be attached to the request).This is only applicable to the request function
  * @property {object} query - An object of query parameters to be encoded into the URL.
  * @property {object} headers - An object of headers to append to the request.
  * @property {string} parseAs - Parse the response body as json, text or stream. By default will use the response headers.
@@ -51,7 +52,6 @@ export function execute(...operations) {
  * request(
  *   'GET',
  *   '/myEndpoint',
- *   {},
  *    {
  *      query: {foo: 'bar', a: 1},
  *      headers: {'content-type': 'application/json'},
@@ -60,14 +60,13 @@ export function execute(...operations) {
  * @function
  * @param {string} method - The HTTP method to use.
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
- * @param {object} data - Body data to append to the request. JSON will be converted to a string.
- * @param {RequestOptions} options - Query, Headers and Authentication parameters
+ * @param {RequestOptions} options - Body, Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function request(method, path, data, options, callback) {
-  return sendRequest(method, path, { body: data, ...options }, callback);
+export function request(method, path, options, callback) {
+  return sendRequest(method, path, options, callback);
 }
 
 /**
@@ -80,7 +79,7 @@ export function request(method, path, data, options, callback) {
  * })
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
- * @param {RequestOptions} Options - Body, Query, Headers and Authentication parameters
+ * @param {RequestOptions} options - Body, Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
@@ -92,9 +91,9 @@ export function get(path, options, callback) {
 /**
  * Make a POST request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
- * @example
+ * @example <caption>Create a resource with data</caption>
  *  post('/myEndpoint',
- *  {'foo': 'bar'},
+ *  $.data
  * {
  *    headers: {'content-type': 'application/json'},
  *  })
@@ -115,7 +114,8 @@ export function post(path, data, options, callback) {
  * Make a PUT request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
- *  put('/myEndpoint',  {'foo': 'bar'},{
+ *  put('/myEndpoint', {'foo': 'bar'},
+ * {
  *    headers: {'content-type': 'application/json'},
  *  })
  * @function

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -5,9 +5,8 @@ import { request as sendRequest, xmlParser } from './util';
  * Options provided to the HTTP request
  * @typedef {Object} RequestOptions
  * @public
- * @property {object|string} body - body data to append to the request. JSON will be converted to a string (but a content-type header will not be attached to the request).
  * @property {object} errors - Map of errorCodes -> error messages, ie, `{ 404: 'Resource not found;' }`. Pass `false` to suppress errors for this code.
- * @property {object} form - Pass a JSON object to be serialised into a multipart HTML form (as FormData) in the body.
+ * @property {boolean} form - True/False if the body data is multipart HTML form (as FormData).
  * @property {object} query - An object of query parameters to be encoded into the URL.
  * @property {object} headers - An object of headers to append to the request.
  * @property {string} parseAs - Parse the response body as json, text or stream. By default will use the response headers.
@@ -52,6 +51,7 @@ export function execute(...operations) {
  * request(
  *   'GET',
  *   '/myEndpoint',
+ *   {},
  *    {
  *      query: {foo: 'bar', a: 1},
  *      headers: {'content-type': 'application/json'},
@@ -60,13 +60,14 @@ export function execute(...operations) {
  * @function
  * @param {string} method - The HTTP method to use.
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
- * @param {RequestOptions} params - Query, Headers and Authentication parameters
+ * @param {object} data - Body data to append to the request. JSON will be converted to a string.
+ * @param {RequestOptions} options - Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function request(method, path, params, callback) {
-  return sendRequest(method, path, params, callback);
+export function request(method, path, data, options, callback) {
+  return sendRequest(method, path, { body: data, ...options }, callback);
 }
 
 /**
@@ -79,71 +80,73 @@ export function request(method, path, params, callback) {
  * })
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
- * @param {RequestOptions} params - Query, Headers and Authentication parameters
+ * @param {RequestOptions} Options - Body, Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function get(path, params, callback) {
-  return sendRequest('GET', path, params, callback);
+export function get(path, options, callback) {
+  return sendRequest('GET', path, options, callback);
 }
 
 /**
  * Make a POST request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
- *  post('/myEndpoint', {
- *    body: {'foo': 'bar'},
+ *  post('/myEndpoint',
+ *  {'foo': 'bar'},
+ * {
  *    headers: {'content-type': 'application/json'},
  *  })
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
- * @param {RequestOptions} params - Body, Query, Headers and Authentication parameters
+ * @param {object} data - Body data to append to the request. JSON will be converted to a string.
+ * @param {RequestOptions} options - Query, Headers and Authentication parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {operation}
  */
 
-export function post(path, params, callback) {
-  return sendRequest('POST', path, params, callback);
+export function post(path, data, options, callback) {
+  return sendRequest('POST', path, { body: data, ...options }, callback);
 }
 
 /**
  * Make a PUT request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
- *  put('/myEndpoint', {
- *    body: {'foo': 'bar'},
+ *  put('/myEndpoint',  {'foo': 'bar'},{
  *    headers: {'content-type': 'application/json'},
  *  })
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
- * @param {RequestOptions} params - Body, Query, Headers and Auth parameters
+ * @param {object} data - Body data to append to the request. JSON will be converted to a string.
+ * @param {RequestOptions} options- Query, Headers and Auth parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function put(path, params, callback) {
-  return sendRequest('PUT', path, params, callback);
+export function put(path, data, options, callback) {
+  return sendRequest('PUT', path, { body: data, ...options }, callback);
 }
 
 /**
  * Make a PATCH request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
- *  patch('/myEndpoint', {
- *    body: {'foo': 'bar'},
+ *  patch('/myEndpoint', {'foo': 'bar'}, {
  *    headers: {'content-type': 'application/json'},
  *  })
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
- * @param {RequestOptions} params - Body, Query, Headers and Auth parameters
+ * @param {object} data - Body data to append to the request. JSON will be converted to a string.
+ * @param {RequestOptions} options - Query, Headers and Auth parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function patch(path, params, callback) {
-  return sendRequest('PATCH', path, params, callback);
+export function patch(path, data, options, callback) {
+  return sendRequest('PATCH', path, { body: data, ...options }, callback);
 }
 
 /**
@@ -155,13 +158,13 @@ export function patch(path, params, callback) {
  *  })
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
- * @param {RequestOptions} params - Body, Query, Headers and Auth parameters
+ * @param {RequestOptions} options - Query, Headers and Auth parameters
  * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function del(path, params, callback) {
-  return sendRequest('DELETE', path, params, callback);
+export function del(path, options, callback) {
+  return sendRequest('DELETE', path, options, callback);
 }
 
 /**
@@ -180,18 +183,18 @@ export function del(path, params, callback) {
  *   ($) => {
  *     return $("table[class=your_table]").parsetable(true, true, true);
  *   },
- *   (next) => ({ ...next, results: next.data.body })
+ *   (next) => ({ ...next, results: next.data.data })
  * );
  * @function
- * @param {String} body - data string to be parsed
+ * @param {String} data - Body string to be parsed
  * @param {function} script - script for extracting data
  * @param {function} callback - (Optional) Callback function
  * @state data - the parsed XML as a JSON object
  * @state references - an array of all previous data objects used in the Job
  * @returns {Operation}
  */
-export function parseXML(body, script, callback) {
-  return xmlParser(body, script, callback);
+export function parseXML(data, script, callback) {
+  return xmlParser({ body: data }, script, callback);
 }
 
 export {

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -51,7 +51,7 @@ export function execute(...operations) {
  * @example
  * request(
  *   'GET',
- *   '/myEndpoint',
+ *   '/patient',
  *    {
  *      query: {foo: 'bar', a: 1},
  *      headers: {'content-type': 'application/json'},
@@ -73,7 +73,7 @@ export function request(method, path, options, callback) {
  * Make a GET request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
- * get('/myEndpoint', {
+ * get('/patient', {
  *   query: {foo: 'bar', a: 1},
  *   headers: {'content-type': 'application/json'},
  * })
@@ -91,12 +91,12 @@ export function get(path, options, callback) {
 /**
  * Make a POST request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
- * @example <caption>Create a resource with data</caption>
- *  post('/myEndpoint',
- *  $.data
- * {
- *    headers: {'content-type': 'application/json'},
- *  })
+ * @example <caption>POST a resource with from state</caption>
+ * post('/patient' $.data)
+   @example <caption>POST a resource with custom headers</caption>
+ * post('/patient' $.data, {
+ *   headers: { 'content-type': 'application/fhir+json' },
+ * })
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {object} data - Body data to append to the request. JSON will be converted to a string.
@@ -113,11 +113,12 @@ export function post(path, data, options, callback) {
 /**
  * Make a PUT request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
- * @example
- *  put('/myEndpoint', {'foo': 'bar'},
- * {
- *    headers: {'content-type': 'application/json'},
- *  })
+ * @example <caption>PUT a resource from state</caption>
+ * put('/patient', $.data)
+ * @example <caption>PUT a resource with custom headers</caption>
+ * put('/patient', $.data, {
+ *   headers: { 'content-type': 'application/fhir+json' },
+ * })
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {object} data - Body data to append to the request. JSON will be converted to a string.
@@ -133,10 +134,12 @@ export function put(path, data, options, callback) {
 /**
  * Make a PATCH request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
- * @example
- *  patch('/myEndpoint', {'foo': 'bar'}, {
- *    headers: {'content-type': 'application/json'},
- *  })
+ * @example <caption>PATCH a resource from state</caption>
+ * patch('/patient', $.data)
+ * @example <caption>PATCH a resource with custom headers</caption>
+ * patch('/patient', $.data, {
+ *   headers: { 'content-type': 'application/fhir+json' },
+ * })
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {object} data - Body data to append to the request. JSON will be converted to a string.
@@ -153,9 +156,7 @@ export function patch(path, data, options, callback) {
  * Make a DELETE request. If `configuration.baseUrl` is set, paths must be relative.
  * @public
  * @example
- *  del(`/myendpoint/${state => state.data.id}`, {
- *    headers: {'content-type': 'application/json'}
- *  })
+ * del(`/myendpoint/${$.data.id}`)
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} options - Query, Headers and Auth parameters

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -64,14 +64,14 @@ export function request(method, path, params, callback = s => s) {
       params
     );
 
-    let { body, headers = {} } = resolvedParams;
+    let { body, headers = { 'Content-Type': 'application/json' } } = resolvedParams;
 
-    if (resolvedParams.json) {
-      console.warn(
-        'WARNING: The `json` option has been deprecated. Use `body` instead'
-      );
-      body = resolvedParams.json;
-    }
+    // if (resolvedParams.json) {
+    //   console.warn(
+    //     'WARNING: The `json` option has been deprecated. Use `body` instead'
+    //   );
+    //   body = resolvedParams.json;
+    // }
 
     if (resolvedParams.form) {
       body = encodeFormBody(body);
@@ -99,10 +99,7 @@ export function request(method, path, params, callback = s => s) {
 
     const options = {
       ...resolvedParams,
-      headers: {
-        ...(!resolvedParams.form ? { 'Content-Type': 'application/json' } : {}),
-        ...headers,
-      },
+      headers,
       baseUrl,
       body,
       tls,

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -100,7 +100,7 @@ export function request(method, path, params, callback = s => s) {
     const options = {
       ...resolvedParams,
       headers: {
-        'Content-type': 'application/json',
+        ...(resolvedParams.json ? { 'Content-Type': 'application/json' } : {}),
         ...headers,
       },
       baseUrl,

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -74,7 +74,7 @@ export function request(method, path, params, callback = s => s) {
     }
 
     if (resolvedParams.form) {
-      body = encodeFormBody(resolvedParams.form);
+      body = encodeFormBody(body);
     }
 
     const baseUrl = state.configuration?.baseUrl;
@@ -99,7 +99,10 @@ export function request(method, path, params, callback = s => s) {
 
     const options = {
       ...resolvedParams,
-      headers,
+      headers: {
+        'Content-type': 'application/json',
+        ...headers,
+      },
       baseUrl,
       body,
       tls,

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -100,7 +100,7 @@ export function request(method, path, params, callback = s => s) {
     const options = {
       ...resolvedParams,
       headers: {
-        ...(resolvedParams.json ? { 'Content-Type': 'application/json' } : {}),
+        ...(!resolvedParams.form ? { 'Content-Type': 'application/json' } : {}),
         ...headers,
       },
       baseUrl,

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -66,13 +66,6 @@ export function request(method, path, params, callback = s => s) {
 
     let { body, headers = { 'Content-Type': 'application/json' } } = resolvedParams;
 
-    // if (resolvedParams.json) {
-    //   console.warn(
-    //     'WARNING: The `json` option has been deprecated. Use `body` instead'
-    //   );
-    //   body = resolvedParams.json;
-    // }
-
     if (resolvedParams.form) {
       body = encodeFormBody(body);
     }

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -643,46 +643,6 @@ describe('post', () => {
     ]);
   });
 
-  it('can be called inside an each with old "json" request config', async () => {
-    testServer
-      .intercept({
-        path: '/api/fake-json',
-        method: 'POST',
-      })
-      .reply(200, ({ body }) => body)
-      .persist();
-
-    const state = {
-      configuration: {},
-      things: [
-        { name: 'a', age: 42 },
-        { name: 'b', age: 83 },
-        { name: 'c', age: 112 },
-      ],
-      replies: [],
-    };
-
-    const finalState = await execute(
-      each(
-        '$.things[*]',
-        post(
-          'https://www.example.com/api/fake-json',
-          state => state.data,
-          {},
-          next => {
-            next.replies.push(next.response.body);
-            return next;
-          }
-        )
-      )
-    )(state);
-
-    expect(finalState.replies).to.eql([
-      '{"name":"a","age":42}',
-      '{"name":"b","age":83}',
-      '{"name":"c","age":112}',
-    ]);
-  });
 
   it('should make an http request from inside the parseCSV callback', async function () {
     testServer

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -92,7 +92,7 @@ describe('request()', () => {
       err = e;
     }
     expect(err.code).to.eql('UNEXPECTED_RELATIVE_URL');
-    expect(err.description).to.not.be.undefined
+    expect(err.description).to.not.be.undefined;
   });
 
   it('should throw if url is absolute and does not match baseUrl', async () => {
@@ -531,9 +531,7 @@ describe('post', () => {
     const state = {};
 
     await execute(
-      post('https://www.example.com/api/json', {
-        body: { name: 'tony stark', age: 24 },
-      })
+      post('https://www.example.com/api/json', { name: 'tony stark', age: 24 })
     )(state);
 
     expect(req.body).to.equal(JSON.stringify({ name: 'tony stark', age: 24 }));
@@ -565,8 +563,8 @@ describe('post', () => {
     };
 
     const { data } = await execute(
-      post('https://www.example.com/api/form-data', {
-        form: formData,
+      post('https://www.example.com/api/form-data', formData, {
+        form: true,
       })
     )({});
 
@@ -592,10 +590,13 @@ describe('post', () => {
       },
     };
     const { response } = await execute(
-      post('https://www.example.com/api/custom-success-codes', {
-        body: state => state.data,
-        errors: { 502: false },
-      })
+      post(
+        'https://www.example.com/api/custom-success-codes',
+        state => state.data,
+        {
+          errors: { 502: false },
+        }
+      )
     )(state);
 
     expect(response.statusCode).to.eq(502);
@@ -625,9 +626,8 @@ describe('post', () => {
         '$.things[*]',
         post(
           'https://www.example.com/api/json',
-          {
-            body: state => state.data,
-          },
+          state => state.data,
+          {},
           next => {
             next.replies.push(next.response.body);
             return next;
@@ -667,9 +667,8 @@ describe('post', () => {
         '$.things[*]',
         post(
           'https://www.example.com/api/fake-json',
-          {
-            json: state => state.data,
-          },
+          state => state.data,
+          {},
           next => {
             next.replies.push(next.response.body);
             return next;
@@ -705,16 +704,10 @@ describe('post', () => {
       csv,
       { chunkSize: 2 },
       (state, rows) =>
-        post(
-          'https://www.example.com/api/csv-reader',
-          {
-            body: rows,
-          },
-          state => {
-            state.apiResponses.push(...state.response.body);
-            return state;
-          }
-        )(state)
+        post('https://www.example.com/api/csv-reader', rows, {}, state => {
+          state.apiResponses.push(...state.response.body);
+          return state;
+        })(state)
     )(state);
 
     expect(resultingState.apiResponses).to.eql([
@@ -745,9 +738,7 @@ describe('put', () => {
     const state = {};
 
     const { response } = await execute(
-      put('https://www.example.com/api/fake-items/6', {
-        body,
-      })
+      put('https://www.example.com/api/fake-items/6', body)
     )(state);
 
     expect(response.statusCode).to.eql(200);
@@ -780,9 +771,8 @@ describe('put', () => {
         '$.things[*]',
         put(
           '/api/json',
-          {
-            body: state => state.data,
-          },
+          state => state.data,
+          {},
           next => {
             next.replies.push(next.response.body);
             return next;
@@ -817,9 +807,7 @@ describe('patch', () => {
     const state = {};
 
     const { response } = await execute(
-      patch('https://www.example.com/api/items/7', {
-        body,
-      })
+      patch('https://www.example.com/api/items/7', body)
     )(state);
 
     expect(response.statusCode).to.eql(200);
@@ -852,9 +840,8 @@ describe('patch', () => {
         '$.things[*]',
         patch(
           '/api/fake-json',
-          state => ({
-            body: state.data,
-          }),
+          state => state.data,
+          {},
           next => {
             next.replies.push(next.response.body);
             return next;
@@ -966,10 +953,13 @@ describe('tls', () => {
         state.httpsOptions = { ca: state.configuration.privateKey };
         return state;
       }),
-      post('https://www.example.com/api/sslCertCheck', state => ({
-        body: state.data,
-        agentOptions: state.httpsOptions,
-      }))
+      post(
+        'https://www.example.com/api/sslCertCheck',
+        state => state.data,
+        state => ({
+          agentOptions: state.httpsOptions,
+        })
+      )
     )(state);
     expect(finalState.data).to.eql({ a: 1 });
   });
@@ -985,8 +975,7 @@ describe('tls', () => {
     };
 
     const finalState = await execute(
-      post('https://www.example.com/api/sslCertCheck', {
-        body: state => state.data,
+      post('https://www.example.com/api/sslCertCheck', state => state.data, {
         tls: { ca: state.configuration.privateKey },
       })
     )(state);
@@ -1008,8 +997,7 @@ describe('tls', () => {
         state.httpsOptions = { ca: state.configuration.privateKey };
         return state;
       }),
-      post('https://www.example.com/api/sslCertCheck', {
-        body: state => state.data,
+      post('https://www.example.com/api/sslCertCheck', state => state.data, {
         tls: state => state.httpsOptions,
       })
     )(state);

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -643,7 +643,6 @@ describe('post', () => {
     ]);
   });
 
-
   it('should make an http request from inside the parseCSV callback', async function () {
     testServer
       .intercept({

--- a/packages/http/test/integration.js
+++ b/packages/http/test/integration.js
@@ -70,9 +70,7 @@ describe('Integration tests', () => {
       data: {},
     };
     const { response } = await execute(
-      post('/', {
-        body: { name: 'Joe' },
-      })
+      post('/',  { name: 'Joe' })
     )(state);
 
     expect(response.body).to.eql('Hello, World!');


### PR DESCRIPTION
## Summary

Change signature on all `http` functions to allow body data sent separately from the `options`

Fixes #922 


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
