### PR TITLE
Phase 6 improve OpenMRS adaptor docs

### DIFF
--- a/.changeset/eleven-spiders-play.md
+++ b/.changeset/eleven-spiders-play.md
@@ -1,0 +1,9 @@
+---
+'@openfn/language-openmrs': minor
+---
+
+- Added `state` annotations for all requests.
+- Improved the examples on the `get` function. 
+- Added a typedef for OpenMRS options that only includes query params.
+- Removed the `throw` declaration on the upsert docbloc.
+- Updated the`upsert`example signatures.

--- a/packages/openmrs/ast.json
+++ b/packages/openmrs/ast.json
@@ -7,22 +7,32 @@
         "options"
       ],
       "docs": {
-        "description": "Make a get request to any OpenMRS REST endpoint.",
+        "description": "Fetch resources from OpenMRS. Use this to fetch a single resource,\nor to search a list. Query parameters will be appended to the request URL,\nrefer to {@link https://rest.openmrs.org/ OpenMRS Docs} for details.",
         "tags": [
           {
             "title": "example",
-            "description": "get(\"/patient/abc\")",
-            "caption": "Get a patient by UUID"
+            "description": "get(\"patient\")",
+            "caption": "List all patients"
           },
           {
             "title": "example",
-            "description": "get(\"/patient\", {query: {q: 'Jon', limit: 1}})",
-            "caption": "Get a patient with query and limit"
+            "description": "get(\"patient\", { q: \"brian\", limit: 1 })",
+            "caption": "List patients by name with a limit(<a href=\"https://rest.openmrs.org/#search-patients\">see OpenMRS API</a>)"
           },
           {
             "title": "example",
-            "description": "get(\"/patient/abc/allergy/xyz\")",
-            "caption": "Get an allergy subresource by its UUID and parent patient UUID"
+            "description": "get(\"patient/abc\")",
+            "caption": "Fetch patient by UUID"
+          },
+          {
+            "title": "example",
+            "description": "get(\"patient/abc/allergy\")",
+            "caption": "List allergy subresources"
+          },
+          {
+            "title": "example",
+            "description": "get(\"patient/abc/allergy/xyz\")",
+            "caption": "Get allergy subresource by its UUID and parent patient UUID"
           },
           {
             "title": "function",
@@ -36,7 +46,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource (excluding /ws/rest/v1/)",
+            "description": "Path to resource (excluding `/ws/rest/v1/`)",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -45,16 +55,24 @@
           },
           {
             "title": "param",
-            "description": "An object containing query, headers, and body for the request. See {@link https://rest.openmrs.org/ OpenMRS Rest API docs} for available query parameters",
+            "description": "Query parameters (eg `limit`, `q`)",
             "type": {
               "type": "OptionalType",
               "expression": {
                 "type": "NameExpression",
-                "name": "RequestOptions"
+                "name": "RestQueryOptions"
               }
             },
             "name": "options",
             "default": "{}"
+          },
+          {
+            "title": "state",
+            "description": "{HttpState}"
+          },
+          {
+            "title": "state",
+            "description": "data The requested resources"
           },
           {
             "title": "returns",
@@ -75,7 +93,7 @@
         "data"
       ],
       "docs": {
-        "description": "Create a record",
+        "description": "Create a resource. For a list of valid resources, see {@link https://rest.openmrs.org/ OpenMRS Docs}",
         "tags": [
           {
             "title": "public",
@@ -89,7 +107,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource (excluding /ws/rest/v1/)",
+            "description": "Path to resource (excluding `/ws/rest/v1/`)",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -98,12 +116,20 @@
           },
           {
             "title": "param",
-            "description": "Object which defines data that will be used to create a given instance of resource",
+            "description": "Resource definition",
             "type": {
               "type": "NameExpression",
               "name": "object"
             },
             "name": "data"
+          },
+          {
+            "title": "state",
+            "description": "{HttpState}"
+          },
+          {
+            "title": "state",
+            "description": "data The newly created resource"
           },
           {
             "title": "returns",
@@ -116,7 +142,7 @@
           {
             "title": "example",
             "description": "create(\"person\", {\n  names: [\n    {\n      givenName: \"Mohit\",\n      familyName: \"Kumar\",\n    },\n  ],\n  gender: \"M\",\n  birthdate: \"1997-09-02\",\n  addresses: [\n    {\n      address1: \"30, Vivekananda Layout, Munnekolal,Marathahalli\",\n      cityVillage: \"Bengaluru\",\n      country: \"India\",\n      postalCode: \"560037\",\n    },\n  ],\n});",
-            "caption": "Create a person"
+            "caption": "Create a person (<a href=\"https://rest.openmrs.org/#create-a-person\">see OpenMRS API</a>)"
           },
           {
             "title": "example",
@@ -139,7 +165,7 @@
         "data"
       ],
       "docs": {
-        "description": "Update data. A generic helper function to update a resource object of any type.\nUpdating an object requires to send `all required fields` or the `full body`",
+        "description": "Update a resource. Only properties included in the data will be affected.\nFor a list of valid resources and for update rules, see the Update sections\nof the {@link https://rest.openmrs.org/ OpenMRS Docs}",
         "tags": [
           {
             "title": "public",
@@ -153,7 +179,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource (excluding /ws/rest/v1/)",
+            "description": "Path to resource (excluding `/ws/rest/v1/`)",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -162,12 +188,16 @@
           },
           {
             "title": "param",
-            "description": "Data to update. It requires to send `all required fields` or the `full body`. If you want `partial updates`, use `patch` operation.",
+            "description": "Resource properties to update",
             "type": {
               "type": "NameExpression",
               "name": "Object"
             },
             "name": "data"
+          },
+          {
+            "title": "state",
+            "description": "{HttpState}"
           },
           {
             "title": "returns",
@@ -179,8 +209,8 @@
           },
           {
             "title": "example",
-            "description": "update('person/3cad37ad-984d-4c65-a019-3eb120c9c373',{\"gender\":\"M\",\"birthdate\":\"1997-01-13\"})",
-            "caption": "a person"
+            "description": "update('person/3cad37ad-984d-4c65-a019-3eb120c9c373', {\n  'gender': 'M',\n  'birthdate':'1997-01-13'\n})",
+            "caption": "Update a person (<a href=\"https://rest.openmrs.org/#create-a-person\">see OpenMRS API</a>)"
           }
         ]
       },
@@ -193,7 +223,7 @@
         "data"
       ],
       "docs": {
-        "description": "Upsert a record. A generic helper function used to atomically either insert a row, or on the basis of the row already existing, UPDATE that existing row instead.",
+        "description": "Upsert a record. If the resource exists, it will be updated. Otherwise, a new resource will be created.",
         "tags": [
           {
             "title": "public",
@@ -207,7 +237,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource (excluding /ws/rest/v1/)",
+            "description": "Path to resource (excluding `/ws/rest/v1/`)",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -216,7 +246,7 @@
           },
           {
             "title": "param",
-            "description": "The data to use for update or create depending on the result of the query.",
+            "description": "The resource data",
             "type": {
               "type": "NameExpression",
               "name": "Object"
@@ -224,12 +254,8 @@
             "name": "data"
           },
           {
-            "title": "throws",
-            "description": "Throws range error",
-            "type": {
-              "type": "NameExpression",
-              "name": "RangeError"
-            }
+            "title": "state",
+            "description": "{HttpState}"
           },
           {
             "title": "returns",
@@ -241,13 +267,8 @@
           },
           {
             "title": "example",
-            "description": "upsert('patient', { q: '10007JJ' }, { person: { age: 50 } });",
-            "caption": "For an existing patient using upsert"
-          },
-          {
-            "title": "example",
-            "description": "upsert(\n  \"patient\",\n  { q: \"1000EHE\" },\n  {\n    identifiers: [\n      {\n        identifier: \"1000EHE\",\n        identifierType: \"05a29f94-c0ed-11e2-94be-8c13b969e334\",\n        location: \"44c3efb0-2583-4c80-a79e-1f756a03c0a1\",\n        preferred: true,\n      },\n    ],\n    person: {\n      gender: \"M\",\n      age: 42,\n    },\n  }\n);",
-            "caption": "For non existing patient creating a patient record using upsert"
+            "description": "upsert(\"patient/a5d38e09-efcb-4d91-a526-50ce1ba5011a\", {\n  identifiers: [\n    {\n      identifier: '4023287',\n      identifierType: '05a29f94-c0ed-11e2-94be-8c13b969e334',\n      preferred: true,\n    },\n  ],\n  person: {\n    gender: 'M',\n    age: 42,\n    birthdate: '1970-01-01T00:00:00.000+0100',\n    birthdateEstimated: false,\n    names: [\n      {\n        givenName: 'Doe',\n        familyName: 'John',\n      },\n    ],\n  },\n})",
+            "caption": "Upsert a patient"
           }
         ]
       },

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -35,11 +35,15 @@ export function execute(...operations) {
 
 /**
  * Make a get request to any OpenMRS REST endpoint.
- * @example <caption>Get a patient by UUID</caption>
+ * @example <caption>List all patients</caption>
+ * get("/patient")
+ * @example <caption>List patients by name with a limit</caption>
+ * get("/patient", { query: { q: "brian", limit: 1 }})
+ * @example <caption>List patient by UUID</caption>
  * get("/patient/abc")
- * @example <caption>Get a patient with query and limit</caption>
- * get("/patient", {query: {q: 'Jon', limit: 1}})
- * @example <caption>Get an allergy subresource by its UUID and parent patient UUID</caption>
+ * @example <caption>List allergy subresources</caption>
+ * get("/patient/abc/allergy")
+ * @example <caption>List allergy subresource by its UUID and parent patient UUID</caption>
  * get("/patient/abc/allergy/xyz")
  * @function
  * @public

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -234,27 +234,8 @@ export function update(path, data) {
  * @param {Object} data - The data to use for update or create depending on the result of the query.
  * @state {HttpState}
  * @returns {Operation}
- * @example <caption>For an existing patient using upsert</caption>
- * upsert('patient', { q: '10007JJ' }, { person: { age: 50 } });
- * @example <caption>For non existing patient creating a patient record using upsert </caption>
- * upsert(
- *   "patient",
- *   { q: "1000EHE" },
- *   {
- *     identifiers: [
- *       {
- *         identifier: "1000EHE",
- *         identifierType: "05a29f94-c0ed-11e2-94be-8c13b969e334",
- *         location: "44c3efb0-2583-4c80-a79e-1f756a03c0a1",
- *         preferred: true,
- *       },
- *     ],
- *     person: {
- *       gender: "M",
- *       age: 42,
- *     },
- *   }
- * );
+ * @example <caption>Upsert patient</caption>
+ * upsert('patient/b52ec6f9-0e26-424c-a4a1-c64f9d571eb3', { person: { age: 50 }});
  */
 export function upsert(path,  data) {
   return async state => {

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -3,6 +3,14 @@ import { expandReferences } from '@openfn/language-common/util';
 import { request, prepareNextState, cleanPath } from './Utils';
 
 /**
+ * State object
+ * @typedef {object} HttpState
+ * @property data - The parsed response body
+ * @property response - The response from the OpenMRS server, including headers, statusCode, body, etc
+ * @property references  - An array of all previous data objects used in the job
+ */
+
+/**
  * Execute a sequence of operations.
  * Wraps `language-common/execute`, and prepends initial state for OpenMRS.
  * @example
@@ -37,6 +45,7 @@ export function execute(...operations) {
  * @public
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
  * @param {RequestOptions}  [options={}] - An object containing query, headers, and body for the request. See {@link https://rest.openmrs.org/ OpenMRS Rest API docs} for available query parameters
+ * @state {HttpState}
  * @returns {Operation}
  */
 export function get(path, options) {
@@ -74,6 +83,7 @@ export function get(path, options) {
  * @function
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
  * @param {object} data - Object which defines data that will be used to create a given instance of resource
+ * @state {HttpState}
  * @returns {Operation}
  * @example <caption>Create a person</caption>
  * create("person", {
@@ -164,6 +174,7 @@ export function create(path, data) {
  * @function
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
  * @param {Object} data - Data to update. It requires to send `all required fields` or the `full body`. If you want `partial updates`, use `patch` operation.
+ * @state {HttpState}
  * @returns {Operation}
  * @example <caption>a person</caption>
  * update('person/3cad37ad-984d-4c65-a019-3eb120c9c373',{"gender":"M","birthdate":"1997-01-13"})
@@ -202,6 +213,7 @@ export function update(path, data) {
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
  * @param {Object} data - The data to use for update or create depending on the result of the query.
  * @throws {RangeError} - Throws range error
+ * @state {HttpState}
  * @returns {Operation}
  * @example <caption>For an existing patient using upsert</caption>
  * upsert('patient', { q: '10007JJ' }, { person: { age: 50 } });
@@ -270,6 +282,7 @@ export function upsert(path,  data) {
  * @public
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
  * @param {RequestOptions}  [options={}] - An object containing query, headers, and body for the request. See {@link https://rest.openmrs.org/ OpenMRS Rest API docs} for available query parameters
+ * @state {HttpState}
  * @returns {Operation}
  */
 function _delete(path, options) {

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -185,6 +185,7 @@ export function create(path, data) {
  * @param {string} path - Path to resource (excluding `/ws/rest/v1/`)
  * @param {Object} data - Resource properties to update
  * @state {HttpState}
+ * @state data The updated resource
  * @returns {Operation}
  * @example <caption>Update a person (<a href="https://rest.openmrs.org/#create-a-person">see OpenMRS API</a>)</caption>
  * update('person/3cad37ad-984d-4c65-a019-3eb120c9c373', {
@@ -222,6 +223,7 @@ export function update(path, data) {
  * @param {string} path - Path to resource (excluding `/ws/rest/v1/`)
  * @param {Object} data - The resource data
  * @state {HttpState}
+ * @state data The updated or newly created resource
  * @returns {Operation}
  * @example <caption>Upsert a patient (<a href="https://rest.openmrs.org/#patients-overview">see OpenMRS API</a>)</caption>
  * upsert("patient/a5d38e09-efcb-4d91-a526-50ce1ba5011a", {

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -50,7 +50,7 @@ export function execute(...operations) {
  * refer to {@link https://rest.openmrs.org/ OpenMRS Docs} for details.
  * @example <caption>List all patients</caption>
  * get("patient")
- * @example <caption>List patients by name with a limit(<a href="https://rest.openmrs.org/#search-patients">see OpenMRS API</a>)</caption>
+ * @example <caption>Search patients by name with a limit (<a href="https://rest.openmrs.org/#search-patients">see OpenMRS API</a>)</caption>
  * get("patient", { q: "brian", limit: 1 })
  * @example <caption>Fetch patient by UUID</caption>
  * get("patient/abc")
@@ -117,7 +117,7 @@ export function get(path, options) {
  *     },
  *   ],
  * });
- * @example <caption>Create an encounter</caption>
+ * @example <caption>Create an encounter (<a href="https://rest.openmrs.org/#create-an-encounter">see OpenMRS API</a>)</caption>
  * create("encounter", {
  *   encounterDatetime: '2023-05-25T06:08:25.000+0000',
  *   patient: '1fdaa696-e759-4a7d-a066-f1ae557c151b',
@@ -131,7 +131,7 @@ export function get(path, options) {
  *     stopDatetime: '2023-05-25T06:09:25.000+0000',
  *   },
  * })
- * @example <caption>Create a patient</caption>
+ * @example <caption>Create a patient (<a href="https://rest.openmrs.org/#create-a-patient">see OpenMRS API</a>)</caption>
  * create("patient", {
  *   identifiers: [
  *     {
@@ -223,7 +223,7 @@ export function update(path, data) {
  * @param {Object} data - The resource data
  * @state {HttpState}
  * @returns {Operation}
- * @example <caption>Upsert a patient</caption>
+ * @example <caption>Upsert a patient (<a href="https://rest.openmrs.org/#patients-overview">see OpenMRS API</a>)</caption>
  * upsert("patient/a5d38e09-efcb-4d91-a526-50ce1ba5011a", {
  *   identifiers: [
  *     {

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -64,7 +64,7 @@ export function execute(...operations) {
  * @function
  * @public
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
- * @param {OpenMRSRequestOptions}
+ * @param {OpenMRSRequestOptions} [options = {}]
  * @state {HttpState}
  * @returns {Operation}
  */
@@ -300,7 +300,7 @@ export function upsert(path,  data) {
  * @function
  * @public
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
- * @param {OpenMRSRequestOptions}
+ * @param {OpenMRSRequestOptions}  [options = {}]
  * @state {HttpState}
  * @returns {Operation}
  */

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -232,7 +232,6 @@ export function update(path, data) {
  * @function
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
  * @param {Object} data - The data to use for update or create depending on the result of the query.
- * @throws {RangeError} - Throws range error
  * @state {HttpState}
  * @returns {Operation}
  * @example <caption>For an existing patient using upsert</caption>

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -11,6 +11,22 @@ import { request, prepareNextState, cleanPath } from './Utils';
  */
 
 /**
+ * OpenMRS query object. This is a brief overview with commonly used parameters that cut across multiple requests. For more details about parameters specific to your request visit the [official docs](https://rest.openmrs.org/)
+ * @typedef {object} OpenMRSQueryObject query parameters
+ * @property {string} q - Search by query for listings
+ * @property {number} limit - Number of listings returned in the `results` array.
+ * @property {boolean} purge - For delete operations only. Use with caution! The resource will be voided unless purge = true. Purging will attempt to remove the resource irreversibly. Resources that are referenced from existing data can not be purged.
+ * @property {number} startindex - Commonly used with `query.q` and `query.limit` for pagination to position the cursor.
+ * @property {boolean} includeAll - Include voided/retired/disabled resources in the response.
+ */
+
+/**
+ * OpenMRS Options.
+ * @typedef {object} OpenMRSRequestOptions
+ * @property {OpenMRSQueryObject} query - Query params object
+ */
+
+/**
  * Execute a sequence of operations.
  * Wraps `language-common/execute`, and prepends initial state for OpenMRS.
  * @example
@@ -48,7 +64,7 @@ export function execute(...operations) {
  * @function
  * @public
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
- * @param {RequestOptions}  [options={}] - An object containing query, headers, and body for the request. See {@link https://rest.openmrs.org/ OpenMRS Rest API docs} for available query parameters
+ * @param {OpenMRSRequestOptions}
  * @state {HttpState}
  * @returns {Operation}
  */
@@ -285,7 +301,7 @@ export function upsert(path,  data) {
  * @function
  * @public
  * @param {string} path - Path to resource (excluding /ws/rest/v1/)
- * @param {RequestOptions}  [options={}] - An object containing query, headers, and body for the request. See {@link https://rest.openmrs.org/ OpenMRS Rest API docs} for available query parameters
+ * @param {OpenMRSRequestOptions}
  * @state {HttpState}
  * @returns {Operation}
  */

--- a/packages/openmrs/src/Utils.js
+++ b/packages/openmrs/src/Utils.js
@@ -8,7 +8,7 @@ import {
 export const prepareNextState = (state, response, callback = s => s) => {
   const { body, ...responseWithoutBody } = response;
   const nextState = {
-    ...composeNextState(state, response.body),
+    ...composeNextState(state, body),
     response: responseWithoutBody,
   };
 
@@ -87,7 +87,6 @@ export async function request(state, method, path, options = {}) {
 
   return allResponses;
 }
-
 
 export function cleanPath(path) {
   return path

--- a/packages/openmrs/src/fhir.js
+++ b/packages/openmrs/src/fhir.js
@@ -38,6 +38,7 @@ import { prepareNextState } from './Utils';
  * @param {string} path - Path to resource
  * @param {FhirParameters} query - Request parameters
  * @param {function} [callback] - Optional callback to handle the response
+ * @state {HttpState}
  * @returns {Operation}
  */
 export function get(path, query, callback = s => s) {

--- a/packages/openmrs/src/http.js
+++ b/packages/openmrs/src/http.js
@@ -25,6 +25,7 @@ import * as util from './Utils';
  * @param {string} method - HTTP method to use
  * @param {string} path - Path to resource
  * @param {RequestOptions}  [options={}] - An object containing query, headers, and body for the request
+ * @state {HttpState}
  * @returns {Operation}
  */
 export function request(method, path, options = {}) {
@@ -59,6 +60,7 @@ export function request(method, path, options = {}) {
  *  )
  * @param {string} path - path to resource
  * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
+ * @state {HttpState}
  * @returns {operation}
  */
 export function get(path, options = {}) {
@@ -96,6 +98,7 @@ export function get(path, options = {}) {
  * @param {string} path - path to resource
  * @param {any} data - the payload
  * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
+ * @state {HttpState}
  * @returns {operation}
  */
 export function post(path, data, options = {}) {
@@ -124,6 +127,7 @@ export function post(path, data, options = {}) {
  * )
  * @param {string} path - path to resource
  * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
+ * @state {HttpState}
  * @returns {operation}
  */
  function _delete(path, options = {}) {

--- a/packages/openmrs/src/http.js
+++ b/packages/openmrs/src/http.js
@@ -3,11 +3,11 @@ import * as util from './Utils';
 
 /**
  * Options object
- * @typedef {Object} RequestOptions
+ * @typedef {Object} HTTPRequestOptions
  * @property {object} query - An object of query parameters to be encoded into the URL
  * @property {object} headers - An object of all request headers
  * @property {object} body - The request body (as JSON)
- * @property {string} [parseAs='json'] - The response format to parse (e.g., 'json', 'text', or 'stream')
+ * @property {string} [parseAs=json] - The response format to parse (e.g., 'json', 'text', or 'stream')
  */
 
 /**
@@ -15,16 +15,16 @@ import * as util from './Utils';
  * @example <caption>GET request with a URL query</caption>
  * http.request("GET",
  *   "/ws/rest/v1/patient/d3f7e1a8-0114-4de6-914b-41a11fc8a1a8", {
- *    query:{ 
- *       limit: 1, 
- *       offset: 20 
+ *    query:{
+ *       limit: 1,
+ *       offset: 20
  *    },
  * });
  * @function
  * @public
  * @param {string} method - HTTP method to use
  * @param {string} path - Path to resource
- * @param {RequestOptions}  [options={}] - An object containing query, headers, and body for the request
+ * @param {HTTPRequestOptions}  [options={}] - An object containing query, headers, and body for the request
  * @state {HttpState}
  * @returns {Operation}
  */
@@ -59,20 +59,28 @@ export function request(method, path, options = {}) {
  *  }
  *  )
  * @param {string} path - path to resource
- * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
+ * @param {HTTPRequestOptions} [options={}] - An object containing query params and headers for the request
  * @state {HttpState}
  * @returns {operation}
  */
 export function get(path, options = {}) {
   return async state => {
-    const [resolvedPath, resolvedOptions] = expandReferences(state, path, options);
+    const [resolvedPath, resolvedOptions] = expandReferences(
+      state,
+      path,
+      options
+    );
 
-    const response = await util.request(state, 'GET', resolvedPath, resolvedOptions);
+    const response = await util.request(
+      state,
+      'GET',
+      resolvedPath,
+      resolvedOptions
+    );
 
     return util.prepareNextState(state, response);
   };
 }
-
 
 /**
  * Make a POST request to an OpenMRS endpoint
@@ -97,24 +105,33 @@ export function get(path, options = {}) {
  * )
  * @param {string} path - path to resource
  * @param {any} data - the payload
- * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
+ * @param {HTTPRequestOptions} [options={}] - An object containing query params and headers for the request
  * @state {HttpState}
  * @returns {operation}
  */
 export function post(path, data, options = {}) {
-  return  async state => {
-    const [resolvedPath, resolvedData, resolvedOptions] = expandReferences(state, path, data, options);
+  return async state => {
+    const [resolvedPath, resolvedData, resolvedOptions] = expandReferences(
+      state,
+      path,
+      data,
+      options
+    );
 
     const optionsObject = {
       data: resolvedData,
-      ...resolvedOptions
-    }
-    const response = await util.request(state, 'POST', resolvedPath, optionsObject);
+      ...resolvedOptions,
+    };
+    const response = await util.request(
+      state,
+      'POST',
+      resolvedPath,
+      optionsObject
+    );
 
     return util.prepareNextState(state, response);
-  }
+  };
 }
-
 
 /**
  * Make a DELETE request to an OpenMRS endpoint
@@ -126,18 +143,27 @@ export function post(path, data, options = {}) {
  *  "/ws/rest/v1/patient/abc/"
  * )
  * @param {string} path - path to resource
- * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
+ * @param {HTTPRequestOptions} [options={}] - An object containing query params and headers for the request
  * @state {HttpState}
  * @returns {operation}
  */
- function _delete(path, options = {}) {
-  return  async state => {
-    const [resolvedPath, resolvedOptions] = expandReferences(state, path, options);
+function _delete(path, options = {}) {
+  return async state => {
+    const [resolvedPath, resolvedOptions] = expandReferences(
+      state,
+      path,
+      options
+    );
 
-    const response = await util.request(state, 'DELETE', resolvedPath, resolvedOptions);
+    const response = await util.request(
+      state,
+      'DELETE',
+      resolvedPath,
+      resolvedOptions
+    );
 
     return util.prepareNextState(state, response);
-  }
+  };
 }
 
 export { _delete as delete };


### PR DESCRIPTION
## Summary

OpenMRS docs don't currently give you a lot of help with query APIs

Fixes #492 

## Details

- add `@state` annotations to every function (including the http and fhir namespace).

- make sure the get() function makes sense and has examples of getting a list, searching a list by name, getting a single resource, and getting a subresource.

- Add a dedicated typedef for OpenMRS request params

- Remove `throw` declaration in `upsert` docbloc

- Update `upsert` examples signatures

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
