### PR TITLE
odoo: default `create` options to `{}` and remove logs

### DIFF
--- a/.changeset/cool-actors-argue.md
+++ b/.changeset/cool-actors-argue.md
@@ -2,5 +2,6 @@
 '@openfn/language-odoo': patch
 ---
 
-Default `create()` to `{}` and update logs to a descriptive message:
-`Creating a res.partner resource...`
+Default `create()` options to `{}` to ensure that the options argument is optional.
+
+

--- a/.changeset/cool-actors-argue.md
+++ b/.changeset/cool-actors-argue.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-odoo': patch
+---
+
+Default `create()` to `{}` and update logs to a descriptive message:
+`Creating a res.partner resource...`

--- a/.changeset/long-parents-fly.md
+++ b/.changeset/long-parents-fly.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-odoo': patch
+---
+
+Simplified logging across the adaptor without displaying user data

--- a/packages/odoo/ast.json
+++ b/packages/odoo/ast.json
@@ -17,7 +17,8 @@
           },
           {
             "title": "example",
-            "description": "create(\"res.partner\", { name: \"Kool Keith\" }, {externalId: 23});"
+            "description": "create(\"res.partner\", { name: \"Kool Keith\" }, {externalId: 23});",
+            "caption": "Create a partner record with an external Id"
           },
           {
             "title": "function",
@@ -44,7 +45,7 @@
           },
           {
             "title": "param",
-            "description": "Optional external ID for the record.",
+            "description": "Options to send to the request. Includes an optional external ID for the record.",
             "type": {
               "type": "NameExpression",
               "name": "object"

--- a/packages/odoo/src/Adaptor.js
+++ b/packages/odoo/src/Adaptor.js
@@ -62,15 +62,15 @@ async function login(state) {
 /**
  * Create a record in Odoo
  * @public
- * @example
+ * @example <caption> Create a partner record with an external Id</caption>
  * create("res.partner", { name: "Kool Keith" }, {externalId: 23});
  * @function
  * @param {string} model - The specific record model i.e. "res.partner"
  * @param {object} data - The data to be created in JSON.
- * @param {object} options - Optional external ID for the record.
+ * @param {object} options - Options to send to the request. Includes an optional external ID for the record.
  * @returns {Operation}
  */
-export function create(model, data, options) {
+export function create(model, data, options = {}) {
   return async state => {
     const [resolvedModel, resolvedData, resolvedOptions] = expandReferences(
       state,
@@ -79,11 +79,12 @@ export function create(model, data, options) {
       options
     );
 
-    console.log(resolvedModel, resolvedData, resolvedOptions);
+    console.log(`Creating a ${resolvedModel} resource...`);
+
     const response = await odooConn.create(
       resolvedModel,
       resolvedData,
-      resolvedOptions.externalId
+      resolvedOptions?.externalId
     );
 
     return composeNextState(state, response);
@@ -111,8 +112,7 @@ export function read(model, recordId, fields = []) {
       recordId,
       fields
     );
-
-    console.log(resolvedModel, resolvedRecordId, resolvedFields);
+    console.log(`Reading a ${resolvedModel} resource...`);
     const response = await odooConn.read(
       resolvedModel,
       resolvedRecordId,
@@ -142,7 +142,7 @@ export function update(model, recordId, data) {
       data
     );
 
-    console.log(resolvedModel, resolvedRecordId, resolvedData);
+    console.log(`Updating a ${resolvedModel} resource...`);
     const response = await odooConn.update(
       resolvedModel,
       resolvedRecordId,
@@ -170,7 +170,8 @@ export function deleteRecord(model, recordId) {
       recordId
     );
 
-    console.log(resolvedModel, resolvedRecordId);
+    console.log(`Deleting a ${resolvedModel} resource...`);
+
     const response = await odooConn.delete(resolvedModel, resolvedRecordId);
     return composeNextState(state, response);
   };


### PR DESCRIPTION
## Summary

Default the `create()` function in `odoo` to  `{ }`. Update the logs to a more descriptive sentence such as `Creating a res.partner resource...` 

Fixes #1010

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
