### PR TITLE
odoo: Fix `read()` docs example to show fields as string array

### DIFF
--- a/.changeset/strong-apples-stare.md
+++ b/.changeset/strong-apples-stare.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-odoo': patch
+---
+
+Update the third argument in `read()` examples and documentation to explicitly
+indicate that it accepts an array of strings.

--- a/packages/odoo/src/Adaptor.js
+++ b/packages/odoo/src/Adaptor.js
@@ -94,13 +94,13 @@ export function create(model, data, options) {
  * Get a record from Odoo. Returns all fields unless a field list is provided as a third argument
  * @public
  * @example <caption>Download records with select fields</caption>
- * read("res.partner", [1] , [name]);
+ * read("res.partner", [1] , ['name']);
  * @example <caption>Download a single record with all fields</caption>
  * read("res.partner", $.recordIds);
  * @function
  * @param {string} model - The specific record model from i.e. "res.partner"
  * @param {number} recordId - An array of record IDs to read.
- * @param {string} fields - An optional array of fields to read from the record.
+ * @param {string[]} fields - An optional array of field strings to read from the record.
  * @returns {Operation}
  */
 export function read(model, recordId, fields = []) {


### PR DESCRIPTION
## Summary

Fix `read` docs example in `odoo` to ensure that fields in the examples are strings.

Fixes #1009

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
