### PR TITLE
http: control and default contentType

### DIFF
--- a/.changeset/curly-mirrors-appear.md
+++ b/.changeset/curly-mirrors-appear.md
@@ -1,0 +1,15 @@
+---
+'@openfn/language-http': major
+---
+
+- Add contentType option for automatic `Content-Type` header allocation.
+- Add `Content-Type` header to the response.
+
+
+## Breaking Changes
+
+All the functions in the `http` adaptor would require a header object to be sent to the `options` field. 
+
+In this new change, we are allowing the user to either pass in a header with the desired `Content-Type` or pass in a value in the `contentType` option. 
+
+If `Content-Type` is passed, we will use the value sent, else automatically create it based on the value sent in `contentType` with the default being `json`.

--- a/.changeset/curly-planets-laugh.md
+++ b/.changeset/curly-planets-laugh.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-http': patch
----
-
-Add contentType option for automatic `Content-Type` header allocation.

--- a/.changeset/curly-planets-laugh.md
+++ b/.changeset/curly-planets-laugh.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-http': patch
+---
+
+Add contentType option for automatic `Content-Type` header allocation.

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -6,7 +6,7 @@ import { request as sendRequest, xmlParser } from './util';
  * @typedef {Object} RequestOptions
  * @public
  * @property {object} errors - Map of errorCodes -> error messages, ie, `{ 404: 'Resource not found;' }`. Pass `false` to suppress errors for this code.
- * @property {string} contentType - Specifies the `Content-Type` for the request. Defaults to `json`. Supported values: `json`, `xml`, `string`, and `form` (for FormData).
+ * @property {string} contentType - Sets the `Content-Type` header on the request. Defaults to `json`. Supported values: `json`, `xml`, `string`, and `form` (for FormData).
  * @property {object|string} body - body data to append to the request. JSON will be converted to a string (but a content-type header will not be attached to the request).This is only applicable to the request function
  * @property {object} query - An object of query parameters to be encoded into the URL.
  * @property {object} headers - An object of headers to append to the request.

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -6,7 +6,7 @@ import { request as sendRequest, xmlParser } from './util';
  * @typedef {Object} RequestOptions
  * @public
  * @property {object} errors - Map of errorCodes -> error messages, ie, `{ 404: 'Resource not found;' }`. Pass `false` to suppress errors for this code.
- * @property {string} contentType - Resolves to the respective content-type header for the data being sent. Default is `json`. Values to be sent include `xml`, `string`, 'form' for FormData and `json`.
+ * @property {string} contentType - Specifies the `Content-Type` for the request. Defaults to `json`. Supported values: `json`, `xml`, `string`, and `form` (for FormData).
  * @property {object|string} body - body data to append to the request. JSON will be converted to a string (but a content-type header will not be attached to the request).This is only applicable to the request function
  * @property {object} query - An object of query parameters to be encoded into the URL.
  * @property {object} headers - An object of headers to append to the request.

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -6,7 +6,7 @@ import { request as sendRequest, xmlParser } from './util';
  * @typedef {Object} RequestOptions
  * @public
  * @property {object} errors - Map of errorCodes -> error messages, ie, `{ 404: 'Resource not found;' }`. Pass `false` to suppress errors for this code.
- * @property {boolean} form - Set to `true` if the body data is multipart HTML form (as FormData).
+ * @property {string} contentType - Resolves to the respective content-type header for the data being sent. Default is `json`. Values to be sent include `xml`, `string`, 'form' for FormData and `json`.
  * @property {object|string} body - body data to append to the request. JSON will be converted to a string (but a content-type header will not be attached to the request).This is only applicable to the request function
  * @property {object} query - An object of query parameters to be encoded into the URL.
  * @property {object} headers - An object of headers to append to the request.

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -72,16 +72,26 @@ export function request(method, path, params, callback = s => s) {
 
     let { body, contentType = 'json', headers = {} } = resolvedParams;
 
-    const hasContentType = Object.keys(headers).some(
+    const contentTypeKey = Object.keys(headers).find(
       key => key.toLowerCase() === 'content-type'
     );
+
+    const hasContentType = !!contentTypeKey;
+    const contentTypeValue = hasContentType ? headers[contentTypeKey] : '';
 
     if (hasContentType) {
       headers = { ...headers };
     } else if (contentType === 'form') {
       body = encodeFormBody(body);
     } else {
-      headers = { ...headers, 'Content-Type': CONTENT_TYPES[contentType] };
+      headers = {
+        ...headers,
+        'Content-Type': CONTENT_TYPES[contentType] || 'application/json',
+      };
+    }
+
+    if (contentTypeValue.toLowerCase().includes('multipart/form-data')) {
+      body = encodeFormBody(body);
     }
 
     const baseUrl = state.configuration?.baseUrl;

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -72,14 +72,17 @@ export function request(method, path, params, callback = s => s) {
 
     let { body, contentType = 'json', headers = {} } = resolvedParams;
 
-    const hasContentType = Object.keys(headers).some(
+    const hasContentType = Object.keys(headers).find(
       key => key.toLowerCase() === 'content-type'
     );
 
-    if (hasContentType) {
+    if (contentType === 'form') {
+      delete headers[hasContentType];
       headers = { ...headers };
-    } else if (contentType === 'form') {
+
       body = encodeFormBody(body);
+    } else if (hasContentType) {
+      headers = { ...headers };
     } else {
       headers = {
         ...headers,

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -72,19 +72,11 @@ export function request(method, path, params, callback = s => s) {
 
     let { body, contentType = 'json', headers = {} } = resolvedParams;
 
-    const contentTypeKey = Object.keys(headers).find(
+    const hasContentType = Object.keys(headers).some(
       key => key.toLowerCase() === 'content-type'
     );
 
-    const hasContentType = contentTypeKey && headers[contentTypeKey];
-
-    const contentTypeValue = hasContentType
-      ? headers[contentTypeKey].toLowerCase()
-      : '';
-
-    const shouldEncodeForm =
-      (!hasContentType && contentType === 'form') ||
-      contentTypeValue.includes('multipart/form-data');
+    const shouldEncodeForm = !hasContentType && contentType === 'form';
 
     if (shouldEncodeForm) {
       body = encodeFormBody(body);

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -76,13 +76,11 @@ export function request(method, path, params, callback = s => s) {
       key => key.toLowerCase() === 'content-type'
     );
 
-    const shouldEncodeForm = !hasContentType && contentType === 'form';
-
-    if (shouldEncodeForm) {
+    if (hasContentType) {
+      headers = { ...headers };
+    } else if (contentType === 'form') {
       body = encodeFormBody(body);
-    }
-
-    if (!hasContentType && !shouldEncodeForm) {
+    } else {
       headers = {
         ...headers,
         'Content-Type': CONTENT_TYPES[contentType] || 'application/json',

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -76,22 +76,25 @@ export function request(method, path, params, callback = s => s) {
       key => key.toLowerCase() === 'content-type'
     );
 
-    const hasContentType = !!contentTypeKey;
-    const contentTypeValue = hasContentType ? headers[contentTypeKey] : '';
+    const hasContentType = contentTypeKey && headers[contentTypeKey];
 
-    if (hasContentType) {
-      headers = { ...headers };
-    } else if (contentType === 'form') {
+    const contentTypeValue = hasContentType
+      ? headers[contentTypeKey].toLowerCase()
+      : '';
+
+    const shouldEncodeForm =
+      (!hasContentType && contentType === 'form') ||
+      contentTypeValue.includes('multipart/form-data');
+
+    if (shouldEncodeForm) {
       body = encodeFormBody(body);
-    } else {
+    }
+
+    if (!hasContentType && !shouldEncodeForm) {
       headers = {
         ...headers,
         'Content-Type': CONTENT_TYPES[contentType] || 'application/json',
       };
-    }
-
-    if (contentTypeValue.toLowerCase().includes('multipart/form-data')) {
-      body = encodeFormBody(body);
     }
 
     const baseUrl = state.configuration?.baseUrl;

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -72,8 +72,12 @@ export function request(method, path, params, callback = s => s) {
 
     let { body, contentType = 'json', headers = {} } = resolvedParams;
 
-    if (resolvedParams.headers) {
-      headers = { ...headers, ...resolvedParams.headers };
+    const hasContentType = Object.keys(headers).some(
+      key => key.toLowerCase() === 'content-type'
+    );
+
+    if (hasContentType) {
+      headers = { ...resolvedParams.headers };
     } else if (contentType === 'form') {
       body = encodeFormBody(body);
     } else {

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -72,16 +72,16 @@ export function request(method, path, params) {
 
     let { body, contentType = 'json', headers = {} } = resolvedParams;
 
-    const hasContentType = Object.keys(headers).find(
+    const contentTypeHeader = Object.keys(headers).find(
       key => key.toLowerCase() === 'content-type'
     );
 
     if (contentType === 'form') {
-      delete headers[hasContentType];
+      delete headers[contentTypeHeader];
       headers = { ...headers };
 
       body = encodeFormBody(body);
-    } else if (hasContentType) {
+    } else if (contentTypeHeader) {
       headers = { ...headers };
     } else {
       headers = {

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -77,7 +77,7 @@ export function request(method, path, params, callback = s => s) {
     );
 
     if (hasContentType) {
-      headers = { ...resolvedParams.headers };
+      headers = { ...headers };
     } else if (contentType === 'form') {
       body = encodeFormBody(body);
     } else {

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -51,6 +51,12 @@ const assertUrl = (pathOrUrl, baseUrl) => {
   }
 };
 
+export const CONTENT_TYPES = {
+  xml: 'application/xml',
+  json: 'application/json',
+  string: 'text/plain',
+};
+
 /**
  * Request helper function
  * @function
@@ -64,10 +70,14 @@ export function request(method, path, params, callback = s => s) {
       params
     );
 
-    let { body, headers = { 'Content-Type': 'application/json' } } = resolvedParams;
+    let { body, contentType = 'json', headers = {} } = resolvedParams;
 
-    if (resolvedParams.form) {
+    if (resolvedParams.headers) {
+      headers = { ...headers, ...resolvedParams.headers };
+    } else if (contentType === 'form') {
       body = encodeFormBody(body);
+    } else {
+      headers = { ...headers, 'Content-Type': CONTENT_TYPES[contentType] };
     }
 
     const baseUrl = state.configuration?.baseUrl;

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -516,6 +516,95 @@ describe('get()', () => {
   });
 });
 
+describe('contentType', () => {
+  it('should use "Content-Type" header if both contentType and headers are provided', async () => {
+    let req;
+    testServer
+      .intercept({
+        path: '/api/fake-json',
+        method: 'POST',
+      })
+      .reply(200, r => {
+        req = r;
+        return { id: 1, name: 'a', age: 42 };
+      });
+    const state = {
+      configuration: {},
+    };
+
+    const response = await execute(
+      post(
+        'https://www.example.com/api/fake-json',
+        { name: 'a', age: 42 },
+        { headers: { 'Content-Type': 'application/json' }, contentType: 'form' }
+      )
+    )(state);
+
+    expect(req.body).to.equal(JSON.stringify({ name: 'a', age: 42 }));
+    expect(JSON.parse(response.data).id).to.eql(1);
+    expect(req.headers['Content-Type']).to.equal('application/json');
+  });
+
+  it('should handle invalid contentType and default to application/json', async () => {
+    let req;
+    testServer
+      .intercept({
+        path: '/api/fake-json',
+        method: 'POST',
+      })
+      .reply(200, r => {
+        req = r;
+        return { id: 1, name: 'a', age: 42 };
+      });
+    const state = {
+      configuration: {},
+    };
+
+    const response = await execute(
+      post(
+        'https://www.example.com/api/fake-json',
+        { name: 'a', age: 42 },
+        { contentType: 'file' }
+      )
+    )(state);
+
+    expect(req.body).to.equal(JSON.stringify({ name: 'a', age: 42 }));
+    expect(JSON.parse(response.data).id).to.eql(1);
+    expect(req.headers['Content-Type']).to.equal('application/json');
+  });
+
+  it('should handle multipart/form-data if sent in the headers ', async () => {
+    let req;
+    testServer
+      .intercept({
+        path: '/api/fake-json',
+        method: 'POST',
+      })
+      .reply(200, r => {
+        req = r;
+        return { id: 1, name: 'a', age: 42 };
+      });
+    const state = {
+      configuration: {},
+    };
+
+    const response = await execute(
+      post(
+        'https://www.example.com/api/fake-json',
+        { name: 'a', age: 42 },
+        {
+          headers: { 'Content-Type': 'multipart/form-data' },
+          contentType: 'form',
+        }
+      )
+    )(state);
+
+    expect(req.body instanceof FormData).to.equal(true);
+    expect(JSON.parse(response.data).id).to.eql(1);
+    expect(req.headers['Content-Type']).to.equal('multipart/form-data');
+  });
+});
+
 describe('post', () => {
   it('post a JSON object', async () => {
     let req;

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -517,7 +517,7 @@ describe('get()', () => {
 });
 
 describe('contentType', () => {
-  it('should use "Content-Type" header if both contentType and headers are provided', async () => {
+  it('should prefer content-type header to contentType option', async () => {
     let req;
     testServer
       .intercept({

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -572,37 +572,6 @@ describe('contentType', () => {
     expect(JSON.parse(response.data).id).to.eql(1);
     expect(req.headers['Content-Type']).to.equal('application/json');
   });
-
-  it('should handle multipart/form-data if sent in the headers ', async () => {
-    let req;
-    testServer
-      .intercept({
-        path: '/api/fake-json',
-        method: 'POST',
-      })
-      .reply(200, r => {
-        req = r;
-        return { id: 1, name: 'a', age: 42 };
-      });
-    const state = {
-      configuration: {},
-    };
-
-    const response = await execute(
-      post(
-        'https://www.example.com/api/fake-json',
-        { name: 'a', age: 42 },
-        {
-          headers: { 'Content-Type': 'multipart/form-data' },
-          contentType: 'form',
-        }
-      )
-    )(state);
-
-    expect(req.body instanceof FormData).to.equal(true);
-    expect(JSON.parse(response.data).id).to.eql(1);
-    expect(req.headers['Content-Type']).to.equal('multipart/form-data');
-  });
 });
 
 describe('post', () => {

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -517,7 +517,7 @@ describe('get()', () => {
 });
 
 describe('contentType', () => {
-  it('should prefer content-type header to contentType option', async () => {
+  it('should prefer contentType option to content-type header', async () => {
     let req;
     testServer
       .intercept({
@@ -540,9 +540,8 @@ describe('contentType', () => {
       )
     )(state);
 
-    expect(req.body).to.equal(JSON.stringify({ name: 'a', age: 42 }));
+    expect(req.body instanceof FormData).to.equal(true);
     expect(JSON.parse(response.data).id).to.eql(1);
-    expect(req.headers['Content-Type']).to.equal('application/json');
   });
 
   it('should handle invalid contentType and default to application/json', async () => {
@@ -565,6 +564,35 @@ describe('contentType', () => {
         'https://www.example.com/api/fake-json',
         { name: 'a', age: 42 },
         { contentType: 'file' }
+      )
+    )(state);
+
+    
+    expect(req.body).to.equal(JSON.stringify({ name: 'a', age: 42 }));
+    expect(JSON.parse(response.data).id).to.eql(1);
+    expect(req.headers['Content-Type']).to.equal('application/json');
+  });
+
+  it('should use content-type header when given', async () => {
+    let req;
+    testServer
+      .intercept({
+        path: '/api/fake-json',
+        method: 'POST',
+      })
+      .reply(200, r => {
+        req = r;
+        return { id: 1, name: 'a', age: 42 };
+      });
+    const state = {
+      configuration: {},
+    };
+
+    const response = await execute(
+      post(
+        'https://www.example.com/api/fake-json',
+        { name: 'a', age: 42 },
+        { headers: { 'Content-Type': 'application/json' } }
       )
     )(state);
 

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -286,8 +286,10 @@ describe('get()', () => {
         headers: { 'x-openfn': 'testing' },
       })
     )(state);
-
-    expect(data).to.eql({ 'x-openfn': 'testing' });
+    expect(data).to.eql({
+      'x-openfn': 'testing',
+      'Content-Type': 'application/json',
+    });
   });
 
   it('sets up a basic auth header', async () => {
@@ -564,7 +566,7 @@ describe('post', () => {
 
     const { data } = await execute(
       post('https://www.example.com/api/form-data', formData, {
-        form: true,
+        contentType: 'form',
       })
     )({});
 


### PR DESCRIPTION
## Summary

Replace `form` with `contentType` in `http` to allow automatic content-header configuration. 

Fixes #1005 

## Details

The `http` adaptor processes different types of data such as `xml`, `json`, and `form`.
With these different types, we need to allow users to send which type of data they are sending, but we also need to have a default one set, hence using an options `contentType` that replaces `forms`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
