### PR TITLE
http:  strip callbacks

### DIFF
--- a/.changeset/great-candles-remember.md
+++ b/.changeset/great-candles-remember.md
@@ -7,7 +7,7 @@
 ## Migration Guide
 
 All functions in `http` allowed for the use of `callbacks` as the third option.
-We have stripped this and allow users to use promise chaining instead.
+We have stripped this and allowed users to use promise chaining instead.
 
 So if you used to do this:
 

--- a/.changeset/great-candles-remember.md
+++ b/.changeset/great-candles-remember.md
@@ -1,0 +1,28 @@
+---
+'@openfn/language-http': major
+---
+
+- Strip `callbacks` from `http`.
+
+## Migration Guide
+
+All functions in `http` allowed for the use of `callbacks` as the third option.
+We have stripped this and allow users to use promise chaining instead.
+
+So if you used to do this:
+
+```js
+post('/patient', { body: $.patient }, next => {
+  state.results.push(next.response.body);
+  return next;
+});
+```
+
+You must edit your code to do this:
+
+```js
+post('/patient', $.patient).then(next => {
+  state.results.push(next.response.body);
+  return next;
+});
+```

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -5,8 +5,7 @@
       "params": [
         "method",
         "path",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Make a HTTP request. If `configuration.baseUrl` is set, paths must be relative.",
@@ -53,15 +52,6 @@
             "name": "options"
           },
           {
-            "title": "param",
-            "description": "(Optional) Callback function",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "callback"
-          },
-          {
             "title": "state",
             "description": "{HttpState}"
           },
@@ -81,8 +71,7 @@
       "name": "get",
       "params": [
         "path",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Make a GET request. If `configuration.baseUrl` is set, paths must be relative.",
@@ -120,15 +109,6 @@
             "name": "options"
           },
           {
-            "title": "param",
-            "description": "(Optional) Callback function",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "callback"
-          },
-          {
             "title": "state",
             "description": "{HttpState}"
           },
@@ -149,8 +129,7 @@
       "params": [
         "path",
         "data",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Make a POST request. If `configuration.baseUrl` is set, paths must be relative.",
@@ -203,15 +182,6 @@
             "name": "options"
           },
           {
-            "title": "param",
-            "description": "(Optional) Callback function",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "callback"
-          },
-          {
             "title": "state",
             "description": "{HttpState}"
           },
@@ -232,8 +202,7 @@
       "params": [
         "path",
         "data",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Make a PUT request. If `configuration.baseUrl` is set, paths must be relative.",
@@ -286,15 +255,6 @@
             "name": "options-null"
           },
           {
-            "title": "param",
-            "description": "(Optional) Callback function",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "callback"
-          },
-          {
             "title": "state",
             "description": "{HttpState}"
           },
@@ -315,8 +275,7 @@
       "params": [
         "path",
         "data",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Make a PATCH request. If `configuration.baseUrl` is set, paths must be relative.",
@@ -369,15 +328,6 @@
             "name": "options"
           },
           {
-            "title": "param",
-            "description": "(Optional) Callback function",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "callback"
-          },
-          {
             "title": "state",
             "description": "{HttpState}"
           },
@@ -397,8 +347,7 @@
       "name": "del",
       "params": [
         "path",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Make a DELETE request. If `configuration.baseUrl` is set, paths must be relative.",
@@ -436,15 +385,6 @@
             "name": "options"
           },
           {
-            "title": "param",
-            "description": "(Optional) Callback function",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "callback"
-          },
-          {
             "title": "state",
             "description": "{HttpState}"
           },
@@ -464,8 +404,7 @@
       "name": "parseXML",
       "params": [
         "data",
-        "script",
-        "callback"
+        "script"
       ],
       "docs": {
         "description": "Parse XML with the Cheerio parser",
@@ -506,15 +445,6 @@
               "name": "function"
             },
             "name": "script"
-          },
-          {
-            "title": "param",
-            "description": "(Optional) Callback function",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "callback"
           },
           {
             "title": "state",

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -61,12 +61,11 @@ export function execute(...operations) {
  * @param {string} method - The HTTP method to use.
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} options - Body, Query, Headers and Authentication parameters
- * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function request(method, path, options, callback) {
-  return sendRequest(method, path, options, callback);
+export function request(method, path, options) {
+  return sendRequest(method, path, options);
 }
 
 /**
@@ -80,12 +79,11 @@ export function request(method, path, options, callback) {
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} options - Body, Query, Headers and Authentication parameters
- * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function get(path, options, callback) {
-  return sendRequest('GET', path, options, callback);
+export function get(path, options) {
+  return sendRequest('GET', path, options);
 }
 
 /**
@@ -101,13 +99,12 @@ export function get(path, options, callback) {
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {object} data - Body data to append to the request. JSON will be converted to a string.
  * @param {RequestOptions} options - Query, Headers and Authentication parameters
- * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {operation}
  */
 
-export function post(path, data, options, callback) {
-  return sendRequest('POST', path, { body: data, ...options }, callback);
+export function post(path, data, options) {
+  return sendRequest('POST', path, { body: data, ...options });
 }
 
 /**
@@ -123,12 +120,11 @@ export function post(path, data, options, callback) {
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {object} data - Body data to append to the request. JSON will be converted to a string.
  * @param {RequestOptions} options- Query, Headers and Auth parameters
- * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function put(path, data, options, callback) {
-  return sendRequest('PUT', path, { body: data, ...options }, callback);
+export function put(path, data, options) {
+  return sendRequest('PUT', path, { body: data, ...options });
 }
 
 /**
@@ -144,12 +140,11 @@ export function put(path, data, options, callback) {
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {object} data - Body data to append to the request. JSON will be converted to a string.
  * @param {RequestOptions} options - Query, Headers and Auth parameters
- * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function patch(path, data, options, callback) {
-  return sendRequest('PATCH', path, { body: data, ...options }, callback);
+export function patch(path, data, options) {
+  return sendRequest('PATCH', path, { body: data, ...options });
 }
 
 /**
@@ -160,12 +155,11 @@ export function patch(path, data, options, callback) {
  * @function
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.
  * @param {RequestOptions} options - Query, Headers and Auth parameters
- * @param {function} callback - (Optional) Callback function
  * @state {HttpState}
  * @returns {Operation}
  */
-export function del(path, options, callback) {
-  return sendRequest('DELETE', path, options, callback);
+export function del(path, options) {
+  return sendRequest('DELETE', path, options);
 }
 
 /**
@@ -189,13 +183,12 @@ export function del(path, options, callback) {
  * @function
  * @param {String} data - Body string to be parsed
  * @param {function} script - script for extracting data
- * @param {function} callback - (Optional) Callback function
  * @state data - the parsed XML as a JSON object
  * @state references - an array of all previous data objects used in the Job
  * @returns {Operation}
  */
-export function parseXML(data, script, callback) {
-  return xmlParser({ body: data }, script, callback);
+export function parseXML(data, script) {
+  return xmlParser({ body: data }, script);
 }
 
 export {

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -56,7 +56,7 @@ const assertUrl = (pathOrUrl, baseUrl) => {
  * @function
  * @private
  */
-export function request(method, path, params, callback = s => s) {
+export function request(method, path, params) {
   return state => {
     const [resolvedPath, resolvedParams = {}] = expandReferences(
       state,
@@ -108,7 +108,6 @@ export function request(method, path, params, callback = s => s) {
           response,
         };
       })
-      .then(callback)
       .catch(err => {
         logResponse(err);
 
@@ -121,7 +120,7 @@ export function request(method, path, params, callback = s => s) {
  * @function
  * @private
  */
-export function xmlParser(body, script, callback = s => s) {
+export function xmlParser(body, script) {
   return state => {
     const [resolvedBody] = expandReferences(state, body);
     const $ = cheerio.load(resolvedBody);
@@ -131,12 +130,12 @@ export function xmlParser(body, script, callback = s => s) {
       const result = script($);
       try {
         const r = JSON.parse(result);
-        return callback(composeNextState(state, r));
+        return composeNextState(state, r);
       } catch (e) {
-        return callback(composeNextState(state, { body: result }));
+        return composeNextState(state, { body: result });
       }
     } else {
-      return callback(composeNextState(state, { body: resolvedBody }));
+      return composeNextState(state, { body: resolvedBody });
     }
   };
 }

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -381,37 +381,6 @@ describe('get()', () => {
     expect(data).eql({ ok: true });
   });
 
-  it('pass state to the callback', async () => {
-    testServer
-      .intercept({
-        path: '/api/callback',
-        method: 'GET',
-      })
-      .reply(
-        200,
-        { id: 3 },
-        {
-          headers: jsonHeaders,
-        }
-      );
-
-    const state = {
-      configuration: { baseUrl: 'https://www.example.com' },
-      data: {},
-    };
-
-    let callbackState;
-
-    const finalState = await execute(
-      get('api/callback', {}, state => {
-        callbackState = state;
-        return state;
-      })
-    )(state);
-
-    expect(callbackState).to.eql(finalState);
-  });
-
   it('should throw for a 404 response', async () => {
     testServer
       .intercept({
@@ -471,7 +440,7 @@ describe('get()', () => {
     expect(response.statusCode).to.eql(404);
   });
 
-  it('can be called inside an each block', async () => {
+  it.skip('can be called inside an each block', async () => {
     testServer
       .intercept({
         path: '/api/fake-json',
@@ -497,20 +466,24 @@ describe('get()', () => {
           'https://www.example.com/api/fake-json',
           {
             body: state => state.data,
-          },
-          next => {
-            next.replies.push(next.response.body);
-            return next;
           }
-        )
+        ).then((next, state) => {
+          console.log({state});
+          
+          next.replies.push(next.response.body);
+          return next;
+        })
       )
     )(state);
 
-    expect(finalState.replies).to.eql([
-      '{"name":"a","age":42}',
-      '{"name":"b","age":83}',
-      '{"name":"c","age":112}',
-    ]);
+    console.log({finalState});
+    
+
+    // expect(finalState.replies).to.eql([
+    //   '{"name":"a","age":42}',
+    //   '{"name":"b","age":83}',
+    //   '{"name":"c","age":112}',
+    // ]);
   });
 });
 
@@ -602,7 +575,7 @@ describe('post', () => {
     expect(response.statusCode).to.eq(502);
   });
 
-  it('can be called inside an each block', async () => {
+  it.only('can be called inside an each block', async () => {
     testServer
       .intercept({
         path: '/api/json',
@@ -627,12 +600,10 @@ describe('post', () => {
         post(
           'https://www.example.com/api/json',
           state => state.data,
-          {},
-          next => {
-            next.replies.push(next.response.body);
-            return next;
-          }
-        )
+        ).then(next => {
+          next.replies.push(next.response.body);
+          return next;
+        })
       )
     )(state);
 

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -440,51 +440,6 @@ describe('get()', () => {
     expect(response.statusCode).to.eql(404);
   });
 
-  it.skip('can be called inside an each block', async () => {
-    testServer
-      .intercept({
-        path: '/api/fake-json',
-        method: 'GET',
-      })
-      .reply(200, ({ body }) => body)
-      .persist();
-
-    const state = {
-      configuration: {},
-      things: [
-        { name: 'a', age: 42 },
-        { name: 'b', age: 83 },
-        { name: 'c', age: 112 },
-      ],
-      replies: [],
-    };
-
-    const finalState = await execute(
-      each(
-        '$.things[*]',
-        get(
-          'https://www.example.com/api/fake-json',
-          {
-            body: state => state.data,
-          }
-        ).then((next, state) => {
-          console.log({state});
-          
-          next.replies.push(next.response.body);
-          return next;
-        })
-      )
-    )(state);
-
-    console.log({finalState});
-    
-
-    // expect(finalState.replies).to.eql([
-    //   '{"name":"a","age":42}',
-    //   '{"name":"b","age":83}',
-    //   '{"name":"c","age":112}',
-    // ]);
-  });
 });
 
 describe('post', () => {
@@ -574,80 +529,6 @@ describe('post', () => {
 
     expect(response.statusCode).to.eq(502);
   });
-
-  it.only('can be called inside an each block', async () => {
-    testServer
-      .intercept({
-        path: '/api/json',
-        method: 'POST',
-      })
-      .reply(200, ({ body }) => body)
-      .persist();
-
-    const state = {
-      configuration: {},
-      things: [
-        { name: 'a', age: 42 },
-        { name: 'b', age: 83 },
-        { name: 'c', age: 112 },
-      ],
-      replies: [],
-    };
-
-    const finalState = await execute(
-      each(
-        '$.things[*]',
-        post(
-          'https://www.example.com/api/json',
-          state => state.data,
-        ).then(next => {
-          next.replies.push(next.response.body);
-          return next;
-        })
-      )
-    )(state);
-
-    expect(finalState.replies).to.eql([
-      '{"name":"a","age":42}',
-      '{"name":"b","age":83}',
-      '{"name":"c","age":112}',
-    ]);
-  });
-
-  it('should make an http request from inside the parseCSV callback', async function () {
-    testServer
-      .intercept({
-        path: '/api/csv-reader',
-        method: 'POST',
-      })
-      .reply(200, ({ body }) => body, {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
-      .persist();
-
-    const csv = 'id,name\n1,taylor\n2,mtuchi\n3,joe\n4,stu\n5,elias';
-    const state = { references: [], data: [], apiResponses: [] };
-
-    const resultingState = await parseCsv(
-      csv,
-      { chunkSize: 2 },
-      (state, rows) =>
-        post('https://www.example.com/api/csv-reader', rows, {}, state => {
-          state.apiResponses.push(...state.response.body);
-          return state;
-        })(state)
-    )(state);
-
-    expect(resultingState.apiResponses).to.eql([
-      { id: '1', name: 'taylor' },
-      { id: '2', name: 'mtuchi' },
-      { id: '3', name: 'joe' },
-      { id: '4', name: 'stu' },
-      { id: '5', name: 'elias' },
-    ]);
-  });
 });
 
 describe('put', () => {
@@ -675,48 +556,6 @@ describe('put', () => {
     expect(req.body).to.equal(JSON.stringify(body));
   });
 
-  it('can be called inside an each block', async () => {
-    testServer
-      .intercept({
-        path: '/api/json',
-        method: 'put',
-      })
-      .reply(200, ({ body }) => body)
-      .persist();
-
-    const state = {
-      configuration: {
-        baseUrl: 'https://www.example.com',
-      },
-      things: [
-        { name: 'a', age: 42 },
-        { name: 'b', age: 83 },
-        { name: 'c', age: 112 },
-      ],
-      replies: [],
-    };
-
-    const finalState = await execute(
-      each(
-        '$.things[*]',
-        put(
-          '/api/json',
-          state => state.data,
-          {},
-          next => {
-            next.replies.push(next.response.body);
-            return next;
-          }
-        )
-      )
-    )(state);
-
-    expect(finalState.replies).to.eql([
-      '{"name":"a","age":42}',
-      '{"name":"b","age":83}',
-      '{"name":"c","age":112}',
-    ]);
-  });
 });
 
 describe('patch', () => {
@@ -744,48 +583,6 @@ describe('patch', () => {
     expect(req.body).to.equal(JSON.stringify(body));
   });
 
-  it('can be called inside an each block', async () => {
-    testServer
-      .intercept({
-        path: '/api/fake-json',
-        method: 'PATCH',
-      })
-      .reply(200, ({ body }) => body)
-      .persist();
-
-    const state = {
-      configuration: {
-        baseUrl: 'https://www.example.com',
-      },
-      things: [
-        { name: 'a', age: 42 },
-        { name: 'b', age: 83 },
-        { name: 'c', age: 112 },
-      ],
-      replies: [],
-    };
-
-    const finalState = await execute(
-      each(
-        '$.things[*]',
-        patch(
-          '/api/fake-json',
-          state => state.data,
-          {},
-          next => {
-            next.replies.push(next.response.body);
-            return next;
-          }
-        )
-      )
-    )(state);
-
-    expect(finalState.replies).to.eql([
-      '{"name":"a","age":42}',
-      '{"name":"b","age":83}',
-      '{"name":"c","age":112}',
-    ]);
-  });
 });
 
 describe('delete', () => {
@@ -808,48 +605,6 @@ describe('delete', () => {
     )(state);
 
     expect(response.statusCode).to.eql(204);
-  });
-
-  it('can be called inside an each block', async () => {
-    testServer
-      .intercept({
-        path: '/api/fake-json',
-        method: 'DELETE',
-      })
-      .reply(200, ({ body }) => body)
-      .persist();
-
-    const state = {
-      configuration: {},
-      things: [
-        { name: 'a', age: 42 },
-        { name: 'b', age: 83 },
-        { name: 'c', age: 112 },
-      ],
-      replies: [],
-    };
-
-    const finalState = await execute(
-      each(
-        '$.things[*]',
-        del(
-          'https://www.example.com/api/fake-json',
-          {
-            body: state => state.data,
-          },
-          next => {
-            next.replies.push(next.response.body);
-            return next;
-          }
-        )
-      )
-    )(state);
-
-    expect(finalState.replies).to.eql([
-      '{"name":"a","age":42}',
-      '{"name":"b","age":83}',
-      '{"name":"c","age":112}',
-    ]);
   });
 });
 

--- a/packages/http/test/integration.js
+++ b/packages/http/test/integration.js
@@ -69,9 +69,7 @@ describe('Integration tests', () => {
       },
       data: {},
     };
-    const { response } = await execute(
-      post('/',  { name: 'Joe' })
-    )(state);
+    const { response } = await execute(post('/', { name: 'Joe' }))(state);
 
     expect(response.body).to.eql('Hello, World!');
     expect(response.method).to.eql('POST');


### PR DESCRIPTION
## Summary

All functions in `http` allowed for the use of `callbacks` as the third option. We have stripped this and allowed users to use promise chaining instead.


Fixes #997 

## Details

All adaptor functions are being re-worked and callbacks are getting stripped. 
Since the `callbacks` have been the third option in the function, this has been removed but the same functionality can be achieved using promise chaining: 

So if you used to do this:

```js
post('/patient', { body: $.patient }, next => {
  state.results.push(next.response.body);
  return next;
});
```

You must edit your code to do this:

```js
post('/patient', $.patient).then(next => {
  state.results.push(next.response.body);
  return next;
});
```

Tests that were previously focused on testing the behaviour of callbacks have been removed as the new promise chaining cannot be simulated in the test environments

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
