### PR TITLE
http: remove duplicated response body

### DIFF
--- a/.changeset/soft-radios-fix.md
+++ b/.changeset/soft-radios-fix.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-http': patch
+---
+
+- Remove duplicated body response from `http`.

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -64,7 +64,8 @@ export function request(method, path, params, callback = s => s) {
       params
     );
 
-    let { body, headers = { 'Content-Type': 'application/json' } } = resolvedParams;
+    let { body, headers = { 'Content-Type': 'application/json' } } =
+      resolvedParams;
 
     if (resolvedParams.form) {
       body = encodeFormBody(body);
@@ -101,11 +102,12 @@ export function request(method, path, params, callback = s => s) {
 
     return commonRequest(method, resolvedPath, options)
       .then(response => {
+        const { body, ...responseWithoutBody } = response;
         logResponse(response);
 
         return {
-          ...composeNextState(state, response.body),
-          response,
+          ...composeNextState(state, body),
+          response: responseWithoutBody,
         };
       })
       .then(callback)

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -215,7 +215,6 @@ describe('get()', () => {
     expect(responseWithoutDuration).to.eql({
       method: 'GET',
       headers: { 'content-type': 'application/json' },
-      body: { x: 31 },
       statusCode: 201,
       statusMessage: 'Created',
       url: 'https://www.example.com/json',
@@ -499,7 +498,7 @@ describe('get()', () => {
             body: state => state.data,
           },
           next => {
-            next.replies.push(next.response.body);
+            next.replies.push(next.data);
             return next;
           }
         )
@@ -629,7 +628,7 @@ describe('post', () => {
           state => state.data,
           {},
           next => {
-            next.replies.push(next.response.body);
+            next.replies.push(next.data);
             return next;
           }
         )
@@ -664,7 +663,7 @@ describe('post', () => {
       { chunkSize: 2 },
       (state, rows) =>
         post('https://www.example.com/api/csv-reader', rows, {}, state => {
-          state.apiResponses.push(...state.response.body);
+          state.apiResponses.push(...state.data);
           return state;
         })(state)
     )(state);
@@ -733,7 +732,7 @@ describe('put', () => {
           state => state.data,
           {},
           next => {
-            next.replies.push(next.response.body);
+            next.replies.push(next.data);
             return next;
           }
         )
@@ -802,7 +801,7 @@ describe('patch', () => {
           state => state.data,
           {},
           next => {
-            next.replies.push(next.response.body);
+            next.replies.push(next.data);
             return next;
           }
         )
@@ -867,7 +866,7 @@ describe('delete', () => {
             body: state => state.data,
           },
           next => {
-            next.replies.push(next.response.body);
+            next.replies.push(next.data);
             return next;
           }
         )

--- a/packages/http/test/integration.js
+++ b/packages/http/test/integration.js
@@ -56,9 +56,9 @@ describe('Integration tests', () => {
       },
       data: {},
     };
-    const { response } = await execute(get('/'))(state);
+    const { data, response } = await execute(get('/'))(state);
 
-    expect(response.body).to.eql('Hello, World!');
+    expect(data).to.eql('Hello, World!');
     expect(response.method).to.eql('GET');
   });
 
@@ -69,11 +69,9 @@ describe('Integration tests', () => {
       },
       data: {},
     };
-    const { response } = await execute(
-      post('/',  { name: 'Joe' })
-    )(state);
+    const { data, response } = await execute(post('/', { name: 'Joe' }))(state);
 
-    expect(response.body).to.eql('Hello, World!');
+    expect(data).to.eql('Hello, World!');
     expect(response.method).to.eql('POST');
   });
 
@@ -85,13 +83,13 @@ describe('Integration tests', () => {
       data: {},
     };
 
-    const { response } = await execute(
+    const { data } = await execute(
       get('/redirect', {
         headers: { followAllRedirects: true },
       })
     )(state);
 
-    expect(response.body).to.eql({ ok: true });
+    expect(data).to.eql({ ok: true });
   });
 
   it('should pass if certs are added to the request', async () => {
@@ -103,7 +101,7 @@ describe('Integration tests', () => {
       data: {},
     };
 
-    const { response } = await execute(
+    const { data } = await execute(
       get('/', {
         tls: {
           ca,
@@ -113,7 +111,7 @@ describe('Integration tests', () => {
       })
     )(state);
 
-    expect(response.body).to.eql('Hello, HTTPS World!');
+    expect(data).to.eql('Hello, HTTPS World!');
   });
 
   it('should fail if certs are not added to the request', async () => {


### PR DESCRIPTION
## Summary

Remove the duplicated body from `http` response. 

Fixes #948 

## Details

When a response is received, state contains a `data` field which has the body response, but there is another duplication of the body in the `response` field in the state.

The duplicated `body` field in the `response` parameter has been removed and all related tests updated

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
