### PR TITLE
Claude gpt documentation fix

### DIFF
--- a/packages/chatgpt/ast.json
+++ b/packages/chatgpt/ast.json
@@ -19,6 +19,11 @@
             "type": null
           },
           {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
             "title": "param",
             "description": "The prompt",
             "type": {

--- a/packages/chatgpt/src/Adaptor.js
+++ b/packages/chatgpt/src/Adaptor.js
@@ -54,6 +54,7 @@ export function execute(...operations) {
  * @example
  * prompt('Write a haiku about surfing.' model='gpt-4o');
  * @public
+ * @function
  * @param {string} message - The prompt
  * @param {string} model - The model (defaults to 'gpt-4o)
  * @returns {operation}

--- a/packages/chatgpt/src/Adaptor.js
+++ b/packages/chatgpt/src/Adaptor.js
@@ -2,6 +2,7 @@ import {
   composeNextState,
   execute as commonExecute,
 } from '@openfn/language-common';
+import { expandReferences } from '@openfn/language-common/util';
 import OpenAI from 'openai';
 
 let client;
@@ -61,9 +62,12 @@ export function execute(...operations) {
  */
 export function prompt(message, model = 'gpt-4o') {
   return async state => {
+
+    const [resolvedMessage, resolvedModel] = expandReferences(state, message, model);
+   
     const msg = await client.chat.completions.create({
-      model,
-      messages: [{ role: 'user', content: message }],
+      model: resolvedModel,
+      messages: [{ role: 'user', content: resolvedMessage }],
     });
     return composeNextState(state, msg);
   };

--- a/packages/chatgpt/test/Adaptor.test.js
+++ b/packages/chatgpt/test/Adaptor.test.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { enableMockClient } from '@openfn/language-common/util';
 import { prompt, setMockClient } from '../src/Adaptor.js';
 import testData from "./fixtures/fixture.json" assert {type: 'json'};
 

--- a/packages/claude/src/Adaptor.js
+++ b/packages/claude/src/Adaptor.js
@@ -52,6 +52,7 @@ export function setMockClient(mock) {
 /**
  * Prompt the Claude chat interface to respond
  * @public
+ * @function
  * @example
  * prompt('Write a haiku about surfing.');
  * @param {string} message - The prompt

--- a/packages/claude/src/Adaptor.js
+++ b/packages/claude/src/Adaptor.js
@@ -3,6 +3,8 @@ import {
   execute as commonExecute,
 } from '@openfn/language-common';
 import Anthropic from '@anthropic-ai/sdk';
+import { expandReferences } from '@openfn/language-common/util';
+
 
 let client;
 
@@ -61,10 +63,12 @@ export function setMockClient(mock) {
  */
 export function prompt(message, model = 'claude-3-7-sonnet-20250219') {
   return async state => {
+    const [resolvedMessage, resolvedModel] = expandReferences(state, message, model);
+
     const msg = await client.messages.create({
-      model,
+      model: resolvedModel,
       max_tokens: 1024,
-      messages: [{ role: 'user', content: message }],
+      messages: [{ role: 'user', content: resolvedMessage }],
     });
     return composeNextState(state, msg);
   };

--- a/packages/claude/test/Adaptor.test.js
+++ b/packages/claude/test/Adaptor.test.js
@@ -1,6 +1,4 @@
 import { expect } from 'chai';
-import { enableMockClient } from '@openfn/language-common/util';
-
 import { prompt, setMockClient } from '../src/Adaptor.js';
 
 // This creates a mock client which acts like a fake server.


### PR DESCRIPTION
## Summary

Expand refs in both gpt and claude adaptors and add a `function` tag to prompt functions in both adaptors

Fixes #1038 

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
