### PR TITLE
dhis2: Implement `http` namespace

### DIFF
--- a/packages/dhis2/ast.json
+++ b/packages/dhis2/ast.json
@@ -5,8 +5,7 @@
       "params": [
         "resourceType",
         "data",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Create a record",
@@ -54,18 +53,6 @@
               }
             },
             "name": "options"
-          },
-          {
-            "title": "param",
-            "description": "Optional callback to handle the response",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "function"
-              }
-            },
-            "name": "callback"
           },
           {
             "title": "returns",
@@ -145,8 +132,7 @@
         "resourceType",
         "path",
         "data",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Update data. A generic helper function to update a resource object of any type.\nUpdating an object requires to send `all required fields` or the `full body`",
@@ -199,18 +185,6 @@
               }
             },
             "name": "options"
-          },
-          {
-            "title": "param",
-            "description": "Optional callback to handle the response",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "function"
-              }
-            },
-            "name": "callback"
           },
           {
             "title": "returns",
@@ -280,240 +254,12 @@
       "valid": true
     },
     {
-      "name": "get",
-      "params": [
-        "resourceType",
-        "query",
-        "options",
-        "callback"
-      ],
-      "docs": {
-        "description": "Get data. Generic helper method for getting data of any kind from DHIS2.\n- This can be used to get `DataValueSets`,`events`,`trackers`,`etc.`",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "The type of resource to get(use its `plural` name). E.g. `dataElements`, `tracker/trackedEntities`,`organisationUnits`, etc.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "resourceType"
-          },
-          {
-            "title": "param",
-            "description": "A query object that will limit what resources are retrieved when converted into request params.",
-            "type": {
-              "type": "NameExpression",
-              "name": "Object"
-            },
-            "name": "query"
-          },
-          {
-            "title": "param",
-            "description": "Optional `options` to define URL parameters via params beyond filters, request configuration (e.g. `auth`) and DHIS2 api version to use.",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "Object"
-              }
-            },
-            "name": "options"
-          },
-          {
-            "title": "param",
-            "description": "The parameters for the request.",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "Object"
-              }
-            },
-            "name": "options.params"
-          },
-          {
-            "title": "param",
-            "description": "The configuration for the request, including headers, etc.",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "Object"
-              }
-            },
-            "name": "options.requestConfig"
-          },
-          {
-            "title": "param",
-            "description": "Optional flag to indicate if the response should be returned as a Base64 encoded string.",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "boolean"
-              }
-            },
-            "name": "options.asBase64",
-            "default": "false"
-          },
-          {
-            "title": "param",
-            "description": "Optional callback to handle the response",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "function"
-              }
-            },
-            "name": "callback"
-          },
-          {
-            "title": "returns",
-            "description": "state",
-            "type": {
-              "type": "NameExpression",
-              "name": "Operation"
-            }
-          },
-          {
-            "title": "example",
-            "description": "get('dataValueSets', {\n  dataSet: 'pBOMPrpg1QX',\n  orgUnit: 'DiszpKrYNg8',\n  period: '201401',\n  fields: '*',\n});",
-            "caption": "Get all data values for the 'pBOMPrpg1QX' dataset"
-          },
-          {
-            "title": "example",
-            "description": "get('programs', { orgUnit: 'TSyzvBiovKh', fields: '*' });",
-            "caption": "Get all programs for an organization unit"
-          },
-          {
-            "title": "example",
-            "description": "get('tracker/trackedEntities/F8yKM85NbxW');",
-            "caption": "Get a single tracked entity given the provided ID. See [TrackedEntities docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#tracked-entities-get-apitrackertrackedentities)"
-          },
-          {
-            "title": "example",
-            "description": "get('tracker/enrollments/abcd');",
-            "caption": "Get an enrollment given the provided ID. See [Enrollment docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#enrollments-get-apitrackerenrollments)"
-          },
-          {
-            "title": "example",
-            "description": "get('tracker/events');",
-            "caption": "Get all events matching given criteria. See [Events docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#events-get-apitrackerevents)"
-          },
-          {
-            "title": "example",
-            "description": "get('tracker/relationships', {\n  trackedEntity:['F8yKM85NbxW'],\n});",
-            "caption": "Get the relationship between two tracker entities. The only required parameters are 'trackedEntity', 'enrollment' or 'event'. See [Relationships docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#relationships-get-apitrackerrelationships)"
-          }
-        ]
-      },
-      "valid": false
-    },
-    {
-      "name": "post",
-      "params": [
-        "resourceType",
-        "data",
-        "query",
-        "options",
-        "callback"
-      ],
-      "docs": {
-        "description": "Post data. Generic helper method for posting data of any kind to DHIS2.\nThis can be used to create `DataValueSets`,`events`,`trackers`,etc.",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "Type of resource to create. E.g. `trackedEntities`, `programs`, `events`, ...",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "resourceType"
-          },
-          {
-            "title": "magic",
-            "description": "resourceType $.children.resourceTypes[*]"
-          },
-          {
-            "title": "param",
-            "description": "Object which defines data that will be used to create a given instance of resource. To create a single instance of a resource, `data` must be a javascript object, and to create multiple instances of a resources, `data` must be an array of javascript objects.",
-            "type": {
-              "type": "NameExpression",
-              "name": "Dhis2Data"
-            },
-            "name": "data"
-          },
-          {
-            "title": "param",
-            "description": "Optional `options` to define URL parameters via params (E.g. `filter`, `dimension` and other import parameters), request config (E.g. `auth`) and the DHIS2 apiVersion.",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "Object"
-              }
-            },
-            "name": "options"
-          },
-          {
-            "title": "param",
-            "description": "Optional callback to handle the response",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "function"
-              }
-            },
-            "name": "callback"
-          },
-          {
-            "title": "returns",
-            "description": "state",
-            "type": {
-              "type": "NameExpression",
-              "name": "Operation"
-            }
-          },
-          {
-            "title": "example",
-            "description": "post(\"tracker\", {\n  events: [\n    {\n      program: \"eBAyeGv0exc\",\n      orgUnit: \"DiszpKrYNg8\",\n      status: \"COMPLETED\",\n    },\n  ],\n});",
-            "caption": "Create an event"
-          }
-        ]
-      },
-      "valid": false
-    },
-    {
       "name": "upsert",
       "params": [
         "resourceType",
         "query",
         "data",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Upsert a record. A generic helper function used to atomically either insert a row, or on the basis of the row already existing, UPDATE that existing row instead.",
@@ -591,18 +337,6 @@
               }
             },
             "name": "options"
-          },
-          {
-            "title": "param",
-            "description": "Optional callback to handle the response",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "function"
-              }
-            },
-            "name": "callback"
           },
           {
             "title": "throws",
@@ -684,103 +418,12 @@
       "valid": true
     },
     {
-      "name": "patch",
-      "params": [
-        "resourceType",
-        "path",
-        "data",
-        "options",
-        "callback"
-      ],
-      "docs": {
-        "description": "Patch a record. A generic helper function to send partial updates on one or more object properties.\n- You are not required to send the full body of object properties.\n- This is useful for cases where you don't want or need to update all properties on a object.",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "The type of resource to be updated. E.g. `dataElements`, `organisationUnits`, etc.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "resourceType"
-          },
-          {
-            "title": "param",
-            "description": "The `id` or `path` to the `object` to be updated. E.g. `FTRrcoaog83` or `FTRrcoaog83/{collection-name}/{object-id}`",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "path"
-          },
-          {
-            "title": "param",
-            "description": "Data to update. Include only the fields you want to update. E.g. `{name: \"New Name\"}`",
-            "type": {
-              "type": "NameExpression",
-              "name": "Object"
-            },
-            "name": "data"
-          },
-          {
-            "title": "param",
-            "description": "Optional configuration, including params for the update ({preheatCache: true, strategy: 'UPDATE', mergeMode: 'REPLACE'}). Defaults to `{operationName: 'patch', apiVersion: state.configuration.apiVersion, responseType: 'json'}`",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "Object"
-              }
-            },
-            "name": "options"
-          },
-          {
-            "title": "param",
-            "description": "Optional callback to handle the response",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "function"
-              }
-            },
-            "name": "callback"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "Operation"
-            }
-          },
-          {
-            "title": "example",
-            "description": "patch('dataElements', 'FTRrcoaog83', { name: 'New Name' });",
-            "caption": "a dataElement"
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
       "name": "destroy",
       "params": [
         "resourceType",
         "path",
         "data",
-        "options",
-        "callback"
+        "options"
       ],
       "docs": {
         "description": "Delete a record. A generic helper function to delete an object",
@@ -861,18 +504,6 @@
               }
             },
             "name": "options"
-          },
-          {
-            "title": "param",
-            "description": "Optional callback to handle the response",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "function"
-              }
-            },
-            "name": "callback"
           },
           {
             "title": "returns",

--- a/packages/dhis2/src/http.js
+++ b/packages/dhis2/src/http.js
@@ -1,0 +1,228 @@
+import { expandReferences, encode } from '@openfn/language-common/util';
+import { generateUrl, handleResponse } from './Utils';
+import * as client from './Client';
+
+/**
+ * Options object
+ * @typedef {Object} RequestOptions
+ * @property {object} query - An object of query parameters to be encoded into the URL
+ * @property {object} requestConfig -  The configuration for the request, including headers, etc.
+ * @property {object} data - The request body (as JSON)
+ */
+
+/**
+ * Get data. Generic helper method for getting data of any kind from DHIS2.
+ * - This can be used to get `DataValueSets`,`events`,`trackers`,`etc.`
+ * @public
+ * @function
+ * @param {string} resourceType - The type of resource to get(use its `plural` name). E.g. `dataElements`, `tracker/trackedEntities`,`organisationUnits`, etc.
+ * @param {Object} query - A query object that will limit what resources are retrieved when converted into request params.
+ * @param {Object} [options] - Optional `options` to define URL parameters via params beyond filters, request configuration (e.g. `auth`) and DHIS2 api version to use.
+ * @param {Object} [options.params] - The parameters for the request.
+ * @param {Object} [options.requestConfig] - The configuration for the request, including headers, etc.
+ * @param {boolean} [options.asBase64=false] - Optional flag to indicate if the response should be returned as a Base64 encoded string.
+ * @returns {Operation} state
+ * @example <caption>Get all data values for the 'pBOMPrpg1QX' dataset</caption>
+ * http.get('dataValueSets', {
+ *   dataSet: 'pBOMPrpg1QX',
+ *   orgUnit: 'DiszpKrYNg8',
+ *   period: '201401',
+ *   fields: '*',
+ * });
+ * @example <caption>Get all programs for an organization unit</caption>
+ * http.get('programs', { orgUnit: 'TSyzvBiovKh', fields: '*' });
+ * @example <caption>Get a single tracked entity given the provided ID. See [TrackedEntities docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#tracked-entities-get-apitrackertrackedentities)</caption>
+ * http.get('tracker/trackedEntities/F8yKM85NbxW');
+ * @example <caption>Get an enrollment given the provided ID. See [Enrollment docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#enrollments-get-apitrackerenrollments)</caption>
+ * http.get('tracker/enrollments/abcd');
+ * @example <caption>Get all events matching given criteria. See [Events docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#events-get-apitrackerevents)</caption>
+ * http.get('tracker/events');
+ * @example <caption>Get the relationship between two tracker entities. The only required parameters are 'trackedEntity', 'enrollment' or 'event'. See [Relationships docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#relationships-get-apitrackerrelationships)</caption>
+ * http.get('tracker/relationships', {
+ *   trackedEntity:['F8yKM85NbxW'],
+ * });
+ */
+export function get(resourceType, query, options = {}) {
+  return state => {
+    console.log('Preparing get operation...');
+
+    const [resolvedResourceType, resolvedQuery, resolvedOptions] =
+      expandReferences(state, resourceType, query, options);
+
+    const { params, requestConfig, asBase64 = false } = resolvedOptions;
+    const { configuration } = state;
+
+    console.log(
+      'url',
+      generateUrl(configuration, resolvedOptions, resolvedResourceType)
+    );
+
+    return client
+      .request(configuration, {
+        method: 'get',
+        url: generateUrl(configuration, resolvedOptions, resolvedResourceType),
+        params: {
+          ...resolvedQuery,
+          ...params,
+        },
+        responseType: asBase64 ? 'arraybuffer' : 'json',
+        ...requestConfig,
+      })
+      .then(result => {
+        console.log(`Retrieved ${resolvedResourceType}`);
+        const response = asBase64 ? { data: encode(result.data) } : result;
+        return handleResponse(response, state);
+      });
+  };
+}
+
+/**
+ * Post data. Generic helper method for posting data of any kind to DHIS2.
+ * This can be used to create `DataValueSets`,`events`,`trackers`,etc.
+ * @public
+ * @function
+ * @param {string} resourceType - Type of resource to create. E.g. `trackedEntities`, `programs`, `events`, ...
+ * @magic resourceType $.children.resourceTypes[*]
+ * @param {Dhis2Data} data - Object which defines data that will be used to create a given instance of resource. To create a single instance of a resource, `data` must be a javascript object, and to create multiple instances of a resources, `data` must be an array of javascript objects.
+ * @param {Object} [options] - Optional `options` to define URL parameters via params (E.g. `filter`, `dimension` and other import parameters), request config (E.g. `auth`) and the DHIS2 apiVersion.
+ * @returns {Operation} state
+ * @example <caption>Create an event</caption>
+ * http.post("tracker", {
+ *   events: [
+ *     {
+ *       program: "eBAyeGv0exc",
+ *       orgUnit: "DiszpKrYNg8",
+ *       status: "COMPLETED",
+ *     },
+ *   ],
+ * });
+ */
+export function post(resourceType, data, query, options = {}) {
+  return state => {
+    console.log('Preparing post operation...');
+
+    const [resolvedResourceType, resolvedQuery, resolvedOptions, resolvedData] =
+      expandReferences(state, resourceType, query, options, data);
+
+    const { params, requestConfig } = resolvedOptions;
+    const { configuration } = state;
+
+    return client
+      .request(configuration, {
+        method: 'post',
+        url: generateUrl(configuration, resolvedOptions, resolvedResourceType),
+        params: { ...resolvedQuery, ...params },
+        responseType: 'json',
+        data: resolvedData,
+        ...requestConfig,
+      })
+      .then(result => {
+        console.log(`Created ${resolvedResourceType}`);
+        return handleResponse(result, state);
+      });
+  };
+}
+
+/**
+ * Patch a record. A generic helper function to send partial updates on one or more object properties.
+ * - You are not required to send the full body of object properties.
+ * - This is useful for cases where you don't want or need to update all properties on a object.
+ * @public
+ * @function
+ * @param {string} resourceType - The type of resource to be updated. E.g. `dataElements`, `organisationUnits`, etc.
+ * @param {string} path - The `id` or `path` to the `object` to be updated. E.g. `FTRrcoaog83` or `FTRrcoaog83/{collection-name}/{object-id}`
+ * @param {Object} data - Data to update. Include only the fields you want to update. E.g. `{name: "New Name"}`
+ * @param {Object} [options] - Optional configuration, including params for the update ({preheatCache: true, strategy: 'UPDATE', mergeMode: 'REPLACE'}). Defaults to `{operationName: 'patch', apiVersion: state.configuration.apiVersion, responseType: 'json'}`
+ * @returns {Operation}
+ * @example <caption>a dataElement</caption>
+ * http.patch('dataElements', 'FTRrcoaog83', { name: 'New Name' });
+ */
+// TODO: @Elias, can this be deleted in favor of update? How does DHIS2 handle PATCH vs PUT?
+// I need to investigate on this. But I think DHIS2 forces to send all properties back when we do an update. If that's confirmed then this may be needed.
+export function patch(resourceType, path, data, options = {}) {
+  return state => {
+    console.log('Preparing patch operation...');
+
+    const [resolvedResourceType, resolvedPath, resolvedData, resolvedOptions] =
+      expandReferences(state, resourceType, path, data, options);
+
+    const { params, requestConfig } = resolvedOptions;
+    const { configuration } = state;
+
+    return client
+      .request(configuration, {
+        method: 'patch',
+        url: generateUrl(
+          configuration,
+          resolvedOptions,
+          resolvedResourceType,
+          resolvedPath
+        ),
+        params,
+        data: resolvedData,
+        ...requestConfig,
+      })
+      .then(result => {
+        console.log(`Patched ${resolvedResourceType} at ${resolvedPath}`);
+        return handleResponse(result, state);
+      });
+  };
+}
+
+/**
+ * Make a HTTP request to any dhis2 endpoint
+ * @example <caption>GET request with a URL params</caption>
+ * http.request("GET",
+ *   "tracker/relationships", {
+ *    params:{
+ *        trackedEntity: ['F8yKM85NbxW']
+ *    },
+ * });
+ * @example <caption>Upsert a tracker resource </caption>
+ * http.request('POST', 'tracker', {
+ *   data: {
+ *   orgUnit: 'TSyzvBiovKh',
+ *   trackedEntityType: 'nEenWmSyUEp',
+ *   attributes: [
+ *     {
+ *       attribute: 'w75KJ2mc4zz',
+ *       value: 'Qassime',
+ *     },
+ *   ],
+ *  },
+ *   params:{
+ *      importStrategy: 'CREATE_AND_UPDATE'
+ *    }
+ *  });
+ * @function
+ * @public
+ * @param {string} method - HTTP method to use
+ * @param {string} path - Path to resource
+ * @param {RequestOptions}  [options] - An optional object containing query, requestConfig, and data for the request
+ * @returns {Operation}
+ */
+export function request(method, path, options = {}) {
+  return state => {
+    console.log(`Preparing a ${method.toLowerCase()} operation...`);
+
+    const [resolvedMethod, resolvedPath, resolvedOptions = {}] =
+      expandReferences(state, method, path, options);
+
+    const { params, requestConfig, data } = resolvedOptions;
+    const { configuration } = state;
+
+    return client
+      .request(configuration, {
+        method: resolvedMethod,
+        url: generateUrl(configuration, resolvedOptions, resolvedPath),
+        params: { ...params },
+        responseType: 'json',
+        data,
+        ...requestConfig,
+      })
+      .then(result => {
+        console.log(`Successful ${method.toLowerCase()} operation...`);
+        return handleResponse(result, state);
+      });
+  };
+}

--- a/packages/dhis2/src/index.js
+++ b/packages/dhis2/src/index.js
@@ -4,3 +4,4 @@ export { metadata };
 import * as Adaptor from './Adaptor';
 export default Adaptor;
 export * from './Adaptor';
+export * as http from './http';

--- a/packages/dhis2/test/index.test.js
+++ b/packages/dhis2/test/index.test.js
@@ -3,11 +3,11 @@ import {
   execute,
   create,
   update,
-  get,
   upsert,
   findAttributeValue,
   findAttributeValueById,
 } from '../src/Adaptor';
+import { get, post, request, patch } from '../src/http';
 import { dataValue } from '@openfn/language-common';
 import {
   buildUrl,
@@ -292,9 +292,9 @@ describe('post', () => {
         message: 'the response',
       });
 
-    const finalState = await execute(
-      create('tracker', { events: [state.data] })
-    )(state);
+    const finalState = await execute(post('tracker', { events: [state.data] }))(
+      state
+    );
 
     expect(finalState.data).to.eql({
       httpStatus: 'OK',
@@ -318,7 +318,7 @@ describe('post', () => {
       });
 
     const finalState = await execute(
-      create('tracker', {
+      post('tracker', {
         relationships: [
           {
             program: 'abc',
@@ -326,6 +326,82 @@ describe('post', () => {
           },
         ],
       })
+    )(state);
+
+    expect(finalState.data).to.eql({
+      httpStatus: 'OK',
+      message: 'the response',
+    });
+  });
+});
+
+describe('request', () => {
+  const state = {
+    configuration: {
+      username: 'admin',
+      password: 'district',
+      hostUrl: 'https://play.dhis2.org/2.36.4',
+    },
+    data: {
+      program: 'program1',
+      orgUnit: 'org50',
+      trackedEntityType: 'nEenWmSyUEp',
+      status: 'COMPLETED',
+      date: '02-02-20',
+    },
+  };
+
+  it('should create a tracker resource', async () => {
+    testServer
+      .post('/api/tracker?importStrategy=CREATE', {
+        orgUnit: 'TSyzvBiovKh',
+        trackedEntityType: 'nEenWmSyUEp',
+        attributes: [
+          {
+            attribute: 'w75KJ2mc4zz',
+            value: 'Qassime',
+          },
+        ],
+      })
+      .times(2)
+      .matchHeader('authorization', 'Basic YWRtaW46ZGlzdHJpY3Q=')
+      .reply(200, {
+        httpStatus: 'OK',
+        message: 'the response',
+      });
+
+    const finalState = await execute(
+      request('POST', 'tracker', {
+        data: {
+          orgUnit: 'TSyzvBiovKh',
+          trackedEntityType: 'nEenWmSyUEp',
+          attributes: [
+            {
+              attribute: 'w75KJ2mc4zz',
+              value: 'Qassime',
+            },
+          ],
+        },
+        params: {
+          importStrategy: 'CREATE',
+        },
+      })
+    )(state);
+
+    expect(finalState.data).to.eql({
+      httpStatus: 'OK',
+      message: 'the response',
+    });
+  });
+
+  it('should get a trackedEntity', async () => {
+    testServer.get('/api/tracker/trackedEntities/F8yKM85NbxW').reply(200, {
+      httpStatus: 'OK',
+      message: 'the response',
+    });
+
+    const finalState = await execute(
+      request('GET', 'tracker/trackedEntities/F8yKM85NbxW')
     )(state);
 
     expect(finalState.data).to.eql({

--- a/packages/dhis2/test/integration.js
+++ b/packages/dhis2/test/integration.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import crypto from 'node:crypto';
-import { execute, create, update, get, upsert } from '../dist/index.js';
+import { execute, create, update, upsert, http } from '../dist/index.js';
 
 const getRandomProgramPayload = () => {
   const name = crypto.randomBytes(16).toString('hex');
@@ -252,7 +252,7 @@ describe('Integration tests', () => {
 
     it('should get dataValueSets matching the query specified', async () => {
       const finalState = await execute(
-        get('dataValueSets', {
+        http.get('dataValueSets', {
           dataSet: 'pBOMPrpg1QX',
           orgUnit: 'DiszpKrYNg8',
           period: '201401',
@@ -265,7 +265,7 @@ describe('Integration tests', () => {
 
     it('should get a single TEI based on multiple filters', async () => {
       const finalState = await execute(
-        get('tracker/trackedEntities', {
+        http.get('tracker/trackedEntities', {
           program: 'fDd25txQckK',
           orgUnit: 'DiszpKrYNg8',
           filter: ['w75KJ2mc4zz:Eq:Elanor'],
@@ -275,7 +275,7 @@ describe('Integration tests', () => {
       expect(finalState.data.instances.length).to.eq(1);
 
       const finalState2 = await execute(
-        get('trackedEntityInstances', {
+        http.get('trackedEntityInstances', {
           program: 'fDd25txQckK',
           ou: 'DiszpKrYNg8',
           filter: ['w75KJ2mc4zz:Eq:Elanor', 'zDhUuAYrxNC:Eq:NotJackson'],
@@ -287,7 +287,7 @@ describe('Integration tests', () => {
 
     it('should get a no TEIs if non match the filters', async () => {
       const finalState = await execute(
-        get('trackedEntityInstances', {
+        http.get('trackedEntityInstances', {
           program: 'IpHINAT79UW',
           ou: 'DiszpKrYNg8',
           filter: [


### PR DESCRIPTION
## Summary

Move all the generic functions into a `http` namespace, remove callbacks and add a generic `request` function.

Fixes #978 

## Details

All the generic functions such as `post`, `get`, and `update` are moved to their own name-spaced file to separate them from the other specific functions, and a generic `request` function was added as well.

All callbacks are being removed since the same behaviour can be achieved with promise chaining

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
