### PR TITLE
OpenMRS: support error maps (common: support errors:false)

### DIFF
--- a/.changeset/cuddly-garlics-lay.md
+++ b/.changeset/cuddly-garlics-lay.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-openmrs': minor
----
-
-Allow errors to be passed to the http helpers. This overrides the behaviour to
-throw if an error code is returned

--- a/.changeset/cuddly-garlics-lay.md
+++ b/.changeset/cuddly-garlics-lay.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-openmrs': minor
+---
+
+Allow errors to be passed to the http helpers. This overrides the behaviour to
+throw if an error code is returned

--- a/.changeset/red-rats-judge.md
+++ b/.changeset/red-rats-judge.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-common': patch
+---
+
+Allow the errorMap passed into the request helper to be false, which suppresses
+all errors

--- a/.changeset/red-rats-judge.md
+++ b/.changeset/red-rats-judge.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-common': patch
----
-
-Allow the errorMap passed into the request helper to be false, which suppresses
-all errors

--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-asana
 
+## 4.0.9
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 4.0.8
 
 ### Patch Changes

--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-asana",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "An adaptor to access objects in Asana",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-azure-storage
 
+## 2.0.9
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 2.0.8
 
 ### Patch Changes

--- a/packages/azure-storage/package.json
+++ b/packages/azure-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-azure-storage",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "OpenFn adaptor for Azure Storage",
   "type": "module",
   "exports": {

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-beyonic
 
+## 0.3.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.3.10
 
 ### Patch Changes

--- a/packages/beyonic/package.json
+++ b/packages/beyonic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-beyonic",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "beyonic Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-bigquery
 
+## 3.0.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 3.0.9
 
 ### Patch Changes

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-bigquery",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "A Google BigQuery language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cartodb
 
+## 0.4.12
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.4.11
 
 ### Patch Changes

--- a/packages/cartodb/package.json
+++ b/packages/cartodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-cartodb",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "cartodb Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/chatgpt/CHANGELOG.md
+++ b/packages/chatgpt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-chatgpt
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/chatgpt/package.json
+++ b/packages/chatgpt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-chatgpt",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenFn chatgpt adaptor",
   "type": "module",
   "exports": {

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cht
 
+## 1.0.9
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.8
 
 ### Patch Changes

--- a/packages/cht/package.json
+++ b/packages/cht/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-cht",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "OpenFn CHT adaptor",
   "type": "module",
   "exports": {

--- a/packages/claude/CHANGELOG.md
+++ b/packages/claude/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-claude
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/claude/package.json
+++ b/packages/claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-claude",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenFn claude adaptor",
   "type": "module",
   "exports": {

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-collections
 
+## 0.7.5
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.7.4
 
 ### Patch Changes

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-collections",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "OpenFn collections adaptor",
   "type": "module",
   "exports": {

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-commcare
 
+## 3.2.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 3.2.9
 
 ### Patch Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-commcare",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "description": "Commcare Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 2.3.0
 
+## 2.3.1
+
+### Patch Changes
+
+- 23ccb01: Allow the errorMap passed into the request helper to be false, which
+  suppresses all errors
+
 ### Minor Changes
 
 - b3d7f59: Common util functions `encode` and `decode` can now take a JavaScript

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-common",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Common Expressions for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/src/http.js
+++ b/packages/common/src/http.js
@@ -59,7 +59,7 @@ export function options(opts = {}) {
 /**
  * Options provided to the HTTP request
  * @typedef {Object} CommonRequestOptions
- * @property {object} errors - Map of errorCodes -> error messages, ie, `{ 404: 'Resource not found;' }`. Pass `false` to suppress errors.
+ * @property {object|boolean} errors - Map of errorCodes -> error messages, ie, `{ 404: 'Resource not found;' }`. Pass `false` to suppress errors.
  * @property {object} form - Pass a JSON object to be serialised into a multipart HTML form (as FormData) in the body.
  * @property {object} query - An object of query parameters to be encoded into the URL.
  * @property {object} headers - An object of headers to append to the request.

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -47,6 +47,10 @@ export const enableMockClient = baseUrl => {
 };
 
 const assertOK = async (response, errorMap, fullUrl, method, startTime) => {
+  if (errorMap == false) {
+    return;
+  }
+
   const errMapMessage = errorMap[response.statusCode];
 
   const isError =

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -47,7 +47,7 @@ export const enableMockClient = baseUrl => {
 };
 
 const assertOK = async (response, errorMap, fullUrl, method, startTime) => {
-  if (errorMap == false) {
+  if (errorMap === false) {
     return;
   }
 

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -377,6 +377,25 @@ describe('options', () => {
     );
   });
 
+  it('should not throw for 404 if errors is false', async () => {
+    client
+      .intercept({
+        path: '/api/content',
+        method: 'GET',
+      })
+      .reply(404, {});
+
+    const response = await request(
+      'GET',
+      'https://www.example.com/api/content',
+      {
+        errors: false,
+      }
+    );
+
+    expect(response.statusCode).to.eql(404);
+  });
+
   it('should encode keys and values of query', async () => {
     let request;
     client

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dhis2
 
+## 6.3.1
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 6.3.0
 
 ### Minor Changes

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dhis2",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "DHIS2 Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dynamics
 
+## 0.5.13
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.5.12
 
 ### Patch Changes

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dynamics",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "A Microsoft Dynamics Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "2.3.0",
+    "@openfn/language-common": "2.3.1",
     "request": "^2.72.0"
   },
   "devDependencies": {

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-facebook
 
+## 0.4.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.4.10
 
 ### Patch Changes

--- a/packages/facebook/package.json
+++ b/packages/facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-facebook",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "An Language Package for Facebook Messenger API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/fhir-fr/CHANGELOG.md
+++ b/packages/fhir-fr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir-fr
 
+## 1.0.8
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.7
 
 ### Patch Changes

--- a/packages/fhir-fr/package.json
+++ b/packages/fhir-fr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-fhir-fr",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OpenFn fhir-fr adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-fr src ast docs",

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir-ndr-et
 
+## 0.1.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.1.10
 
 ### Patch Changes

--- a/packages/fhir-ndr-et/package.json
+++ b/packages/fhir-ndr-et/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-fhir-ndr-et",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "OpenFn fhir adaptor for NDR HIV in Ehtiopia",
   "type": "module",
   "exports": {

--- a/packages/ghana-bdr/CHANGELOG.md
+++ b/packages/ghana-bdr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ghana-bdr
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/ghana-bdr/package.json
+++ b/packages/ghana-bdr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ghana-bdr",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenFn ghana-bdr adaptor",
   "type": "module",
   "exports": {

--- a/packages/ghana-nia/CHANGELOG.md
+++ b/packages/ghana-nia/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ghana-nia
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/ghana-nia/package.json
+++ b/packages/ghana-nia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ghana-nia",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenFn ghana-nia adaptor",
   "type": "module",
   "exports": {

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-gmail
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-gmail",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "OpenFn gmail adaptor",
   "type": "module",
   "exports": {

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googlesheets
 
+## 3.0.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 3.0.9
 
 ### Patch Changes

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-googlesheets",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "A Google Sheets Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-hive
 
+## 0.3.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.3.10
 
 ### Patch Changes

--- a/packages/hive/package.json
+++ b/packages/hive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-hive",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "An Apache HIVE adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-http
 
+## 7.0.1
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 7.0.0
 
 ### Major Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-http",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/hubtel/CHANGELOG.md
+++ b/packages/hubtel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-hubtel
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/hubtel/package.json
+++ b/packages/hubtel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-hubtel",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenFn hubtel adaptor",
   "type": "module",
   "exports": {

--- a/packages/intuit/CHANGELOG.md
+++ b/packages/intuit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-intuit
 
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.0
 
 Initial release.

--- a/packages/intuit/package.json
+++ b/packages/intuit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-intuit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenFn intuit adaptor",
   "type": "module",
   "exports": {

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-khanacademy
 
+## 0.5.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.5.10
 
 ### Patch Changes

--- a/packages/khanacademy/package.json
+++ b/packages/khanacademy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-khanacademy",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "A Khan Academy Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-kobotoolbox
 
+## 3.0.2
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 3.0.1
 
 ### Patch Changes

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-kobotoolbox",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A Kobo Toolbox Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailchimp
 
+## 1.0.12
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.11
 
 ### Patch Changes

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mailchimp",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "An OpenFn adaptor for use with Mailchimp",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailgun
 
+## 0.5.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.5.9
 
 ### Patch Changes

--- a/packages/mailgun/package.json
+++ b/packages/mailgun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mailgun",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "mailgun Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-maximo
 
+## 0.5.13
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.5.12
 
 ### Patch Changes

--- a/packages/maximo/package.json
+++ b/packages/maximo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-maximo",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "An IBM Maximo EAM Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-medicmobile
 
+## 0.5.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.5.10
 
 ### Patch Changes

--- a/packages/medicmobile/package.json
+++ b/packages/medicmobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-medicmobile",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "A Medic Mobile language pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -1,5 +1,12 @@
 v0.1.6
 
+## 0.5.12
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.5.11
 
 ### Patch Changes

--- a/packages/mogli/package.json
+++ b/packages/mogli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mogli",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "A Mogli SMS Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mojatax/CHANGELOG.md
+++ b/packages/mojatax/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mojatax
 
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/mojatax/package.json
+++ b/packages/mojatax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mojatax",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "OpenFn mojatax adaptor",
   "type": "module",
   "exports": {

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mongodb
 
+## 2.1.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 2.1.10
 
 ### Patch Changes

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mongodb",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "A language package for working with MongoDb",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msgraph
 
+## 0.7.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.7.10
 
 ### Patch Changes

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-msgraph",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Microsoft Graph Language Pack for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mssql
 
+## 5.0.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 5.0.10
 
 ### Patch Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mssql",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mysql
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mysql",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A MySQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "main": "dist/index.cjs",

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-nexmo
 
+## 0.5.13
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.5.12
 
 ### Patch Changes

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-nexmo",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "An Language Package for Nexmo",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ocl
 
+## 1.2.12
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.2.11
 
 ### Patch Changes

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ocl",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "An OCL language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {
@@ -20,7 +20,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "2.3.0"
+    "@openfn/language-common": "2.3.1"
   },
   "devDependencies": {
     "assertion-error": "^1.0.1",

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-odk
 
+## 3.0.12
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/odk/package.json
+++ b/packages/odk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-odk",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "OpenFn odk adaptor",
   "type": "module",
   "exports": {

--- a/packages/odoo/CHANGELOG.md
+++ b/packages/odoo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-odoo
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/odoo/package.json
+++ b/packages/odoo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-odoo",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenFn odoo adaptor",
   "type": "module",
   "exports": {

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openfn
 
+## 2.0.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 2.0.9
 
 ### Patch Changes

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openfn",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "An (experimental) adaptor for accessing the OpenFn web API",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openhim
 
+## 0.3.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.3.9
 
 ### Patch Changes

--- a/packages/openhim/package.json
+++ b/packages/openhim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openhim",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "openhim Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openimis
 
+## 2.0.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 2.0.9
 
 ### Patch Changes

--- a/packages/openimis/package.json
+++ b/packages/openimis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openimis",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "An OpenIMIS adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openlmis
 
+## 1.0.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.0.10
 
 ### Patch Changes

--- a/packages/openlmis/package.json
+++ b/packages/openlmis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openlmis",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "OpenFn openlmis adaptor",
   "type": "module",
   "exports": {

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @openfn/language-openmrs
 
+## 4.4.0
+
+### Minor Changes
+
+- 23ccb01: Allow errors to be passed to the http helpers. This overrides the
+  behaviour to throw if an error code is returned
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 4.3.0
 
 ### Minor Changes

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openmrs",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "OpenMRS Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openmrs/src/Utils.js
+++ b/packages/openmrs/src/Utils.js
@@ -41,6 +41,8 @@ export async function request(state, method, path, options = {}) {
   const authHeaders = makeBasicAuthHeader(username, password);
 
   const opts = {
+    ...options,
+    baseUrl,
     body: data,
     headers: {
       ...authHeaders,
@@ -50,8 +52,6 @@ export async function request(state, method, path, options = {}) {
     parseAs,
   };
 
-  const url = `${baseUrl}${path}`;
-
   let allResponses;
   let queryParams = opts?.query;
   let allowPagination = isNaN(queryParams?.startIndex);
@@ -59,7 +59,7 @@ export async function request(state, method, path, options = {}) {
   do {
     const requestOptions = queryParams ? { ...opts, query: queryParams } : opts;
 
-    const response = await commonRequest(method, url, requestOptions);
+    const response = await commonRequest(method, path, requestOptions);
     logResponse(response);
 
     if (allResponses) {

--- a/packages/openmrs/src/http.js
+++ b/packages/openmrs/src/http.js
@@ -7,6 +7,7 @@ import * as util from './Utils';
  * @property {object} query - An object of query parameters to be encoded into the URL
  * @property {object} headers - An object of all request headers
  * @property {object} body - The request body (as JSON)
+ * @property {object|boolean} errors - Pass `false` to not throw on errors. Pass a map of errorCodes: error messages, ie, `{ 404: 'Resource not found' }`, or `false` to suppress errors for a specific code.
  * @property {string} [parseAs='json'] - The response format to parse (e.g., 'json', 'text', or 'stream')
  */
 
@@ -15,9 +16,9 @@ import * as util from './Utils';
  * @example <caption>GET request with a URL query</caption>
  * http.request("GET",
  *   "/ws/rest/v1/patient/d3f7e1a8-0114-4de6-914b-41a11fc8a1a8", {
- *    query:{ 
- *       limit: 1, 
- *       offset: 20 
+ *    query:{
+ *       limit: 1,
+ *       offset: 20
  *    },
  * });
  * @function
@@ -56,21 +57,36 @@ export function request(method, path, options = {}) {
  *      limit: 1
  *    }
  *  }
- *  )
+ * )
+ * @example <caption>Don't throw if OpenMRS returns a 404 error code</caption>
+ * http.get(
+ *  "/ws/rest/v1/patient",
+ *  {
+ *    errors: { 404: false }
+ *  }
+ * )
  * @param {string} path - path to resource
  * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
  * @returns {operation}
  */
 export function get(path, options = {}) {
   return async state => {
-    const [resolvedPath, resolvedOptions] = expandReferences(state, path, options);
+    const [resolvedPath, resolvedOptions] = expandReferences(
+      state,
+      path,
+      options
+    );
 
-    const response = await util.request(state, 'GET', resolvedPath, resolvedOptions);
+    const response = await util.request(
+      state,
+      'GET',
+      resolvedPath,
+      resolvedOptions
+    );
 
     return util.prepareNextState(state, response);
   };
 }
-
 
 /**
  * Make a POST request to an OpenMRS endpoint
@@ -99,19 +115,28 @@ export function get(path, options = {}) {
  * @returns {operation}
  */
 export function post(path, data, options = {}) {
-  return  async state => {
-    const [resolvedPath, resolvedData, resolvedOptions] = expandReferences(state, path, data, options);
+  return async state => {
+    const [resolvedPath, resolvedData, resolvedOptions] = expandReferences(
+      state,
+      path,
+      data,
+      options
+    );
 
     const optionsObject = {
       data: resolvedData,
-      ...resolvedOptions
-    }
-    const response = await util.request(state, 'POST', resolvedPath, optionsObject);
+      ...resolvedOptions,
+    };
+    const response = await util.request(
+      state,
+      'POST',
+      resolvedPath,
+      optionsObject
+    );
 
     return util.prepareNextState(state, response);
-  }
+  };
 }
-
 
 /**
  * Make a DELETE request to an OpenMRS endpoint
@@ -126,14 +151,23 @@ export function post(path, data, options = {}) {
  * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
  * @returns {operation}
  */
- function _delete(path, options = {}) {
-  return  async state => {
-    const [resolvedPath, resolvedOptions] = expandReferences(state, path, options);
+function _delete(path, options = {}) {
+  return async state => {
+    const [resolvedPath, resolvedOptions] = expandReferences(
+      state,
+      path,
+      options
+    );
 
-    const response = await util.request(state, 'DELETE', resolvedPath, resolvedOptions);
+    const response = await util.request(
+      state,
+      'DELETE',
+      resolvedPath,
+      resolvedOptions
+    );
 
     return util.prepareNextState(state, response);
-  }
+  };
 }
 
 export { _delete as delete };

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openspp
 
+## 2.0.9
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 2.0.8
 
 ### Patch Changes

--- a/packages/openspp/package.json
+++ b/packages/openspp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openspp",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "An OpenFn adaptor for working with the OpenSPP json rpc",
   "type": "module",
   "exports": {

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-postgresql
 
+## 6.0.9
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 6.0.8
 
 ### Patch Changes

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-postgresql",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "description": "A PostgreSQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-primero
 
+## 3.0.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 3.0.9
 
 ### Patch Changes

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-primero",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "A UNICEF Primero language package for use with Open Function",
   "exports": {
     ".": {

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-redis
 
+## 1.2.8
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.2.7
 
 ### Patch Changes

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-redis",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "OpenFn redis adaptor",
   "type": "module",
   "exports": {

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-resourcemap
 
+## 0.4.12
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.4.11
 
 ### Patch Changes

--- a/packages/resourcemap/package.json
+++ b/packages/resourcemap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-resourcemap",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Resourcemap Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-salesforce
 
+## 5.0.5
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 5.0.4
 
 ### Patch Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-salesforce",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "OpenFn Salesforce adaptor",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-satusehat
 
+## 2.0.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 2.0.9
 
 ### Patch Changes

--- a/packages/satusehat/package.json
+++ b/packages/satusehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-satusehat",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "OpenFn Satusehat adaptor",
   "type": "module",
   "exports": {

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-sftp
 
+## 2.0.9
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 2.0.8
 
 ### Patch Changes

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-sftp",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "An SFTP language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-telerivet
 
+## 0.3.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.3.9
 
 ### Patch Changes

--- a/packages/telerivet/package.json
+++ b/packages/telerivet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-telerivet",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "telerivet Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -26,7 +26,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:*"
+    "@openfn/language-common": "workspace:2.3.0"
   },
   "devDependencies": {
     "assertion-error": "2.0.0",

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-vtiger
 
+## 1.3.11
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 1.3.10
 
 ### Patch Changes

--- a/packages/vtiger/package.json
+++ b/packages/vtiger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-vtiger",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "A Vtiger Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/wigal-sms/CHANGELOG.md
+++ b/packages/wigal-sms/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-wigal-sms
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/wigal-sms/package.json
+++ b/packages/wigal-sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-wigal-sms",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenFn wigal-sms adaptor",
   "type": "module",
   "exports": {

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-zoho
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies [23ccb01]
+  - @openfn/language-common@2.3.1
+
 ## 0.4.9
 
 ### Patch Changes

--- a/packages/zoho/package.json
+++ b/packages/zoho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-zoho",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "zoho Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,7 +444,7 @@ importers:
   packages/dynamics:
     dependencies:
       '@openfn/language-common':
-        specifier: 2.3.0
+        specifier: 2.3.1
         version: link:../common
       request:
         specifier: ^2.72.0
@@ -1367,7 +1367,7 @@ importers:
   packages/ocl:
     dependencies:
       '@openfn/language-common':
-        specifier: 2.3.0
+        specifier: 2.3.1
         version: link:../common
     devDependencies:
       assertion-error:
@@ -1984,31 +1984,6 @@ importers:
         specifier: ^1.12.0
         version: 1.12.0
 
-  packages/testing:
-    dependencies:
-      '@openfn/language-common':
-        specifier: workspace:*
-        version: link:../common
-    devDependencies:
-      assertion-error:
-        specifier: 2.0.0
-        version: 2.0.0
-      chai:
-        specifier: 4.3.6
-        version: 4.3.6
-      deep-eql:
-        specifier: 4.1.1
-        version: 4.1.1
-      esno:
-        specifier: ^4.7.0
-        version: 4.7.0
-      rimraf:
-        specifier: 3.0.2
-        version: 3.0.2
-      undici:
-        specifier: ^5.22.1
-        version: 5.28.5
-
   packages/twilio:
     dependencies:
       '@openfn/language-common':
@@ -2241,7 +2216,7 @@ importers:
   tools/import-tests:
     dependencies:
       '@openfn/language-common':
-        specifier: workspace:^2.3.0
+        specifier: workspace:*
         version: link:../../packages/common
 
   tools/metadata:
@@ -3032,15 +3007,6 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: false
 
-  /@esbuild/aix-ppc64@0.21.5:
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/aix-ppc64@0.23.1:
     resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
     engines: {node: '>=18'}
@@ -3056,15 +3022,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/android-arm64@0.21.5:
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.23.1:
@@ -3093,15 +3050,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-arm@0.21.5:
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-arm@0.23.1:
     resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
     engines: {node: '>=18'}
@@ -3117,15 +3065,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/android-x64@0.21.5:
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.23.1:
@@ -3145,15 +3084,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.21.5:
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/darwin-arm64@0.23.1:
     resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
     engines: {node: '>=18'}
@@ -3169,15 +3099,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.21.5:
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.23.1:
@@ -3197,15 +3118,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.21.5:
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/freebsd-arm64@0.23.1:
     resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
     engines: {node: '>=18'}
@@ -3221,15 +3133,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.21.5:
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.23.1:
@@ -3249,15 +3152,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm64@0.21.5:
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-arm64@0.23.1:
     resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
     engines: {node: '>=18'}
@@ -3275,15 +3169,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm@0.21.5:
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-arm@0.23.1:
     resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
     engines: {node: '>=18'}
@@ -3299,15 +3184,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-ia32@0.21.5:
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.23.1:
@@ -3336,15 +3212,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-loong64@0.21.5:
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-loong64@0.23.1:
     resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
     engines: {node: '>=18'}
@@ -3360,15 +3227,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-mips64el@0.21.5:
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.23.1:
@@ -3388,15 +3246,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.21.5:
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-ppc64@0.23.1:
     resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
     engines: {node: '>=18'}
@@ -3412,15 +3261,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-riscv64@0.21.5:
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.23.1:
@@ -3440,15 +3280,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-s390x@0.21.5:
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-s390x@0.23.1:
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
     engines: {node: '>=18'}
@@ -3466,15 +3297,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-x64@0.21.5:
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-x64@0.23.1:
     resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
     engines: {node: '>=18'}
@@ -3490,15 +3312,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.21.5:
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.23.1:
@@ -3527,15 +3340,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.21.5:
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/openbsd-x64@0.23.1:
     resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
     engines: {node: '>=18'}
@@ -3551,15 +3355,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.21.5:
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.23.1:
@@ -3579,15 +3374,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-arm64@0.21.5:
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-arm64@0.23.1:
     resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
     engines: {node: '>=18'}
@@ -3605,15 +3391,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-ia32@0.21.5:
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-ia32@0.23.1:
     resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
     engines: {node: '>=18'}
@@ -3629,15 +3406,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/win32-x64@0.21.5:
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.23.1:
@@ -7452,37 +7220,6 @@ packages:
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
 
-  /esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
-    dev: true
-
   /esbuild@0.23.1:
     resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
     engines: {node: '>=18'}
@@ -7748,13 +7485,6 @@ packages:
     hasBin: true
     dependencies:
       tsx: 3.14.0
-
-  /esno@4.7.0:
-    resolution: {integrity: sha512-81owrjxIxOwqcABt20U09Wn8lpBo9K6ttqbGvQcB3VYNLJyaV1fvKkDtpZd3Rj5BX3WXiGiJCjUevKQGNICzJg==}
-    hasBin: true
-    dependencies:
-      tsx: 4.15.4
-    dev: true
 
   /esno@4.8.0:
     resolution: {integrity: sha512-acMtooReAQGzLU0zcuEDHa8S62meh5aIyi8jboYxyvAePdmuWx2Mpwmt0xjwO0bs9/SXf+dvXJ0QJoDWw814Iw==}
@@ -13693,17 +13423,6 @@ packages:
       source-map-support: 0.5.21
     optionalDependencies:
       fsevents: 2.3.3
-
-  /tsx@4.15.4:
-    resolution: {integrity: sha512-d++FLCwJLrXaBFtRcqdPBzu6FiVOJ2j+UsvUZPtoTrnYtCGU5CEW7iHXtNZfA2fcRTvJFWPqA6SWBuB0GSva9w==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    dependencies:
-      esbuild: 0.21.5
-      get-tsconfig: 4.7.5
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
 
   /tsx@4.19.2:
     resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ packages:
   - 'tools/**'
   # exclude packages that are inside test directories
   - '!**/test/**'
+  # exclude testing
+  - '!packages/testing/**

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,4 +6,4 @@ packages:
   # exclude packages that are inside test directories
   - '!**/test/**'
   # exclude testing
-  - '!packages/testing/**
+  - '!packages/testing/**'

--- a/tools/import-tests/package.json
+++ b/tools/import-tests/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@openfn/language-common": "workspace:^2.3.0"
+    "@openfn/language-common": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary

This PR allows `errors` to be passed to all http functions, which lets users prevent throw-on-error for some or all error codes.

It also adds behaviour to common.http to pass `errors:false` and disable all error checking.

Fixes #1055

Annoyingly there are a lot of formatting diffs in this PR :(

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
