### PR TITLE
common: return `''` when response status code is `204`

### DIFF
--- a/.changeset/calm-flies-listen.md
+++ b/.changeset/calm-flies-listen.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': patch
+---
+
+Return an empty string if response status code is `204`

--- a/.changeset/calm-flies-listen.md
+++ b/.changeset/calm-flies-listen.md
@@ -2,4 +2,4 @@
 '@openfn/language-common': patch
 ---
 
-Return an empty string if response status code is `204`
+Return an empty string if response status code is `204` and do not parse the body

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -245,6 +245,10 @@ async function readResponseBody(response, parseAs) {
       return undefined;
     }
 
+    if (response.statusCode === 204) {
+      return '';
+    }
+
     switch (parseAs) {
       case 'json':
         return await response.body.json();

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -234,6 +234,22 @@ describe('request function', () => {
     expect(response.body).to.eql(undefined);
   });
 
+  it('should return an empty string if response status code is 204', async () => {
+    client
+      .intercept({
+        path: '/api',
+        method: 'PATCH',
+      })
+      .reply(204, '');
+
+    const response = await request('PATCH', 'https://www.example.com/api', {
+      body: { id: 2 },
+    });
+
+    expect(response.statusCode).to.eql(204);
+    expect(response.body).to.eql('');
+  });
+
   it('should throw an error if there is no content-length header and an empty response body', async () => {
     client
       .intercept({


### PR DESCRIPTION
## Summary

Do not parse the response body when the status code is `204`, but instead return an empty string in `state.data`

Fixes #1058 

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
