### PR TITLE
update jsforce to v3

### DIFF
--- a/.changeset/green-dogs-yell.md
+++ b/.changeset/green-dogs-yell.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-salesforce': patch
+---
+
+- Update jsforce library to v3 nodejs build

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@openfn/language-common": "workspace:*",
     "any-ascii": "^0.3.2",
-    "jsforce": "^1.11.1",
+    "@jsforce/jsforce-node": "^3.6.6",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/salesforce/src/meta/helper.js
+++ b/packages/salesforce/src/meta/helper.js
@@ -1,4 +1,4 @@
-import jsforce from 'jsforce';
+import { Connection } from '@jsforce/jsforce-node';
 
 const createHelper = (configuration = {}) => {
   const { loginUrl, username, password, securityToken } = configuration;
@@ -47,7 +47,7 @@ const createHelper = (configuration = {}) => {
 
   return new Promise(resolve => {
     if (loginUrl) {
-      conn = new jsforce.Connection({
+      conn = new Connection({
         loginUrl,
       });
       conn.login(username, password + securityToken, (err, res) => {

--- a/packages/salesforce/src/util.js
+++ b/packages/salesforce/src/util.js
@@ -1,4 +1,4 @@
-import jsforce from 'jsforce';
+import { Connection } from '@jsforce/jsforce-node';
 import { throwError } from '@openfn/language-common/util';
 
 function getConnection(state, options) {
@@ -13,7 +13,7 @@ function getConnection(state, options) {
   }
   console.log('Using Salesforce API version:', options.version);
 
-  return new jsforce.Connection(options);
+  return new Connection(options);
 }
 
 async function createBasicAuthConnection(state) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1819,15 +1819,15 @@ importers:
 
   packages/salesforce:
     dependencies:
+      '@jsforce/jsforce-node':
+        specifier: ^3.6.6
+        version: 3.6.6
       '@openfn/language-common':
         specifier: workspace:*
         version: link:../common
       any-ascii:
         specifier: ^0.3.2
         version: 0.3.2
-      jsforce:
-        specifier: ^1.11.1
-        version: 1.11.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -3602,6 +3602,25 @@ packages:
       jsep: 1.4.0
     dev: false
 
+  /@jsforce/jsforce-node@3.6.6:
+    resolution: {integrity: sha512-WdIo2lLbrz6nkfiaz2UynyaNiM8o+fEjaRev7zA4KKSaQYB1MJ66xHubeI5Iheq8WgkY9XGwWKAwPDhuV+GROQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      base64url: 3.0.1
+      csv-parse: 5.6.0
+      csv-stringify: 6.5.2
+      faye: 1.4.0
+      form-data: 4.0.0
+      https-proxy-agent: 5.0.1
+      multistream: 3.1.0
+      node-fetch: 2.6.9
+      xml2js: 0.6.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
   /@ljharb/through@2.3.13:
     resolution: {integrity: sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==}
     engines: {node: '>= 0.4'}
@@ -3732,6 +3751,11 @@ packages:
       '@redis/client': ^1.0.0
     dependencies:
       '@redis/client': 1.6.0
+    dev: false
+
+  /@sindresorhus/is@4.6.0:
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
     dev: false
 
   /@sinonjs/commons@1.8.3:
@@ -5236,9 +5260,9 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: false
 
-  /base64-url@2.3.3:
-    resolution: {integrity: sha512-dLMhIsK7OplcDauDH/tZLvK7JmUZK3A7KiQpjNzsBrM6Etw7hzNI1tLEywqJk9NnwkgWuFKSlx/IUO7vF6Mo8Q==}
-    engines: {node: '>=6'}
+  /base64url@3.0.1:
+    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
+    engines: {node: '>=6.0.0'}
     dev: false
 
   /base@0.11.2:
@@ -5963,12 +5987,6 @@ packages:
     hasBin: true
     dev: false
 
-  /coffeescript@1.12.7:
-    resolution: {integrity: sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    dev: false
-
   /collect-all@1.0.4:
     resolution: {integrity: sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==}
     engines: {node: '>=0.10.0'}
@@ -6246,15 +6264,17 @@ packages:
     resolution: {integrity: sha512-JiQosUWiOFgp4hQn0an+SBoV9IKdqzhROM0iiN4LB7UpfJBlsSJlWl9nq4zGgxgMAzHJ6V4t29VAVD+3+2NJAg==}
     dev: false
 
-  /csv-stringify@1.1.2:
-    resolution: {integrity: sha512-3NmNhhd+AkYs5YtM1GEh01VR6PKj6qch2ayfQaltx5xpcAdThjnbbI5eT8CzRVpXfGKAxnmrSYLsNl/4f3eWiw==}
-    dependencies:
-      lodash.get: 4.4.2
+  /csv-parse@5.6.0:
+    resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
     dev: false
 
   /csv-stringify@5.6.5:
     resolution: {integrity: sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==}
     dev: true
+
+  /csv-stringify@6.5.2:
+    resolution: {integrity: sha512-RFPahj0sXcmUyjrObAK+DOWtMvMIFV328n4qZJhgX3x2RqkQgOTU2mCUmiFR0CzM6AzChlRSUErjiJeEt8BaQA==}
+    dev: false
 
   /csv@5.5.3:
     resolution: {integrity: sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==}
@@ -9342,11 +9362,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /is-wsl@1.1.0:
-    resolution: {integrity: sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==}
-    engines: {node: '>=4'}
-    dev: false
-
   /is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
@@ -9555,28 +9570,6 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
-
-  /jsforce@1.11.1:
-    resolution: {integrity: sha512-u1vL2F4FYRNccwjwA3ftMULEf9Ekeyvsz7vYKeQ03sKg6m7DNwB2O9d0erCM7k5sQUJ44J39CI05nokDKN3ktw==}
-    engines: {node: '>=4.0'}
-    hasBin: true
-    dependencies:
-      base64-url: 2.3.3
-      co-prompt: 1.0.0
-      coffeescript: 1.12.7
-      commander: 2.20.3
-      csv-parse: 4.16.3
-      csv-stringify: 1.1.2
-      faye: 1.4.0
-      inherits: 2.0.4
-      lodash: 4.17.21
-      multistream: 2.1.1
-      opn: 5.5.0
-      promise: 7.3.1
-      readable-stream: 2.3.8
-      request: 2.88.2
-      xml2js: 0.5.0
     dev: false
 
   /jsforce@1.5.1:
@@ -10518,11 +10511,11 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  /multistream@2.1.1:
-    resolution: {integrity: sha512-xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==}
+  /multistream@3.1.0:
+    resolution: {integrity: sha512-zBgD3kn8izQAN/TaL1PCMv15vYpf+Vcrsfub06njuYVYlzUldzpopTlrEZ53pZVEbfn3Shtv7vRFoOv6LOV87Q==}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 2.3.8
+      readable-stream: 3.6.2
     dev: false
 
   /mustache@2.3.2:
@@ -10914,13 +10907,6 @@ packages:
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /opn@5.5.0:
-    resolution: {integrity: sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==}
-    engines: {node: '>=4'}
-    dependencies:
-      is-wsl: 1.1.0
     dev: false
 
   /optimist@0.3.7:
@@ -11509,12 +11495,6 @@ packages:
     resolution: {integrity: sha512-O+uwGKreKNKkshzZv2P7N64lk6EP17iXBn0PbUnNQhk+Q0AHLstiTrjkx3v5YBd3cxUe7Sq6KyRhl/A0xUjk7Q==}
     dependencies:
       asap: 1.0.0
-    dev: false
-
-  /promise@7.3.1:
-    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
-    dependencies:
-      asap: 2.0.6
     dev: false
 
   /promise@8.3.0:
@@ -14067,6 +14047,14 @@ packages:
 
   /xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+    dev: false
+
+  /xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
     dependencies:
       sax: 1.2.4


### PR DESCRIPTION
## Summary

Update salesforce adaptor to use the latest version of `jsforcev3`

Fixes #1028

## Details

- Use jsforce node build to reduce bundle size. Update the library to `"@jsforce/jsforce-node": "^3.6.6",`
- Update `util.js` and `helper.js` to use `jsforce-node` import
- Ran integration test locally to confirm nothing is breaking 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
