### PR TITLE
feat(#731): Add mSet() function to redis adaptor

### DIFF
--- a/.changeset/modern-ways-share.md
+++ b/.changeset/modern-ways-share.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-redis': minor
+---
+
+add mSet() function on redis adaptor

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,6 @@ dist
 .fuse_*
 
 .vscode/
-
+.idea
 
 /pnpm-publish-summary.json

--- a/packages/redis/ast.json
+++ b/packages/redis/ast.json
@@ -457,12 +457,12 @@
         "entries"
       ],
       "docs": {
-        "description": "Sets multiple JSON documents at specified keys in a single operation.\nIf any key already exists, its value will be replaced by the new value.",
+        "description": "Sets multiple JSON objects at their respective keys. If a key already exists,\nthe existing value will be replaced by the new value.",
         "tags": [
           {
             "title": "example",
-            "description": "mSet([{ key: 'patient', value: { name: 'Alice' } }, { key: 'doctor', value: { name: 'Bob' } }]);",
-            "caption": "Set JSON documents for multiple keys"
+            "description": "mSet([{ key: 'patient', value: { name: 'victor', ihs_number: 12345 } },\n      { key: 'doctor', value: { name: 'Alice', specialization: 'cardiology' } }]);",
+            "caption": "Set multiple JSON objects"
           },
           {
             "title": "function",
@@ -476,31 +476,39 @@
           },
           {
             "title": "param",
-            "description": "Array of key/value pairs to set",
+            "description": "An array of key-value pairs to set in the JSON store.",
             "type": {
-              "type": "ArrayType",
-              "elements": [
+              "type": "TypeApplication",
+              "expression": {
+                "type": "NameExpression",
+                "name": "Array"
+              },
+              "applications": [
                 {
                   "type": "RecordType",
                   "fields": [
                     {
+                      "type": "FieldType",
                       "key": "key",
                       "value": {
-                        "type": "UnionType",
-                        "elements": [
-                          { "type": "NameExpression", "name": "string" },
-                          { "type": "NameExpression", "name": "function" }
-                        ]
+                        "type": "NameExpression",
+                        "name": "string"
                       }
                     },
                     {
+                      "type": "FieldType",
                       "key": "value",
                       "value": {
                         "type": "UnionType",
                         "elements": [
-                          { "type": "NameExpression", "name": "string" },
-                          { "type": "NameExpression", "name": "object" },
-                          { "type": "NameExpression", "name": "function" }
+                          {
+                            "type": "NameExpression",
+                            "name": "string"
+                          },
+                          {
+                            "type": "NameExpression",
+                            "name": "object"
+                          }
                         ]
                       }
                     }

--- a/packages/redis/ast.json
+++ b/packages/redis/ast.json
@@ -452,6 +452,81 @@
       "valid": true
     },
     {
+      "name": "mSet",
+      "params": [
+        "entries"
+      ],
+      "docs": {
+        "description": "Sets multiple JSON documents at specified keys in a single operation.\nIf any key already exists, its value will be replaced by the new value.",
+        "tags": [
+          {
+            "title": "example",
+            "description": "mSet([{ key: 'patient', value: { name: 'Alice' } }, { key: 'doctor', value: { name: 'Bob' } }]);",
+            "caption": "Set JSON documents for multiple keys"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "param",
+            "description": "Array of key/value pairs to set",
+            "type": {
+              "type": "ArrayType",
+              "elements": [
+                {
+                  "type": "RecordType",
+                  "fields": [
+                    {
+                      "key": "key",
+                      "value": {
+                        "type": "UnionType",
+                        "elements": [
+                          { "type": "NameExpression", "name": "string" },
+                          { "type": "NameExpression", "name": "function" }
+                        ]
+                      }
+                    },
+                    {
+                      "key": "value",
+                      "value": {
+                        "type": "UnionType",
+                        "elements": [
+                          { "type": "NameExpression", "name": "string" },
+                          { "type": "NameExpression", "name": "object" },
+                          { "type": "NameExpression", "name": "function" }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "entries"
+          },
+          {
+            "title": "state",
+            "description": "references - an array of all previous data objects used in the Job"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "scan",
       "params": [
         "pattern",

--- a/packages/redis/ast.json
+++ b/packages/redis/ast.json
@@ -457,7 +457,7 @@
         "entries"
       ],
       "docs": {
-        "description": "Sets multiple JSON objects at their respective keys. If a key already exists,\nthe existing value will be replaced by the new value.",
+        "description": "Set values at the root path ('$') in JSON documents stored at multiple keys.\nThis function allows setting multiple key-value pairs in Redis JSON documents in a single operation.\nIf a key already exists, its value will be replaced. If it does not exist, a new key-value pair will be created.",
         "tags": [
           {
             "title": "example",

--- a/packages/redis/src/Adaptor.js
+++ b/packages/redis/src/Adaptor.js
@@ -254,28 +254,30 @@ export function jSet(key, value) {
 }
 
 /**
- * Set values at the root path ('$') in JSON documents stored at multiple keys.
- * @example <caption>Set JSON document values for patient and doctor keys</caption>
- * mSet([{ key: "patient", value: { name: "John" } }, { key: "doctor", value: { age: 42 } }]);
+ * Sets multiple JSON objects at their respective keys. If a key already exists,
+ * the existing value will be replaced by the new value.
+ * @example <caption>Set multiple JSON objects</caption>
+ * mSet([{ key: 'patient', value: { name: 'victor', ihs_number: 12345 } },
+ *       { key: 'doctor', value: { name: 'Alice', specialization: 'cardiology' } }]);
  * @function
  * @public
- * @param {Array<{ key: string|function, value: any|function }>} entries - Array of key/value pairs
- * @state {RedisState}
+ * @param {Array<{ key: string, value: (string|object) }>} entries -
+ * An array of key-value pairs to set in the JSON store.
+ * @state references - an array of all previous data objects used in the Job
  * @returns {Operation}
  */
 export function mSet(entries) {
   return async state => {
     const [resolvedEntries] = expandReferences(state, entries);
-    
-    // New dedicated validation
+
     util.assertMSetArgs(resolvedEntries);
-    
+
     console.log(`Setting values for ${resolvedEntries.length} keys`);
-    
+
     const args = resolvedEntries.flatMap(({ key, value }) => [
       key,
       '$',
-      typeof value === 'string' ? value : JSON.stringify(value)
+      typeof value === 'string' ? value : JSON.stringify(value),
     ]);
 
     await client.json.mSet(...args);
@@ -310,7 +312,7 @@ export function scan(pattern, options = {}) {
     const [resolvedPattern, resolvedOptions] = expandReferences(
       state,
       pattern,
-      options
+      options,
     );
     console.log(`Scanning for keys matching '${resolvedPattern}'`);
 

--- a/packages/redis/src/Adaptor.js
+++ b/packages/redis/src/Adaptor.js
@@ -254,8 +254,9 @@ export function jSet(key, value) {
 }
 
 /**
- * Sets multiple JSON objects at their respective keys. If a key already exists,
- * the existing value will be replaced by the new value.
+ * Set values at the root path ('$') in JSON documents stored at multiple keys.
+ * This function allows setting multiple key-value pairs in Redis JSON documents in a single operation.
+ * If a key already exists, its value will be replaced. If it does not exist, a new key-value pair will be created.
  * @example <caption>Set multiple JSON objects</caption>
  * mSet([{ key: 'patient', value: { name: 'victor', ihs_number: 12345 } },
  *       { key: 'doctor', value: { name: 'Alice', specialization: 'cardiology' } }]);

--- a/packages/redis/src/Adaptor.js
+++ b/packages/redis/src/Adaptor.js
@@ -275,16 +275,16 @@ export function mSet(entries) {
 
     console.log(`Setting values for ${resolvedEntries.length} keys`);
 
-    const args = resolvedEntries.flatMap(({ key, value }) => [
+    const args = resolvedEntries.map(({ key, value }) => ({
       key,
-      '$',
-      typeof value === 'string' ? value : JSON.stringify(value),
-    ]);
-
-    await client.json.mSet(...args);
+      path: "$",
+      value: typeof value === "string" ? value : JSON.stringify(value),
+    }));
+    
+    const result = await client.json.mSet(args);
     console.log(`Set values for ${resolvedEntries.length} keys successfully`);
 
-    return state;
+    return composeNextState(state, result);  
   };
 }
 

--- a/packages/redis/src/Adaptor.js
+++ b/packages/redis/src/Adaptor.js
@@ -254,6 +254,38 @@ export function jSet(key, value) {
 }
 
 /**
+ * Set values at the root path ('$') in JSON documents stored at multiple keys.
+ * @example <caption>Set JSON document values for patient and doctor keys</caption>
+ * mSet([{ key: "patient", value: { name: "John" } }, { key: "doctor", value: { age: 42 } }]);
+ * @function
+ * @public
+ * @param {Array<{ key: string|function, value: any|function }>} entries - Array of key/value pairs
+ * @state {RedisState}
+ * @returns {Operation}
+ */
+export function mSet(entries) {
+  return async state => {
+    const [resolvedEntries] = expandReferences(state, entries);
+    
+    // New dedicated validation
+    util.assertMSetArgs(resolvedEntries);
+    
+    console.log(`Setting values for ${resolvedEntries.length} keys`);
+    
+    const args = resolvedEntries.flatMap(({ key, value }) => [
+      key,
+      '$',
+      typeof value === 'string' ? value : JSON.stringify(value)
+    ]);
+
+    await client.json.mSet(...args);
+    console.log(`Set values for ${resolvedEntries.length} keys successfully`);
+
+    return state;
+  };
+}
+
+/**
  * Returns all keys which match the provided pattern.
  * scan iterates the whole database to find the matching keys
  * @example <caption>Scan for matching keys</caption>

--- a/packages/redis/src/Utils.js
+++ b/packages/redis/src/Utils.js
@@ -73,3 +73,52 @@ export const assertjGetArgs = key => {
     `Make sure to pass a string for jGet(): e.g., jGet('patient')`
   );
 };
+
+export const assertMSetArgs = (entries) => {
+  assertArgType(
+    entries,
+    'object',
+    'mSet requires an array of key/value objects: mSet([{ key: "name", value: "..." }])'
+  );
+  
+  if (!Array.isArray(entries)) {
+    throwArgumentError('array', 'mSet requires an array of key/value pairs');
+  }
+
+  entries.forEach((entry, index) => {
+    if (typeof entry !== 'object' || entry === null) {
+      throwArgumentError(
+        'object',
+        `Entry ${index} must be an object with { key, value }`
+      );
+    }
+
+    if (!('key' in entry)) {
+      throwArgumentError(
+        'key property',
+        `Entry ${index} is missing required 'key' property`
+      );
+    }
+    assertArgType(
+      entry.key,
+      'string',
+      `Key in entry ${index} must be a string`
+    );
+
+    if (!('value' in entry)) {
+      throwArgumentError(
+        'value property',
+        `Entry ${index} is missing required 'value' property`
+      );
+    }
+  });
+};
+
+// Reuse existing error helper from set()
+const throwArgumentError = (expectedType, fixMessage) => {
+  const e = new Error(`TypeError: Invalid argument type`);
+  e.code = 'ARGUMENT_ERROR';
+  e.description = `Expected ${expectedType}`;
+  e.fix = fixMessage;
+  throw e;
+};

--- a/packages/redis/src/Utils.js
+++ b/packages/redis/src/Utils.js
@@ -114,7 +114,6 @@ export const assertMSetArgs = (entries) => {
   });
 };
 
-// Reuse existing error helper from set()
 const throwArgumentError = (expectedType, fixMessage) => {
   const e = new Error(`TypeError: Invalid argument type`);
   e.code = 'ARGUMENT_ERROR';

--- a/packages/redis/test/Adaptor.test.js
+++ b/packages/redis/test/Adaptor.test.js
@@ -626,10 +626,10 @@ describe('jSet', () => {
 describe('mSet', () => {
   const mSetClient = {
     json: {
-      mSet: async (...args) => {
+      mSet: async (args) => {
         expect(args).to.deep.equal([
-          'animals:1', '$', JSON.stringify({ name: 'mammoth' }),
-          'plants:1', '$', JSON.stringify({ type: 'tree' })
+          { key: 'animals:1', path: '$', value: JSON.stringify({ name: 'mammoth' }) },
+          { key: 'plants:1', path: '$', value: JSON.stringify({ type: 'tree' }) },
         ]);
         return 'OK';
       },
@@ -684,10 +684,10 @@ describe('mSet', () => {
   it('should always set results at the document root', async () => {
     setMockClient({
       json: {
-        mSet: async (...args) => {
-          for (let i = 1; i < args.length; i += 3) {
-            expect(args[i]).to.eql('$');
-          }
+        mSet: async (args) => {
+          args.forEach(({ path }) => {
+            expect(path).to.eql('$');
+          });
         },
       },
     });


### PR DESCRIPTION
## Summary

Feat #731: Add `mSet()` function to redis adaptor
Related to #739 

## Details

Add `mSet()` function, which allows you to set multiple key-value pairs at once.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [x] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [x] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
