### PR TITLE
dhis2: Remove discover and switch to `async/await`

### DIFF
--- a/.changeset/warm-pots-rest.md
+++ b/.changeset/warm-pots-rest.md
@@ -1,0 +1,11 @@
+---
+'@openfn/language-dhis2': major
+---
+
+- Remove `discover()` function
+- Switch to `async/await`
+- Bump `axios` version to `1.8.2`
+- Implement better `upsert()` multiple entinties error
+- Fixed `get` with `parseAs:base64`
+- Update state docs in jsDoc
+

--- a/packages/dhis2/ast.json
+++ b/packages/dhis2/ast.json
@@ -68,6 +68,10 @@
             "name": "callback"
           },
           {
+            "title": "state",
+            "description": "{Dhis2State}"
+          },
+          {
             "title": "returns",
             "description": null,
             "type": {
@@ -213,6 +217,10 @@
             "name": "callback"
           },
           {
+            "title": "state",
+            "description": "{Dhis2State}"
+          },
+          {
             "title": "returns",
             "description": null,
             "type": {
@@ -333,8 +341,12 @@
             "name": "callback"
           },
           {
+            "title": "state",
+            "description": "{Dhis2State}"
+          },
+          {
             "title": "returns",
-            "description": "state",
+            "description": null,
             "type": {
               "type": "NameExpression",
               "name": "Operation"
@@ -447,8 +459,12 @@
             "name": "callback"
           },
           {
+            "title": "state",
+            "description": "{Dhis2State}"
+          },
+          {
             "title": "returns",
-            "description": "state",
+            "description": null,
             "type": {
               "type": "NameExpression",
               "name": "Operation"
@@ -543,6 +559,10 @@
               "type": "NameExpression",
               "name": "RangeError"
             }
+          },
+          {
+            "title": "state",
+            "description": "{Dhis2State}"
           },
           {
             "title": "returns",
@@ -640,6 +660,10 @@
             "name": "callback"
           },
           {
+            "title": "state",
+            "description": "{Dhis2State}"
+          },
+          {
             "title": "returns",
             "description": null,
             "type": {
@@ -731,6 +755,10 @@
               }
             },
             "name": "callback"
+          },
+          {
+            "title": "state",
+            "description": "{Dhis2State}"
           },
           {
             "title": "returns",

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@openfn/language-common": "workspace:*",
-    "axios": "^1.7.7",
+    "axios": "^1.8.2",
     "lodash": "^4.17.21",
     "qs": "^6.11.0"
   },

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -480,11 +480,8 @@ export function get(resourceType, options = {}, callback = s => s) {
     );
 
     const { parseAs } = resolvedOptions;
-    const { configuration } = state;
 
-    let response;
-
-    response = await request(configuration, {
+    const response = await request(state.configuration, {
       method: 'GET',
       path: prefixVersionToPath(
         configuration,
@@ -494,9 +491,11 @@ export function get(resourceType, options = {}, callback = s => s) {
       options: resolvedOptions,
     });
 
+    if (parseAs === 'base64') {
+      response.body = encode(response.body);
+    }
     console.log(`Retrieved ${resolvedResourceType}`);
-    response =
-      parseAs === 'base64' ? { body: encode(response.body) } : response;
+
     return handleResponse(response, state, callback);
   };
 }

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -552,9 +552,10 @@ export function post(resourceType, data, options = {}, callback = s => s) {
 
 /**
  * Upsert a record. A generic helper function used to atomically either insert a row, or on the basis of the row already existing, UPDATE that existing row instead.
+ * This function does not work with the absolute tracker path `api/tracker` but rather the new tracker paths and deprecated tracker endpoints.
  * @public
  * @function
- * @param {string} resourceType - The type of a resource to `upsert`. E.g. `trackedEntities`
+ * @param {string} resourceType - The type of a resource to `upsert`. E.g. `trackedEntities`.
  * @param {Object} query - A query object that allows to uniquely identify the resource to update. If no matches found, then the resource will be created.
  * @param {Object} data - The data to use for update or create depending on the result of the query.
  * @param {RequestOptions} [options] - An optional object containing query, parseAs,and headers for the request

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -479,7 +479,7 @@ export function get(resourceType, options = {}, callback = s => s) {
       options
     );
 
-    const { parseAs} = resolvedOptions;
+    const { parseAs } = resolvedOptions;
     const { configuration } = state;
 
     let response;
@@ -495,7 +495,8 @@ export function get(resourceType, options = {}, callback = s => s) {
     });
 
     console.log(`Retrieved ${resolvedResourceType}`);
-    response = parseAs === 'base64' ? { body: encode(response.body) } : response;
+    response =
+      parseAs === 'base64' ? { body: encode(response.body) } : response;
     return handleResponse(response, state, callback);
   };
 }

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -484,7 +484,7 @@ export function get(resourceType, options = {}, callback = s => s) {
     const response = await request(state.configuration, {
       method: 'GET',
       path: prefixVersionToPath(
-        configuration,
+        state.configuration,
         resolvedOptions,
         resolvedResourceType
       ),

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -11,6 +11,14 @@ import {
 } from './Utils';
 
 /**
+ * State object
+ * @typedef {Object} Dhis2State
+ * @property data - The response body (as JSON)
+ * @property response - The HTTP response from the Dhis2 server (excluding the body)
+ * @property references - An array of all previous data objects used in the Job
+ */
+
+/**
  * Options object
  * @typedef {Object} RequestOptions
  * @property {object} query - An object of query parameters to be encoded into the URL
@@ -84,6 +92,7 @@ function configMigrationHelper(state) {
  * @param {Dhis2Data} data - Object which defines data that will be used to create a given instance of resource. To create a single instance of a resource, `data` must be a javascript object, and to create multiple instances of a resources, `data` must be an array of javascript objects.
  * @param {RequestOptions} [options] - An optional object containing query, parseAs,and headers for the request.
  * @param {function} [callback] - Optional callback to handle the response
+ * @state {Dhis2State}
  * @returns {Operation}
  * @example <caption>Create a program</caption>
  * create('programs', {
@@ -255,6 +264,7 @@ export function create(resourceType, data, options = {}, callback = s => s) {
  * @param {Object} data - Data to update. It requires to send `all required fields` or the `full body`. If you want `partial updates`, use `patch` operation.
  * @param {RequestOptions} [options] - An optional object containing query, parseAs,and headers for the request.
  * @param {function} [callback]  - Optional callback to handle the response
+ * @state {Dhis2State}
  * @returns {Operation}
  * @example <caption>a program</caption>
  * update('programs', 'qAZJCrNJK8H', {
@@ -425,7 +435,8 @@ export function update(
  * @param {string} resourceType - The type of resource to get(use its `plural` name). E.g. `dataElements`, `tracker/trackedEntities`,`organisationUnits`, etc.
  * @param {RequestOptions} [options] - An optional object containing query, parseAs,and headers for the request
  * @param {function} [callback]  - Optional callback to handle the response
- * @returns {Operation} state
+ * @state {Dhis2State}
+ * @returns {Operation}
  * @example <caption>Get all data values for the 'pBOMPrpg1QX' dataset</caption>
  * get('dataValueSets', {
  *  query:{
@@ -497,7 +508,8 @@ export function get(resourceType, options = {}, callback = s => s) {
  * @param {Dhis2Data} data - Object which defines data that will be used to create a given instance of resource. To create a single instance of a resource, `data` must be a javascript object, and to create multiple instances of a resources, `data` must be an array of javascript objects.
  * @param {RequestOptions} [options] - An optional object containing query, parseAs,and headers for the request.
  * @param {function} [callback] - Optional callback to handle the response
- * @returns {Operation} state
+ * @state {Dhis2State}
+ * @returns {Operation}
  * @example <caption>Create an event</caption>
  * post("tracker", {
  *   events: [
@@ -545,6 +557,7 @@ export function post(resourceType, data, options = {}, callback = s => s) {
  * @param {RequestOptions} [options] - An optional object containing query, parseAs,and headers for the request
  * @param {function} [callback] - Optional callback to handle the response
  * @throws {RangeError} - Throws range error
+ * @state {Dhis2State}
  * @returns {Operation}
  * @example <caption>Upsert a trackedEntity</caption>
  * upsert('trackedEntities', {}, {
@@ -666,6 +679,7 @@ export function upsert(
  * @param {Object} data - Data to update. Include only the fields you want to update. E.g. `{name: "New Name"}`
  * @param {RequestOptions} [options] - An optional object containing query, parseAs,and headers for the request.
  * @param {function} [callback] - Optional callback to handle the response
+ * @state {Dhis2State}
  * @returns {Operation}
  * @example <caption>a dataElement</caption>
  * patch('dataElements', 'FTRrcoaog83', { name: 'New Name' });
@@ -714,6 +728,7 @@ export function patch(
  * @param {Object} [data] - Optional. This is useful when you want to remove multiple objects from a collection in one request. You can send `data` as, for example, `{"identifiableObjects": [{"id": "IDA"}, {"id": "IDB"}, {"id": "IDC"}]}`. See more {@link https://docs.dhis2.org/2.34/en/dhis2_developer_manual/web-api.html#deleting-objects on DHIS2 API docs}
  * @param {RequestOptions} [options] - An optional object containing query, parseAs,and headers for the request.
  * @param {function} [callback] - Optional callback to handle the response
+ * @state {Dhis2State}
  * @returns {Operation}
  * @example <caption>a tracked entity instance. See [Delete tracker docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#webapi_nti_import)</caption>
  * destroy('trackedEntities', 'LcRd6Nyaq7T');

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -27,8 +27,7 @@ import {
  * @typedef {Object} RequestOptions
  * @property {object} query - An object of query parameters to be encoded into the URL
  * @property {object} headers - An object of all request headers
- * @property {boolean} [asBase64=false] - Optional flag to indicate if the response should be returned as a Base64 encoded string when using the `get` operation.
- * @property {string} [parseAs='json'] - The response format to parse (e.g., 'json', 'text', or 'stream'. Defaults to `json`
+ * @property {string} [parseAs='json'] - The response format to parse (e.g., 'json', 'text', 'stream', or 'base64'. Defaults to `json`
  * @property {string} [apiVersion=42] - The apiVersion of the request. Defaults to 42.
  */
 
@@ -467,8 +466,7 @@ export function update(
  *   headers:{
  *       Accept: 'image/*'
  *   },
- *   parseAs: 'text',
- *   asBase64: true
+ *   parseAs: 'base64',
  * });
  */
 export function get(resourceType, options = {}, callback = s => s) {
@@ -481,7 +479,7 @@ export function get(resourceType, options = {}, callback = s => s) {
       options
     );
 
-    const { asBase64 = false } = resolvedOptions;
+    const { parseAs} = resolvedOptions;
     const { configuration } = state;
 
     let response;
@@ -497,7 +495,7 @@ export function get(resourceType, options = {}, callback = s => s) {
     });
 
     console.log(`Retrieved ${resolvedResourceType}`);
-    response = asBase64 ? { body: encode(response.body) } : response;
+    response = parseAs === 'base64' ? { body: encode(response.body) } : response;
     return handleResponse(response, state, callback);
   };
 }

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -1,5 +1,9 @@
 import { execute as commonExecute } from '@openfn/language-common';
-import { expandReferences, encode } from '@openfn/language-common/util';
+import {
+  expandReferences,
+  encode,
+  throwError,
+} from '@openfn/language-common/util';
 
 import {
   handleResponse,
@@ -628,9 +632,12 @@ export function upsert(
       });
       const resources = response.body[resourceType];
       if (resources.length > 1) {
-        throw new RangeError(
-          `Cannot upsert on Non-unique attribute. The operation found more than one records for your request.`
-        );
+        throwError(409, {
+          description:
+            'Upsert failed: Multiple records found for a non-unique attribute.',
+          fix: 'Ensure the attribute is unique or modify the request to target a single record.',
+          error: 'Conflict',
+        });
       } else if (resources.length <= 0) {
         console.log(`Preparing create operation...`);
         response = await request(configuration, {

--- a/packages/dhis2/test/index.test.js
+++ b/packages/dhis2/test/index.test.js
@@ -189,8 +189,7 @@ describe('get', () => {
         headers: {
           Accept: 'image/*',
         },
-        parseAs: 'text',
-        asBase64: true,
+        parseAs: 'base64',
       })
     )(state);
     expect(finalState.data).to.eql(
@@ -595,7 +594,7 @@ describe('upsert', () => {
             }
           )
         )(state),
-      'Cannot upsert on Non-unique attribute. The operation found more than one records for your request.'
+      '409: Upsert failed: Multiple records found for a non-unique attribute.'
     );
   });
 

--- a/packages/dhis2/test/integration.js
+++ b/packages/dhis2/test/integration.js
@@ -12,7 +12,7 @@ const getRandomProgramPayload = () => {
 const configuration = {
   username: 'admin',
   password: 'district',
-  hostUrl: 'https://play.im.dhis2.org/stable-2-40-5',
+  hostUrl: 'https://play.im.dhis2.org/stable-2-40-7'
 };
 
 describe('Integration tests', () => {
@@ -155,7 +155,7 @@ describe('Integration tests', () => {
         ...fixture.initialState,
         event: 'rBjxtO8npTb',
         data: {
-          href: 'https://play.dhis2.org/2.36.6/api/events/rBjxtO8npTb',
+          href: 'https://play.dhis2.org/stable-2-40-7/api/events/rBjxtO8npTb',
           event: 'rBjxtO8npTb',
           status: 'ACTIVE',
           program: 'M3xtLkYBlKI',
@@ -253,10 +253,10 @@ describe('Integration tests', () => {
     it('should get dataValueSets matching the query specified', async () => {
       const finalState = await execute(
         get('dataValueSets', {
-          dataSet: 'pBOMPrpg1QX',
-          orgUnit: 'DiszpKrYNg8',
-          period: '201401',
-          fields: '*',
+       query:{   dataSet: 'pBOMPrpg1QX',
+        orgUnit: 'sx4lYrYvpJ2',
+        period: '201401',
+        fields: '*',}
         })
       )(state);
 
@@ -266,19 +266,23 @@ describe('Integration tests', () => {
     it('should get a single TEI based on multiple filters', async () => {
       const finalState = await execute(
         get('tracker/trackedEntities', {
+        query:{
           program: 'fDd25txQckK',
           orgUnit: 'DiszpKrYNg8',
           filter: ['w75KJ2mc4zz:Eq:Elanor'],
+        }
         })
       )(state);
 
       expect(finalState.data.instances.length).to.eq(1);
 
       const finalState2 = await execute(
-        http.get('trackedEntityInstances', {
-          program: 'fDd25txQckK',
-          ou: 'DiszpKrYNg8',
-          filter: ['w75KJ2mc4zz:Eq:Elanor', 'zDhUuAYrxNC:Eq:NotJackson'],
+        get('trackedEntityInstances', {
+      query:{
+        program: 'fDd25txQckK',
+        orgUnit: 'DiszpKrYNg8',
+        filter: ['w75KJ2mc4zz:Eq:Elanor', 'zDhUuAYrxNC:Eq:NotJackson'],
+      }
         })
       )(state);
 
@@ -288,15 +292,19 @@ describe('Integration tests', () => {
     it('should get a no TEIs if non match the filters', async () => {
       const finalState = await execute(
         get('trackedEntityInstances', {
-          program: 'IpHINAT79UW',
-          ou: 'DiszpKrYNg8',
-          filter: [
-            'w75KJ2mc4zz:Eq:Tim',
-            'flGbXLXCrEo:Eq:124-not-a-real-id', // case ID
-            'zDhUuAYrxNC:Eq:Thompson',
-          ],
+       query:{
+        program: 'IpHINAT79UW',
+        orgUnit: 'DiszpKrYNg8',
+        filter: [
+          'w75KJ2mc4zz:Eq:Tim',
+          'flGbXLXCrEo:Eq:124-not-a-real-id', // case ID
+          'zDhUuAYrxNC:Eq:Thompson',
+        ],
+       }
         })
       )(state);
+    
+      
 
       expect(finalState.data.trackedEntityInstances.length).to.eq(0);
     });
@@ -343,7 +351,7 @@ describe('Integration tests', () => {
           'trackedEntityInstances',
           {
             program: 'IpHINAT79UW',
-            ou: 'DiszpKrYNg8',
+            orgUnit: 'DiszpKrYNg8',
             filter: ['w75KJ2mc4zz:Eq:John', 'zDhUuAYrxNC:Eq:Thompson'],
           },
           state => state.data
@@ -353,7 +361,7 @@ describe('Integration tests', () => {
       expect(finalState.data.httpStatus).to.eq('OK');
     });
 
-    it('should upsert a trackedEntityInstance via update as query matches one data', async () => {
+    it.only('should upsert a trackedEntityInstance via update as query matches one data', async () => {
       const state = {
         ...fixture.initialState,
         data: {
@@ -372,7 +380,7 @@ describe('Integration tests', () => {
           'trackedEntityInstances',
           {
             program: 'IpHINAT79UW',
-            ou: 'TSyzvBiovKh',
+            orgUnit: 'TSyzvBiovKh',
             filter: ['w75KJ2mc4zz:Eq:Qassim'],
           },
           state => state.data
@@ -382,7 +390,7 @@ describe('Integration tests', () => {
       expect(finalState.data.httpStatus).to.eq('OK');
     });
 
-    it.skip('should fail upserting a trackedEntityInstance by throwing rangeError as query matches many data', async () => {
+    it('should fail upserting a trackedEntityInstance by throwing rangeError as query matches many data', async () => {
       const state = {
         ...fixture.initialState,
         data: {
@@ -416,7 +424,7 @@ describe('Integration tests', () => {
             upsert(
               'trackedEntityInstances',
               {
-                ou: 'DiszpKrYNg8',
+                orgUnit: 'DiszpKrYNg8',
                 filter: ['zDhUuAYrxNC:Eq:Thompson'],
               },
               state => state.data

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,8 +407,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       axios:
-        specifier: ^1.7.7
-        version: 1.7.7
+        specifier: ^1.8.2
+        version: 1.8.3
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -4731,6 +4731,16 @@ packages:
 
   /axios@1.7.7:
     resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /axios@1.8.3:
+    resolution: {integrity: sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==}
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.0
@@ -10326,7 +10336,7 @@ packages:
   /mailgun.js@9.2.0:
     resolution: {integrity: sha512-XfcHtwdE39g6C0Rh54sp8fKfHYxmP5LNC5Z5zZPdgYte760UXCKlT5ilfoqK2MRY0BSXj4F0qEvYAmtao/y4vw==}
     dependencies:
-      axios: 1.7.7
+      axios: 1.8.3
       base-64: 1.0.0
       url-join: 4.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

This PR extends  the work of #1059 (which was merged early)

Fixes #51 #1047 #975 #1049 #1036

## Details

This PR focused on:
- Remove `discover()` function
- Switch to `async/await`
- Bump `axios` version to `1.8.2`
- Implement better `upsert()` multiple entinties error
- Fixed `get` with `parseAs:base64`
- Update state docs in jsDoc

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
