### PR TITLE
http: add `POST` example to `request()` function

### DIFF
--- a/.changeset/dull-zoos-lay.md
+++ b/.changeset/dull-zoos-lay.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-http': patch
+---
+
+- Add a `POST` example to the `request()` function

--- a/packages/http/ast.json
+++ b/packages/http/ast.json
@@ -21,6 +21,11 @@
             "caption": "Make a GET request"
           },
           {
+            "title": "example",
+            "description": "request('POST', '/todos', {\n  body:{\n    \"userId\": 1,\n    \"title\": \"delectus aut autem\",\n    \"completed\": false\n  },\n  headers: { 'content-type': 'application/json' },\n});",
+            "caption": "Make a POST request with a body"
+          },
+          {
             "title": "function",
             "description": null,
             "name": null

--- a/packages/http/src/Adaptor.js
+++ b/packages/http/src/Adaptor.js
@@ -53,6 +53,15 @@ export function execute(...operations) {
  *   query: { foo: 'bar', a: 1 },
  *   headers: { 'content-type': 'application/json' },
  * });
+ * @example <caption>Make a POST request with a body</caption>
+ * request('POST', '/todos', {
+ *   body:{
+ *     "userId": 1,
+ *     "title": "delectus aut autem",
+ *     "completed": false
+ *   },
+ *   headers: { 'content-type': 'application/json' },
+ * });
  * @function
  * @param {string} method - The HTTP method to use.
  * @param {string} path - Path to resource. Can be an absolute URL if baseURL is NOT set on `state.configuration`.


### PR DESCRIPTION
## Summary

Add  `POST` example to `request()` function.

Fixes #1083 

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
