### PR TITLE
primero: add generic http helpers

### DIFF
--- a/.changeset/big-hornets-smell.md
+++ b/.changeset/big-hornets-smell.md
@@ -1,0 +1,14 @@
+---
+'@openfn/language-primero': minor
+---
+
+- Add http generic helpers with `GET`, `POST`, and `PATCH`.
+- With these new updates, you can now do this:
+
+```
+
+http.get('cases', {
+    query:{ remote: true }
+})
+
+```

--- a/packages/primero/src/Adaptor.js
+++ b/packages/primero/src/Adaptor.js
@@ -5,7 +5,7 @@ import {
 import { assembleError, scrubResponse, tryJson } from './Utils';
 import request from 'request';
 
-const composeNextState = (state, data, meta) => {
+export const composeNextState = (state, data, meta) => {
   const nextState = {
     ...state,
     data,

--- a/packages/primero/src/http.js
+++ b/packages/primero/src/http.js
@@ -1,0 +1,109 @@
+import {
+  expandReferences,
+} from '@openfn/language-common/util';
+import { request, prepareNextState } from './Utils';
+
+
+/**
+ * State object
+ * @typedef {Object} PrimeroHttpState
+ * @property data - The response body (as JSON)
+ * @property response - The HTTP response from the Primero server (excluding the body). Responses will be returned in JSON format
+ * @property references - An array of all previous data objects used in the Job
+ */
+
+/**
+ * Options object
+ * @typedef {Object} RequestOptions
+ * @property {object} query - An object of query parameters to be encoded into the URL
+ * @property {object} headers - An object of all request headers
+ * @property {string} [parseAs='json'] - The response format to parse (e.g., 'json', 'text', or 'stream')
+ */
+
+/**
+ * Make a GET request to any Primero endpoint.
+ * @public
+ * @function
+ * @example <caption>GET all cases</caption>
+ * http.get('/cases');
+ * @param {string} path - Path to the resource.
+ * @param {RequestOptions} [options = {}] - An object containing query params and headers for the request
+ * @state {PrimeroHttpState}
+ * @returns {Operation}
+ */
+export function get(path, options = {}) {
+  return async state => {
+
+    const [resolvedPath, resolvedOptions] = expandReferences(state, path, options);
+
+    const response = await request(state, 'GET', resolvedPath, resolvedOptions);
+    
+    console.log('✓', response.body.data.length, `${resolvedPath} fetched.`);
+    return prepareNextState(state, response);
+  };
+}
+
+/**
+ * Make a POST request to any Primero endpoint.
+ * @public
+ * @example <caption>POST a case to Primero</caption>
+ * http.post('cases',{
+ *     age: 16,
+ *     sex: "female",
+ *     name: "Edwine Edgemont",
+ * });
+ * @function
+ * @param {string} path - Path to the resource.
+ * @param {object} data - the body data in JSON format.
+ * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
+ * @state {PrimeroHttpState}
+ * @returns {Operation}
+ */
+export function post(path, data, options = {}) {
+  return async state => {
+
+    const [resolvedPath, resolvedOptions, resolvedData] = expandReferences(state, path, options, data);
+
+    const response = await request(state, 'POST', resolvedPath, {
+        ...resolvedOptions,
+        body: resolvedData
+    });
+        
+    console.log('✓', `${resolvedPath} created.`);
+    return prepareNextState(state, response);
+
+  };
+}
+
+/**
+ * Make a PATCH request to Primero
+ * @public
+ * @example <caption>Update a single case resource </caption>
+ * http.patch('cases/344f3c08-affc-4d8a-b4d3-925b9f4d2867', {
+ *   age: 17,
+ *   sex: "female",
+ *   name: "Edwine Edgemont",
+ *  });
+ * @function
+ * @param {string} path - Path to the resource.
+ * @param {object} data - the body data in JSON format.
+ * @param {RequestOptions} [options={}] - An object containing query params and headers for the request
+ * @state {PrimeroHttpState}
+ * @returns {Operation}
+ */
+export function patch(path, data, options = {}) {
+  return async state => {
+
+    const [resolvedPath, resolvedOptions, resolvedData] = expandReferences(state, path, options, data);
+
+    const response = await request(state, 'PATCH', resolvedPath, {
+        ...resolvedOptions,
+        body: resolvedData
+    });    
+    
+    console.log('✓', `${resolvedPath} updated.`);
+    return prepareNextState(state, response);
+
+  };
+}
+

--- a/packages/primero/src/index.js
+++ b/packages/primero/src/index.js
@@ -2,3 +2,4 @@ import * as Adaptor from './Adaptor';
 export default Adaptor;
 
 export * from './Adaptor';
+export * as http from './http';

--- a/packages/primero/test/index.js
+++ b/packages/primero/test/index.js
@@ -1,7 +1,22 @@
 import Adaptor from '../src';
+import { enableMockClient } from '@openfn/language-common/util';
 import pkg from 'chai';
 const { expect } = pkg;
 import nock from 'nock';
+import { http } from '../src';
+import { request } from '../src/Utils';
+
+const testServer = enableMockClient('https://demo-unicare-bih.primero.org');
+const jsonHeaders = {
+  headers: {
+    'Content-Type': 'application/json',
+  },
+};
+const configuration = {
+  username: 'test',
+  password: 'strongpassword',
+  url: 'https://demo-unicare-bih.primero.org',
+};
 
 const { execute, getCases, alterState } = Adaptor;
 
@@ -86,5 +101,99 @@ describe.skip('The getCases() function', () => {
       expect(counter).to.eql(2);
       console.log(nextState);
     });
+  });
+});
+
+describe('http.get', () => {
+  it('should GET with a query', async () => {
+    testServer
+      .intercept({
+        path: '/api/v2/cases',
+        query: { remote: true },
+        method: 'GET',
+      })
+      .reply(
+        200,
+        {
+          data: [{ name: 'Edwine Edgemont', sex: 'female' }],
+        },
+        { ...jsonHeaders }
+      );
+    const state = { configuration };
+
+    const response = await http.get('cases', {
+      query: { remote: true },
+    })(state);
+
+    expect(response.response.headers['content-type']).to.eql(
+      'application/json'
+    );
+  });
+
+  it('should make a GET request', async () => {
+    testServer
+      .intercept({
+        path: '/api/v2/cases',
+        method: 'GET',
+      })
+      .reply(
+        200,
+        {
+          data: [{ name: 'Edwine Edgemont', sex: 'female' }],
+        },
+        { ...jsonHeaders }
+      );
+    const state = { configuration };
+
+    const { data } = await http.get('cases')(state);
+    expect(data.data[0].name).to.eql('Edwine Edgemont');
+  });
+});
+
+describe('http.post', () => {
+  it('should make a POST request', async () => {
+    testServer
+      .intercept({
+        path: '/api/v2/cases',
+        method: 'POST',
+        data: {
+          data: {
+            name: 'Edwine Edgemont',
+            sex: 'female',
+          },
+        },
+      })
+      .reply(200, { data: { enabled: true, id: '123' } }, { ...jsonHeaders });
+    const state = { configuration };
+
+    const { data } = await http.post('cases', {
+      name: 'Edwine Edgemont',
+      sex: 'female',
+    })(state);
+    expect(data.data.enabled).to.eql(true);
+  });
+});
+
+describe('http.patch', () => {
+  it('should make a PATCH request', async () => {
+    testServer
+      .intercept({
+        path: '/api/v2/cases/123',
+        method: 'PATCH',
+        data: {
+          data: {
+            name: 'Edwine Edgemont',
+            sex: 'female',
+          },
+        },
+      })
+      .reply(200, { data: { enabled: true, id: '123' } }, { ...jsonHeaders });
+    const state = { configuration };
+
+    const { data } = await http.patch('cases/123', {
+      name: 'Edwine Edgemont',
+      sex: 'female',
+    })(state);
+    expect(data.data.enabled).to.eql(true);
   });
 });


### PR DESCRIPTION
## Summary

Add generic http helpers to `primero`.

Fixes #1087

## Details

Used `common` in the new `http` helper function as opposed to `request`.
Implemented `GET`, `POST`, and `PATCH` generic requests. 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
