### PR TITLE
dhis2: implement `util` namespace

### DIFF
--- a/.changeset/small-countries-double.md
+++ b/.changeset/small-countries-double.md
@@ -16,10 +16,6 @@ do this instead:
 
 ```
 
-fn(state =>{
-   const s = util.findAttributeValueById(state.tei, 'y1w2R6leVmh');
-   console.log(s);
-   return state;
-})
+util.findAttributeValueById(state.tei, 'y1w2R6leVmh');
 
 ```

--- a/.changeset/small-countries-double.md
+++ b/.changeset/small-countries-double.md
@@ -1,0 +1,25 @@
+---
+'@openfn/language-dhis2': major
+---
+
+- Implement a `util` namespace for non-operation helper functions.
+
+- This means that if you used to do this:
+
+```
+
+findAttributeValueById(state.tei, 'y1w2R6leVmh')
+
+```
+
+do this instead:
+
+```
+
+fn(state =>{
+   const s = util.findAttributeValueById(state.tei, 'y1w2R6leVmh');
+   console.log(s);
+   return state;
+})
+
+```

--- a/packages/dhis2/ast.json
+++ b/packages/dhis2/ast.json
@@ -384,7 +384,7 @@
           },
           {
             "title": "example",
-            "description": "get('trackedEntityInstances/qHVDKszQmdx/BqaEWTBG3RB/image', {\n  headers:{\n      Accept: 'image/*'\n  },\n  parseAs: 'text',\n  asBase64: true\n});",
+            "description": "get('trackedEntityInstances/qHVDKszQmdx/BqaEWTBG3RB/image', {\n  headers:{\n      Accept: 'image/*'\n  },\n  parseAs: 'base64',\n});",
             "caption": "Get an image from a trackedEntityInstance."
           }
         ]
@@ -489,7 +489,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Upsert a record. A generic helper function used to atomically either insert a row, or on the basis of the row already existing, UPDATE that existing row instead.",
+        "description": "Upsert a record. A generic helper function used to atomically either insert a row, or on the basis of the row already existing, UPDATE that existing row instead.\nThis function does not work with the absolute tracker path `api/tracker` but rather the new tracker paths and deprecated tracker endpoints.",
         "tags": [
           {
             "title": "public",
@@ -503,7 +503,7 @@
           },
           {
             "title": "param",
-            "description": "The type of a resource to `upsert`. E.g. `trackedEntities`",
+            "description": "The type of a resource to `upsert`. E.g. `trackedEntities`.",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -772,218 +772,6 @@
             "title": "example",
             "description": "destroy('trackedEntities', 'LcRd6Nyaq7T');",
             "caption": "a tracked entity instance. See [Delete tracker docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#webapi_nti_import)"
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
-      "name": "findAttributeValueById",
-      "params": [
-        "trackedEntity",
-        "attributeUid"
-      ],
-      "docs": {
-        "description": "Gets an attribute value by its uid",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "example",
-            "description": "findAttributeValueById(state.tei, 'y1w2R6leVmh')"
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "A tracked entity instance (TEI) object",
-            "type": {
-              "type": "NameExpression",
-              "name": "Object"
-            },
-            "name": "trackedEntity"
-          },
-          {
-            "title": "param",
-            "description": "The uid to search for in the TEI's attributes",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "attributeUid"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            }
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
-      "name": "findAttributeValue",
-      "params": [
-        "trackedEntity",
-        "attributeDisplayName"
-      ],
-      "docs": {
-        "description": "Gets an attribute value by its case-insensitive display name",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "example",
-            "description": "findAttributeValue(state.data.trackedEntities[0], 'first name')"
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "A tracked entity instance (TEI) object",
-            "type": {
-              "type": "NameExpression",
-              "name": "Object"
-            },
-            "name": "trackedEntity"
-          },
-          {
-            "title": "param",
-            "description": "The 'displayName' to search for in the TEI's attributes",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "attributeDisplayName"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            }
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
-      "name": "attr",
-      "params": [
-        "attribute",
-        "value"
-      ],
-      "docs": {
-        "description": "Converts an attribute ID and value into a DHIS2 attribute object",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "example",
-            "description": "attr('w75KJ2mc4zz', 'Elias')"
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "A tracked entity instance (TEI) attribute ID.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "attribute"
-          },
-          {
-            "title": "param",
-            "description": "The value for that attribute.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "value"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "object"
-            }
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
-      "name": "dv",
-      "params": [
-        "dataElement",
-        "value"
-      ],
-      "docs": {
-        "description": "Converts a dataElement and value into a DHIS2 dataValue object",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "example",
-            "description": "dv('f7n9E0hX8qk', 12)"
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "A data element ID.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "dataElement"
-          },
-          {
-            "title": "param",
-            "description": "The value for that data element.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "value"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "object"
-            }
           }
         ]
       },

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -782,65 +782,6 @@ export function destroy(
   };
 }
 
-/**
- * Gets an attribute value by its uid
- * @public
- * @example
- * findAttributeValueById(state.tei, 'y1w2R6leVmh')
- * @function
- * @param {Object} trackedEntity - A tracked entity instance (TEI) object
- * @param {string} attributeUid - The uid to search for in the TEI's attributes
- * @returns {string}
- */
-export function findAttributeValueById(trackedEntity, attributeUid) {
-  return trackedEntity?.attributes?.find(a => a?.attribute == attributeUid)
-    ?.value;
-}
-
-/**
- * Gets an attribute value by its case-insensitive display name
- * @public
- * @example
- * findAttributeValue(state.data.trackedEntities[0], 'first name')
- * @function
- * @param {Object} trackedEntity - A tracked entity instance (TEI) object
- * @param {string} attributeDisplayName - The 'displayName' to search for in the TEI's attributes
- * @returns {string}
- */
-export function findAttributeValue(trackedEntity, attributeDisplayName) {
-  return trackedEntity?.attributes?.find(
-    a => a?.displayName.toLowerCase() == attributeDisplayName.toLowerCase()
-  )?.value;
-}
-
-/**
- * Converts an attribute ID and value into a DHIS2 attribute object
- * @public
- * @example
- * attr('w75KJ2mc4zz', 'Elias')
- * @function
- * @param {string} attribute - A tracked entity instance (TEI) attribute ID.
- * @param {string} value - The value for that attribute.
- * @returns {object}
- */
-export function attr(attribute, value) {
-  return { attribute, value };
-}
-
-/**
- * Converts a dataElement and value into a DHIS2 dataValue object
- * @public
- * @example
- * dv('f7n9E0hX8qk', 12)
- * @function
- * @param {string} dataElement - A data element ID.
- * @param {string} value - The value for that data element.
- * @returns {object}
- */
-export function dv(dataElement, value) {
-  return { dataElement, value };
-}
-
 function callNewTracker(
   type = 'update',
   configuration,

--- a/packages/dhis2/src/index.js
+++ b/packages/dhis2/src/index.js
@@ -4,3 +4,4 @@ export { metadata };
 import * as Adaptor from './Adaptor';
 export default Adaptor;
 export * from './Adaptor';
+export * as util from './util';

--- a/packages/dhis2/src/index.ts
+++ b/packages/dhis2/src/index.ts
@@ -8,3 +8,5 @@ import * as Adaptor from './Adaptor';
 export default Adaptor;
 
 export * from './Adaptor';
+
+export * as util from './util';

--- a/packages/dhis2/src/util.js
+++ b/packages/dhis2/src/util.js
@@ -1,0 +1,74 @@
+/**
+ * Converts an attribute ID and value into a DHIS2 attribute object
+ * @public
+ * @example
+ * fn(state => {
+ *    const s = util.attr('w75KJ2mc4zz', 'Elias');
+ *    console.log(s);
+ *    return state;
+ * })
+ * @function
+ * @param {string} attribute - A tracked entity instance (TEI) attribute ID.
+ * @param {string} value - The value for that attribute.
+ * @returns {object}
+ */
+export function attr(attribute, value) {
+  return { attribute, value };
+}
+
+/**
+ * Converts a dataElement and value into a DHIS2 dataValue object
+ * @public
+ * @example
+ * fn(state => {
+ *   const s = util.dv('f7n9E0hX8qk', 12);
+ *   console.log(s);
+ *   return state
+ * })
+ * @function
+ * @param {string} dataElement - A data element ID.
+ * @param {string} value - The value for that data element.
+ * @returns {object}
+ */
+export function dv(dataElement, value) {
+  return { dataElement, value };
+}
+
+/**
+ * Gets an attribute value by its case-insensitive display name
+ * @public
+ * @example
+ * fn(state => {
+ *    const s = util.findAttributeValue(state.data.trackedEntities[0], 'first name');
+ *    console.log(s);
+ *    return state
+ * })
+ * @function
+ * @param {Object} trackedEntity - A tracked entity instance (TEI) object
+ * @param {string} attributeDisplayName - The 'displayName' to search for in the TEI's attributes
+ * @returns {string}
+ */
+export function findAttributeValue(trackedEntity, attributeDisplayName) {
+  return trackedEntity?.attributes?.find(
+    a => a?.displayName.toLowerCase() == attributeDisplayName.toLowerCase()
+  )?.value;
+}
+
+/**
+ * Gets an attribute value by its uid
+ * @public
+ * @example
+ * fn(state =>{
+ *   const s = util.findAttributeValueById(state.tei, 'y1w2R6leVmh');
+ *   console.log(s);
+ *   return state
+ * })
+ * @function
+ * @param {Object} trackedEntity - A tracked entity instance (TEI) object
+ * @param {string} attributeUid - The uid to search for in the TEI's attributes
+ * @returns {string}
+ */
+export function findAttributeValueById(trackedEntity, attributeUid) {
+  return trackedEntity?.attributes?.find(a => a?.attribute == attributeUid)
+    ?.value;
+}

--- a/packages/dhis2/test/index.test.js
+++ b/packages/dhis2/test/index.test.js
@@ -1,12 +1,5 @@
 import chai from 'chai';
-import {
-  execute,
-  create,
-  update,
-  get,
-  upsert,
-  patch,
-} from '../src/Adaptor';
+import { execute, create, update, get, upsert, patch } from '../src/Adaptor';
 import { dataValue } from '@openfn/language-common';
 import { enableMockClient } from '@openfn/language-common/util';
 import {
@@ -15,7 +8,7 @@ import {
   shouldUseNewTracker,
 } from '../src/Utils';
 
-import * as util from '../src/util'
+import * as util from '../src/util';
 
 const { expect } = chai;
 
@@ -405,7 +398,7 @@ describe('update', () => {
   });
 });
 
-describe.skip('patch', () => {
+describe('patch', () => {
   const state = {
     configuration,
     data: {

--- a/packages/dhis2/test/index.test.js
+++ b/packages/dhis2/test/index.test.js
@@ -5,8 +5,6 @@ import {
   update,
   get,
   upsert,
-  findAttributeValue,
-  findAttributeValueById,
   patch,
 } from '../src/Adaptor';
 import { dataValue } from '@openfn/language-common';
@@ -16,6 +14,8 @@ import {
   ensureArray,
   shouldUseNewTracker,
 } from '../src/Utils';
+
+import * as util from '../src/util'
 
 const { expect } = chai;
 
@@ -405,7 +405,7 @@ describe('update', () => {
   });
 });
 
-describe('patch', () => {
+describe.skip('patch', () => {
   const state = {
     configuration,
     data: {
@@ -749,7 +749,7 @@ describe('findAttributeValueById', () => {
       ],
     };
 
-    const theValue = findAttributeValueById(tei, 'Rslz2y06aBf');
+    const theValue = util.findAttributeValueById(tei, 'Rslz2y06aBf');
     expect(theValue).to.eql('McTesterson');
   });
 });
@@ -771,7 +771,7 @@ describe('findAttributeValue', () => {
       ],
     };
 
-    const theValue = findAttributeValue(tei, 'Surname');
+    const theValue = util.findAttributeValue(tei, 'Surname');
     expect(theValue).to.eql('McTesterson');
   });
 });


### PR DESCRIPTION
## Summary

Implement a `util` namespace for non-operation helper functions

Fixes #980

## Details

Moved all the non-operation helper functions to a separate util file and can be accessed using the `fn()` block:

```
fn(state =>{
   const s = util.findAttributeValueById(state.tei, 'y1w2R6leVmh');
   console.log(s);
   return state;
})

```

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
