### PR TITLE
adaptor: automate release dates to adaptor changelogs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,5 +15,9 @@
     "@openfn/parse-jsdoc",
     "@openfn/slack-notify",
     "import-tests"
-  ]
+  ],
+  "snapshot": {
+    "prereleaseTemplate": "{datetime}",
+    "useCalculatedVersion": true
+  }
 }

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ branch`.
 Version numbers should be bumped with `changeset` and git tags should be pushed
 to the release branch BEFORE merging.
 
-1. Run `pnpm changeset version` from root to bump versions
+1. Run `pnpm version:changeset` from root to bump versions and add release dates
 1. Run `pnpm install`
 1. Commit the new version numbers
 1. Push the branch

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "metadata": "pnpm -C tools/metadata cli",
     "slack:notify": "cd tools/slack && pnpm notify",
     "generate": "pnpm -C tools/generate cli generate",
-    "prerelease": "node scripts/prerelease.mjs --no-warnings"
+    "prerelease": "node scripts/prerelease.mjs --no-warnings",
+    "version:changeset": "pnpm changeset version --snapshot && node scripts/changeset-date.js"
   },
   "author": "Open Function Group",
   "license": "ISC",

--- a/scripts/changeset-date.js
+++ b/scripts/changeset-date.js
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+const adaptor = process.argv[2];
+if (!adaptor) {
+  console.error(
+    '❌ Please provide the adaptor name. Usage: node changeset-date.js <adaptor-name>'
+  );
+  process.exit(1);
+}
+
+const pkgPath = path.join('./packages', adaptor);
+
+const formatDate = datetime => {
+  const year = datetime.slice(0, 4);
+  const month = datetime.slice(4, 6);
+  const day = datetime.slice(6, 8);
+  return `${year}-${month}-${day}`;
+};
+
+const fixVersionInText = text =>
+  text.replace(/-(\d{14})/g, (_, dt) => `-${formatDate(dt)}`);
+
+const updateFile = (filePath, label) => {
+  if (fs.existsSync(filePath)) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const updated = fixVersionInText(content);
+    if (content !== updated) {
+      fs.writeFileSync(filePath, updated);
+      console.log(`✔ Updated ${label}`);
+    }
+  }
+};
+
+const pkgJsonPath = path.join(pkgPath, 'package.json');
+if (fs.existsSync(pkgJsonPath)) {
+  const json = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+  const newVersion = fixVersionInText(json.version);
+  if (json.version !== newVersion) {
+    json.version = newVersion;
+    fs.writeFileSync(pkgJsonPath, JSON.stringify(json, null, 2));
+    console.log(`✔ Updated version in ${adaptor}/package.json → ${newVersion}`);
+  }
+}
+
+updateFile(path.join(pkgPath, 'CHANGELOG.md'), `${adaptor}/CHANGELOG.md`);


### PR DESCRIPTION
## Summary

Automate adding release dates and changelogs to adaptor docs

Fixes #721

## Details

Use `snapshot` in `changeset` to automatically add dates to changelogs during adaptor releases.

The resulted output is a datetime looking like this: `20211213000730` and we have created another script to help convert this to `2021-12-13` for readability.

So instead of running 
`pnpm changeset version`

We run:

```
pnpm version:changeset  <adaptor-name>

```

The command runs :`pnpm changeset version --snapshot && node scripts/changeset-date.js` that ensures we get dates and update them accordingly 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
