### PR TITLE
OpenMRS: rework upsert

### DIFF
--- a/packages/openmrs/ast.json
+++ b/packages/openmrs/ast.json
@@ -232,10 +232,11 @@
       "name": "upsert",
       "params": [
         "path",
-        "data"
+        "data",
+        "params"
       ],
       "docs": {
-        "description": "Upsert a record. If the resource exists, it will be updated. Otherwise, a new resource will be created.",
+        "description": "Update a resource if it already exists, or otherwise create a new one.\n\nUpsert will first make a request for the target item (using the `path` and `params`) to see if it exists, and then issue a second create or update request.\nIf the query request returns multiple items, the upsert will throw an error.",
         "tags": [
           {
             "title": "public",
@@ -266,6 +267,15 @@
             "name": "data"
           },
           {
+            "title": "param",
+            "description": "Query parameters to append to the initial query",
+            "type": {
+              "type": "NameExpression",
+              "name": "Object"
+            },
+            "name": "params"
+          },
+          {
             "title": "state",
             "description": "data The created/updated resource, as returned by OpenMRS"
           },
@@ -281,6 +291,11 @@
             "title": "example",
             "description": "upsert(\"patient/a5d38e09-efcb-4d91-a526-50ce1ba5011a\", {\n  identifiers: [\n    {\n      identifier: '4023287',\n      identifierType: '05a29f94-c0ed-11e2-94be-8c13b969e334',\n      preferred: true,\n    },\n  ],\n  person: {\n    gender: 'M',\n    age: 42,\n    birthdate: '1970-01-01T00:00:00.000+0100',\n    birthdateEstimated: false,\n    names: [\n      {\n        givenName: 'Doe',\n        familyName: 'John',\n      },\n    ],\n  },\n})",
             "caption": "Upsert a patient (<a href=\"https://rest.openmrs.org/#patients-overview\">see OpenMRS API</a>)"
+          },
+          {
+            "title": "example",
+            "description": "upsert(\"patient\", $.data, { q: \"Lamine Yamal\" })",
+            "caption": "Upsert a patient using a query to identify the record"
           }
         ]
       },
@@ -297,12 +312,12 @@
         "tags": [
           {
             "title": "example",
-            "description": "delete(\"patient/12346\");",
+            "description": "destroy(\"patient/12346\");",
             "caption": "Void a patient"
           },
           {
             "title": "example",
-            "description": "delete(\"patient/12346\", {\n  purge: true\n});",
+            "description": "destroy(\"patient/12346\", {\n  purge: true\n});",
             "caption": "Purge a patient"
           },
           {

--- a/packages/openmrs/integrations/.gitignore
+++ b/packages/openmrs/integrations/.gitignore
@@ -1,0 +1,1 @@
+output.json

--- a/packages/openmrs/integrations/upsert.js
+++ b/packages/openmrs/integrations/upsert.js
@@ -1,0 +1,93 @@
+const person = {
+  names: [
+    {
+      givenName: 'Peter',
+      familyName: 'Parker',
+    },
+  ],
+  gender: 'M',
+  birthdate: '2009-09-02',
+  addresses: [
+    {
+      address1: '15 Amfan Ave',
+      cityVillage: 'New York',
+      country: 'USA',
+      postalCode: '560037',
+    },
+  ],
+};
+
+// Set up state to use the public openmrs demo sandbox
+fn(state => {
+  state.configuration = {
+    instanceUrl: 'https://o3.openmrs.org/openmrs',
+    username: 'admin',
+    password: 'Admin123',
+  };
+
+  state.uuid = util.uuid();
+
+  return state;
+});
+
+fn(state => {
+  console.log('Creating new person');
+  return state;
+});
+
+// Create a new person
+upsert(`person/${$.uuid}`, person).then(state => {
+  state.uuid = state.data.uuid;
+  console.log('Person should have been created new!');
+  console.log(state.data);
+  console.log('---');
+
+  state.newName = util.uuid();
+  return state;
+});
+
+fn(state => {
+  console.log('Updating person with unique name');
+  return state;
+});
+
+// Now update the same person with unique display name
+upsert(`person/${$.uuid}`, {
+  names: [
+    {
+      givenName: $.newName,
+    },
+  ],
+}).then(state => {
+  console.log('Person should have been updated!');
+  console.log(state.data);
+  console.log('---');
+  return state;
+});
+
+fn(state => {
+  console.log('Updating again with query');
+  return state;
+});
+
+// Now find and update that same person again
+upsert(
+  `person`,
+  {
+    names: [
+      {
+        givenName: 'Spider',
+        familyName: 'Man',
+      },
+    ],
+  },
+  { q: $.newName }
+).then(state => {
+  console.log('Person should now be spiderman!');
+  console.log(state.data);
+  console.log('---');
+  return state;
+});
+// fn(state => ({
+//   data: state.data,
+// }));

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -262,11 +262,15 @@ export function update(path, data) {
 }
 
 /**
- * Upsert a record. If the resource exists, it will be updated. Otherwise, a new resource will be created.
+ * Update a resource if it already exists, or otherwise create a new one.
+ *
+ * Upsert will first make a request for the target item (using the `path` and `params`) to see if it exists, and then issue a second create or update request.
+ * If the query request returns multiple items, the upsert will throw an error.
  * @public
  * @function
  * @param {string} path - Path to resource (excluding `/ws/rest/v1/`)
  * @param {Object} data - The resource data
+ * @param {Object} params - Query parameters to append to the initial query
  * @state data The created/updated resource, as returned by OpenMRS
  * @returns {Operation}
  * @example <caption>Upsert a patient (<a href="https://rest.openmrs.org/#patients-overview">see OpenMRS API</a>)</caption>
@@ -291,19 +295,19 @@ export function update(path, data) {
  *     ],
  *   },
  * })
+ * @example <caption>Upsert a patient using a query to identify the record</caption>
+ * upsert("patient", $.data, { q: "Lamine Yamal" })
  */
-export function upsert(path, data) {
+export function upsert(path, data, params = {}) {
   return async state => {
-    const [resolvedPath, resolvedData] = expandReferences(state, path, data);
-
-    const resourceName =
-      resolvedPath[0] === '/'
-        ? resolvedPath.split('/')[1]
-        : resolvedPath.split('/')[0];
-
-    console.log(
-      `Preparing composed upsert (via 'get' then 'create' OR 'update') on ${resourceName}`
+    const [resolvedPath, resolvedData, resolvedParams] = expandReferences(
+      state,
+      path,
+      data,
+      params
     );
+
+    console.log(`Preparing composed upsert on ${resolvedPath}`);
 
     const { instanceUrl: baseUrl } = state.configuration;
     return await request(
@@ -312,19 +316,30 @@ export function upsert(path, data) {
       cleanPath(`/ws/rest/v1/${resolvedPath}`),
       {
         baseUrl,
+        query: resolvedParams,
+        errors: { 404: false },
       }
-    ).then(resp => {
-      const resource = resp.body.results;
-      if (resource.length > 1) {
+    ).then(res => {
+      let count;
+      if (res.body.results) {
+        count = res.body.results.length;
+      } else {
+        count = Object.keys(res.body).length ? 1 : 0;
+      }
+
+      if (count > 1) {
         throw new RangeError(
           `Found more than one record for your request; cannot upsert on non-unique attribute.`
         );
-      } else if (resource.length === 0) {
-        console.log(`No ${resourceName} found.`);
-        const path = resolvedPath.split('/').slice(0, -1).join('/'); // remove the ID
+      } else if (count === 0) {
+        console.log(`${resolvedPath} found: creating new resource`);
+
+        const path = params.q
+          ? resolvedPath
+          : resolvedPath.split('/').slice(0, -1).join('/'); // remove the ID
         return create(path, resolvedData)(state);
       } else {
-        console.log(`One ${resourceName} found.`);
+        console.log(`${resolvedPath} found: updating existing resource`);
         return update(resolvedPath, resolvedData)(state);
       }
     });

--- a/packages/openmrs/test/adaptor.test.js
+++ b/packages/openmrs/test/adaptor.test.js
@@ -344,52 +344,96 @@ describe('create', () => {
   });
 });
 
-describe('upsert', () => {
-  it('should update a patient', async () => {
-    testServer
-      .intercept({
-        path: `/ws/rest/v1/patient/${testData.patient.uuid}`,
-        method: 'GET',
-      })
-      .reply(200, { results: testData.patientResults }, { ...jsonHeaders });
+describe.only('upsert', () => {
+  const existingUuid = 'abc';
+  const nonExistingUuid = 'xyz';
 
-    testServer
-      .intercept({
-        path: `/ws/rest/v1/patient/${testData.patient.uuid}`,
-        method: 'POST',
-      })
-      .reply(200, ({ body }) => body, {
-        ...jsonHeaders,
-      });
+  // set up fixtures to be shared by these tests
+  testServer
+    .intercept({
+      path: `/ws/rest/v1/patient/${existingUuid}`,
+      method: 'GET',
+    })
+    .reply(200, { ...testData.patientResults }, { ...jsonHeaders })
+    .persist();
 
+  testServer
+    .intercept({
+      path: `/ws/rest/v1/patient/${nonExistingUuid}`,
+      method: 'GET',
+    })
+    .reply(404, {}, { ...jsonHeaders })
+    .persist();
+
+  testServer
+    .intercept({
+      path: `/ws/rest/v1/patient/${existingUuid}`,
+      method: 'POST',
+    })
+    .reply(200, ({ body }) => body, {
+      ...jsonHeaders,
+    })
+    .persist();
+
+  testServer
+    .intercept({
+      path: `/ws/rest/v1/patient`,
+      method: 'GET',
+      query: {
+        q: 'batman',
+      },
+    })
+    .reply(404, { results: testData.patientResults }, { ...jsonHeaders })
+    .persist();
+
+  testServer
+    .intercept({
+      path: `/ws/rest/v1/patient`,
+      method: 'GET',
+      query: {
+        q: 'spiderman',
+      },
+    })
+    .reply(404, {}, { ...jsonHeaders })
+    .persist();
+
+  testServer
+    .intercept({
+      path: `/ws/rest/v1/patient`,
+      method: 'POST',
+    })
+    .reply(200, ({ body }) => body, {
+      ...jsonHeaders,
+    })
+    .persist();
+
+  it('should update an existing patient', async () => {
     const result = await upsert(
-      `patient/${testData.patient.uuid}`,
+      `patient/${existingUuid}`,
       state => state.patient
     )(state);
 
     expect(result.data.person.display).to.eql(testData.patient.person.display);
   });
-  it('should create a patient', async () => {
-    testServer
-      .intercept({
-        path: `/ws/rest/v1/patient/${testData.patient.uuid}`,
-        method: 'GET',
-      })
-      .reply(200, { results: [] }, { ...jsonHeaders });
-
-    testServer
-      .intercept({
-        path: `/ws/rest/v1/patient`,
-        method: 'POST',
-      })
-      .reply(200, ({ body }) => body, {
-        ...jsonHeaders,
-      });
-
+  it('should create a new patient', async () => {
     const result = await upsert(
-      `patient/${testData.patient.uuid}`,
+      `patient/${nonExistingUuid}`,
       state => state.patient
     )(state);
+
+    expect(result.data.person.display).to.eql(testData.patient.person.display);
+  });
+  it('update an existing patient with a query', async () => {
+    const result = await upsert('patient', state => state.patient, {
+      q: 'batman',
+    })(state);
+
+    expect(result.data.person.display).to.eql(testData.patient.person.display);
+  });
+  it('create a new patient with a query', async () => {
+    const result = await upsert('patient', state => state.patient, {
+      q: 'spiderman',
+    })(state);
 
     expect(result.data.person.display).to.eql(testData.patient.person.display);
   });

--- a/packages/openmrs/test/adaptor.test.js
+++ b/packages/openmrs/test/adaptor.test.js
@@ -344,7 +344,7 @@ describe('create', () => {
   });
 });
 
-describe.only('upsert', () => {
+describe('upsert', () => {
   const existingUuid = 'abc';
   const nonExistingUuid = 'xyz';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,7 +475,7 @@ importers:
   packages/dynamics:
     dependencies:
       '@openfn/language-common':
-        specifier: 2.3.1
+        specifier: 2.3.2
         version: link:../common
       request:
         specifier: ^2.72.0
@@ -1478,7 +1478,7 @@ importers:
   packages/ocl:
     dependencies:
       '@openfn/language-common':
-        specifier: 2.3.1
+        specifier: 2.3.2
         version: link:../common
     devDependencies:
       assertion-error:


### PR DESCRIPTION
Playing with the upsert function I found a bunch of problems:

- Adding support for a query (as Mutchi wants) violated a few assumptions about the prior implementation
- OpenMRS returns a 404 for a record that doesn't exist - so upsert was basically failing

I've added an extra integration test around upsert and man, I gotta, say, I think upserting by query is really really sketchy. I don't particularly like what it's done to the code (way too complicated) and I don't think it's a very good deal for the user.

I'm probably going to merge it on that grounds that this is how it used to work and it's what Mutchi wants. But it's on life-support as far as I'm concerned. I might even raise an issue to remove this completely.

And then you say: if I have to have a UUID to upsert, well, it's never really an upsert is it? So now I'm not sure what upsert is even for

Maybe Mutchi's comment on the phone is the right way to go here:
- We take an openmrs as the argument
- if it has a uuid, we try to update it. Note that if it doesn't exist, and we have to post it new, openMRS will assign it its own uuid (not what we give it)
- if it doesn't have a uuid, we just post it new

So really upsert will delegate to `create`  if there's no uuid on the resource, or to `update` if there is.

No AI used.