### PR TITLE
Add `log` and `debug` in common

### DIFF
--- a/.changeset/fifty-news-sing.md
+++ b/.changeset/fifty-news-sing.md
@@ -1,0 +1,19 @@
+---
+'@openfn/language-common': minor
+---
+
+Add `log` and `debug` functions
+
+### Examples
+
+**To output message referencing state**
+
+```js
+log('Patient List::', $.patients);
+```
+
+**To output message with debug level**
+
+```js
+debug('Patient List::', $.patients);
+```

--- a/.changeset/fifty-news-sing.md
+++ b/.changeset/fifty-news-sing.md
@@ -2,18 +2,4 @@
 '@openfn/language-common': minor
 ---
 
-Add `log` and `debug` functions
-
-### Examples
-
-**To output message referencing state**
-
-```js
-log('Patient List::', $.patients);
-```
-
-**To output message with debug level**
-
-```js
-debug('Patient List::', $.patients);
-```
+Add `log()` and `debug()` functions

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1603,7 +1603,7 @@
         "args"
       ],
       "docs": {
-        "description": "Creates a general-purpose logger that prints values to the console while\nmaintaining the state chain. Suitable for regular application logging\nand monitoring runtime behavior.",
+        "description": "Outputs a message to the console while maintaining the state.",
         "tags": [
           {
             "title": "public",
@@ -1619,6 +1619,11 @@
             "title": "example",
             "description": "log('Hello', 'World')\n// Logs: Hello World\nlog($.user.name)\n// Logs value of state.user.name",
             "caption": "Log specific values"
+          },
+          {
+            "title": "example",
+            "description": "log(({ configuration, ...rest }) => rest);",
+            "caption": "Log a specific object from state"
           },
           {
             "title": "example",
@@ -1654,7 +1659,7 @@
         "args"
       ],
       "docs": {
-        "description": "Creates a development-focused logger that prints detailed diagnostic information\nto the console while maintaining the state chain. Useful for debugging and\ndetailed inspection during development.",
+        "description": "Outputs a message to the console with the debug log level while maintaining the state.",
         "tags": [
           {
             "title": "public",
@@ -1670,6 +1675,11 @@
             "title": "example",
             "description": "debug('Hello', 'World')\n// Logs: Hello World\ndebug($.user.name)\n// Logs value of state.user.name",
             "caption": "Log specific values"
+          },
+          {
+            "title": "example",
+            "description": "debug(({ configuration, ...rest }) => rest);",
+            "caption": "Log a specific object from state"
           },
           {
             "title": "example",

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1603,7 +1603,7 @@
         "args"
       ],
       "docs": {
-        "description": "Outputs a message to the console while maintaining the state.",
+        "description": "Outputs a message to the console.",
         "tags": [
           {
             "title": "public",
@@ -1622,22 +1622,15 @@
           },
           {
             "title": "example",
-            "description": "log(({ configuration, ...rest }) => rest);",
-            "caption": "Log a specific object from state"
-          },
-          {
-            "title": "example",
             "description": "log('User:', $.user.name, 'Age:', $.user.age)\n// Logs: User: John Age: 30",
             "caption": "Multiple arguments including state references"
           },
           {
             "title": "param",
-            "description": "Values to log: primitives, objects, or state references",
+            "description": "A value or message to display in the logs",
             "type": {
-              "type": "RestType",
-              "expression": {
-                "type": "AllLiteral"
-              }
+              "type": "NameExpression",
+              "name": "any"
             },
             "name": "args"
           },
@@ -1659,7 +1652,7 @@
         "args"
       ],
       "docs": {
-        "description": "Outputs a message to the console with the debug log level while maintaining the state.",
+        "description": "Outputs a message to the console with the debug log level.",
         "tags": [
           {
             "title": "public",
@@ -1678,22 +1671,15 @@
           },
           {
             "title": "example",
-            "description": "debug(({ configuration, ...rest }) => rest);",
-            "caption": "Log a specific object from state"
-          },
-          {
-            "title": "example",
             "description": "debug('User:', $.user.name, 'Age:', $.user.age)\n// Logs: User: John Age: 30",
             "caption": "Multiple arguments including state references"
           },
           {
             "title": "param",
-            "description": "Values to log: primitives, objects, or state references",
+            "description": "A value or message to display in the logs",
             "type": {
-              "type": "RestType",
-              "expression": {
-                "type": "AllLiteral"
-              }
+              "type": "NameExpression",
+              "name": "any"
             },
             "name": "args"
           },

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1598,6 +1598,80 @@
       "valid": true
     },
     {
+      "name": "log",
+      "params": [
+        "args"
+      ],
+      "docs": {
+        "description": "Creates a state logger that prints values to the console while maintaining the state chain",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "example",
+            "description": "log()\n// Logs entire state object",
+            "caption": "Log entire state when no args provided"
+          },
+          {
+            "title": "example",
+            "description": "log('Hello', 'World')\n// Logs: Hello World\nlog($.user.name)\n// Logs value of state.user.name",
+            "caption": "Log specific values"
+          },
+          {
+            "title": "example",
+            "description": "log('User:', $.user.name, 'Age:', $.user.age)\n// Logs: User: John Age: 30",
+            "caption": "Multiple arguments including state references"
+          },
+          {
+            "title": "param",
+            "description": "Values or state references to log. Can be:\n  - Primitive values (string, number, boolean)\n  - State references (using $ syntax to reference state properties)\n  - Objects\n  - Arrays\nIf no args provided, logs entire state",
+            "type": {
+              "type": "RestType",
+              "expression": {
+                "type": "UnionType",
+                "elements": [
+                  {
+                    "type": "NameExpression",
+                    "name": "string"
+                  },
+                  {
+                    "type": "NameExpression",
+                    "name": "number"
+                  },
+                  {
+                    "type": "NameExpression",
+                    "name": "boolean"
+                  },
+                  {
+                    "type": "NameExpression",
+                    "name": "StateReference"
+                  }
+                ]
+              }
+            },
+            "name": "args"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "map",
       "params": [
         "path",

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1603,7 +1603,7 @@
         "args"
       ],
       "docs": {
-        "description": "Creates a state logger that prints values to the console while maintaining the state chain",
+        "description": "Creates a general-purpose logger that prints values to the console while\nmaintaining the state chain. Suitable for regular application logging\nand monitoring runtime behavior.",
         "tags": [
           {
             "title": "public",
@@ -1628,6 +1628,80 @@
           {
             "title": "example",
             "description": "log('User:', $.user.name, 'Age:', $.user.age)\n// Logs: User: John Age: 30",
+            "caption": "Multiple arguments including state references"
+          },
+          {
+            "title": "param",
+            "description": "Values or state references to log. Can be:\n  - Primitive values (string, number, boolean)\n  - State references (using $ syntax to reference state properties)\n  - Objects\n  - Arrays\nIf no args provided, logs entire state",
+            "type": {
+              "type": "RestType",
+              "expression": {
+                "type": "UnionType",
+                "elements": [
+                  {
+                    "type": "NameExpression",
+                    "name": "string"
+                  },
+                  {
+                    "type": "NameExpression",
+                    "name": "number"
+                  },
+                  {
+                    "type": "NameExpression",
+                    "name": "boolean"
+                  },
+                  {
+                    "type": "NameExpression",
+                    "name": "StateReference"
+                  }
+                ]
+              }
+            },
+            "name": "args"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
+      "name": "debug",
+      "params": [
+        "args"
+      ],
+      "docs": {
+        "description": "Creates a development-focused logger that prints detailed diagnostic information\nto the console while maintaining the state chain. Useful for debugging and\ndetailed inspection during development.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "example",
+            "description": "debug()\n// Logs entire state object",
+            "caption": "Log entire state when no args provided"
+          },
+          {
+            "title": "example",
+            "description": "debug('Hello', 'World')\n// Logs: Hello World\ndebug($.user.name)\n// Logs value of state.user.name",
+            "caption": "Log specific values"
+          },
+          {
+            "title": "example",
+            "description": "debug('User:', $.user.name, 'Age:', $.user.age)\n// Logs: User: John Age: 30",
             "caption": "Multiple arguments including state references"
           },
           {

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1617,11 +1617,6 @@
           },
           {
             "title": "example",
-            "description": "log()\n// Logs entire state object",
-            "caption": "Log entire state when no args provided"
-          },
-          {
-            "title": "example",
             "description": "log('Hello', 'World')\n// Logs: Hello World\nlog($.user.name)\n// Logs value of state.user.name",
             "caption": "Log specific values"
           },
@@ -1632,29 +1627,11 @@
           },
           {
             "title": "param",
-            "description": "Values or state references to log. Can be:\n  - Primitive values (string, number, boolean)\n  - State references (using $ syntax to reference state properties)\n  - Objects\n  - Arrays\nIf no args provided, logs entire state",
+            "description": "Values to log: primitives, objects, or state references",
             "type": {
               "type": "RestType",
               "expression": {
-                "type": "UnionType",
-                "elements": [
-                  {
-                    "type": "NameExpression",
-                    "name": "string"
-                  },
-                  {
-                    "type": "NameExpression",
-                    "name": "number"
-                  },
-                  {
-                    "type": "NameExpression",
-                    "name": "boolean"
-                  },
-                  {
-                    "type": "NameExpression",
-                    "name": "StateReference"
-                  }
-                ]
+                "type": "AllLiteral"
               }
             },
             "name": "args"
@@ -1691,11 +1668,6 @@
           },
           {
             "title": "example",
-            "description": "debug()\n// Logs entire state object",
-            "caption": "Log entire state when no args provided"
-          },
-          {
-            "title": "example",
             "description": "debug('Hello', 'World')\n// Logs: Hello World\ndebug($.user.name)\n// Logs value of state.user.name",
             "caption": "Log specific values"
           },
@@ -1706,29 +1678,11 @@
           },
           {
             "title": "param",
-            "description": "Values or state references to log. Can be:\n  - Primitive values (string, number, boolean)\n  - State references (using $ syntax to reference state properties)\n  - Objects\n  - Arrays\nIf no args provided, logs entire state",
+            "description": "Values to log: primitives, objects, or state references",
             "type": {
               "type": "RestType",
               "expression": {
-                "type": "UnionType",
-                "elements": [
-                  {
-                    "type": "NameExpression",
-                    "name": "string"
-                  },
-                  {
-                    "type": "NameExpression",
-                    "name": "number"
-                  },
-                  {
-                    "type": "NameExpression",
-                    "name": "boolean"
-                  },
-                  {
-                    "type": "NameExpression",
-                    "name": "StateReference"
-                  }
-                ]
+                "type": "AllLiteral"
               }
             },
             "name": "args"

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -932,3 +932,44 @@ export function assert(expression, errorMessage) {
     return state;
   };
 }
+
+/**
+ * Represents a reference to a value in the state object
+ * @typedef {Object} StateReference
+ * @property {string} key - JSON path to the value in the state object
+ */
+/**
+ * Creates a state logger that prints values to the console while maintaining the state chain
+ * @public
+ * @function
+ * @example <caption>Log entire state when no args provided</caption>
+ * log()
+ * // Logs entire state object
+ * @example <caption>Log specific values</caption>
+ * log('Hello', 'World')
+ * // Logs: Hello World
+ * log($.user.name)
+ * // Logs value of state.user.name
+ * @example <caption>Multiple arguments including state references</caption>
+ * log('User:', $.user.name, 'Age:', $.user.age)
+ * // Logs: User: John Age: 30
+ * @param {...(string|number|boolean|StateReference)} args - Values or state references to log. Can be:
+ *   - Primitive values (string, number, boolean)
+ *   - State references (using $ syntax to reference state properties)
+ *   - Objects
+ *   - Arrays
+ * If no args provided, logs entire state
+ * @returns {Operation}
+ */
+export function log(...args) {
+  return state => {
+    const [resolvedArgs] = newExpandReferences(state, args);
+    if (resolvedArgs.length === 0 || !resolvedArgs) {
+      console.log(state);
+    } else {
+      console.log(...resolvedArgs);
+    }
+
+    return state;
+  };
+}

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -934,19 +934,11 @@ export function assert(expression, errorMessage) {
 }
 
 /**
- * Represents a reference to a value in the state object
- * @typedef {Object} StateReference
- * @property {string} key - JSON path to the value in the state object
- */
-/**
  * Creates a general-purpose logger that prints values to the console while
  * maintaining the state chain. Suitable for regular application logging
  * and monitoring runtime behavior.
  * @public
  * @function
- * @example <caption>Log entire state when no args provided</caption>
- * log()
- * // Logs entire state object
  * @example <caption>Log specific values</caption>
  * log('Hello', 'World')
  * // Logs: Hello World
@@ -955,23 +947,13 @@ export function assert(expression, errorMessage) {
  * @example <caption>Multiple arguments including state references</caption>
  * log('User:', $.user.name, 'Age:', $.user.age)
  * // Logs: User: John Age: 30
- * @param {...(string|number|boolean|StateReference)} args - Values or state references to log. Can be:
- *   - Primitive values (string, number, boolean)
- *   - State references (using $ syntax to reference state properties)
- *   - Objects
- *   - Arrays
- * If no args provided, logs entire state
+ * @param {...*} args - Values to log: primitives, objects, or state references
  * @returns {Operation}
  */
 export function log(...args) {
   return state => {
     const [resolvedArgs] = newExpandReferences(state, args);
-    if (resolvedArgs.length === 0 || !resolvedArgs) {
-      console.log(state);
-    } else {
-      console.log(...resolvedArgs);
-    }
-
+    console.log(...resolvedArgs);
     return state;
   };
 }
@@ -982,9 +964,6 @@ export function log(...args) {
  * detailed inspection during development.
  * @public
  * @function
- * @example <caption>Log entire state when no args provided</caption>
- * debug()
- * // Logs entire state object
  * @example <caption>Log specific values</caption>
  * debug('Hello', 'World')
  * // Logs: Hello World
@@ -993,23 +972,13 @@ export function log(...args) {
  * @example <caption>Multiple arguments including state references</caption>
  * debug('User:', $.user.name, 'Age:', $.user.age)
  * // Logs: User: John Age: 30
- * @param {...(string|number|boolean|StateReference)} args - Values or state references to log. Can be:
- *   - Primitive values (string, number, boolean)
- *   - State references (using $ syntax to reference state properties)
- *   - Objects
- *   - Arrays
- * If no args provided, logs entire state
+ * @param {...*} args - Values to log: primitives, objects, or state references
  * @returns {Operation}
  */
 export function debug(...args) {
   return state => {
     const [resolvedArgs] = newExpandReferences(state, args);
-    if (resolvedArgs.length === 0 || !resolvedArgs) {
-      console.debug(state);
-    } else {
-      console.debug(...resolvedArgs);
-    }
-
+    console.debug(...resolvedArgs);
     return state;
   };
 }

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -934,9 +934,7 @@ export function assert(expression, errorMessage) {
 }
 
 /**
- * Creates a general-purpose logger that prints values to the console while
- * maintaining the state chain. Suitable for regular application logging
- * and monitoring runtime behavior.
+ * Outputs a message to the console while maintaining the state.
  * @public
  * @function
  * @example <caption>Log specific values</caption>
@@ -944,6 +942,8 @@ export function assert(expression, errorMessage) {
  * // Logs: Hello World
  * log($.user.name)
  * // Logs value of state.user.name
+ * @example <caption>Log a specific object from state</caption>
+ * log(({ configuration, ...rest }) => rest);
  * @example <caption>Multiple arguments including state references</caption>
  * log('User:', $.user.name, 'Age:', $.user.age)
  * // Logs: User: John Age: 30
@@ -959,9 +959,7 @@ export function log(...args) {
 }
 
 /**
- * Creates a development-focused logger that prints detailed diagnostic information
- * to the console while maintaining the state chain. Useful for debugging and
- * detailed inspection during development.
+ * Outputs a message to the console with the debug log level while maintaining the state.
  * @public
  * @function
  * @example <caption>Log specific values</caption>
@@ -969,6 +967,8 @@ export function log(...args) {
  * // Logs: Hello World
  * debug($.user.name)
  * // Logs value of state.user.name
+ * @example <caption>Log a specific object from state</caption>
+ * debug(({ configuration, ...rest }) => rest);
  * @example <caption>Multiple arguments including state references</caption>
  * debug('User:', $.user.name, 'Age:', $.user.age)
  * // Logs: User: John Age: 30

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -934,7 +934,7 @@ export function assert(expression, errorMessage) {
 }
 
 /**
- * Outputs a message to the console while maintaining the state.
+ * Outputs a message to the console.
  * @public
  * @function
  * @example <caption>Log specific values</caption>
@@ -942,12 +942,10 @@ export function assert(expression, errorMessage) {
  * // Logs: Hello World
  * log($.user.name)
  * // Logs value of state.user.name
- * @example <caption>Log a specific object from state</caption>
- * log(({ configuration, ...rest }) => rest);
  * @example <caption>Multiple arguments including state references</caption>
  * log('User:', $.user.name, 'Age:', $.user.age)
  * // Logs: User: John Age: 30
- * @param {...*} args - Values to log: primitives, objects, or state references
+ * @param {any} args - A value or message to display in the logs
  * @returns {Operation}
  */
 export function log(...args) {
@@ -959,7 +957,7 @@ export function log(...args) {
 }
 
 /**
- * Outputs a message to the console with the debug log level while maintaining the state.
+ * Outputs a message to the console with the debug log level.
  * @public
  * @function
  * @example <caption>Log specific values</caption>
@@ -967,12 +965,10 @@ export function log(...args) {
  * // Logs: Hello World
  * debug($.user.name)
  * // Logs value of state.user.name
- * @example <caption>Log a specific object from state</caption>
- * debug(({ configuration, ...rest }) => rest);
  * @example <caption>Multiple arguments including state references</caption>
  * debug('User:', $.user.name, 'Age:', $.user.age)
  * // Logs: User: John Age: 30
- * @param {...*} args - Values to log: primitives, objects, or state references
+ * @param {any} args - A value or message to display in the logs
  * @returns {Operation}
  */
 export function debug(...args) {

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -939,7 +939,9 @@ export function assert(expression, errorMessage) {
  * @property {string} key - JSON path to the value in the state object
  */
 /**
- * Creates a state logger that prints values to the console while maintaining the state chain
+ * Creates a general-purpose logger that prints values to the console while
+ * maintaining the state chain. Suitable for regular application logging
+ * and monitoring runtime behavior.
  * @public
  * @function
  * @example <caption>Log entire state when no args provided</caption>
@@ -968,6 +970,44 @@ export function log(...args) {
       console.log(state);
     } else {
       console.log(...resolvedArgs);
+    }
+
+    return state;
+  };
+}
+
+/**
+ * Creates a development-focused logger that prints detailed diagnostic information
+ * to the console while maintaining the state chain. Useful for debugging and
+ * detailed inspection during development.
+ * @public
+ * @function
+ * @example <caption>Log entire state when no args provided</caption>
+ * debug()
+ * // Logs entire state object
+ * @example <caption>Log specific values</caption>
+ * debug('Hello', 'World')
+ * // Logs: Hello World
+ * debug($.user.name)
+ * // Logs value of state.user.name
+ * @example <caption>Multiple arguments including state references</caption>
+ * debug('User:', $.user.name, 'Age:', $.user.age)
+ * // Logs: User: John Age: 30
+ * @param {...(string|number|boolean|StateReference)} args - Values or state references to log. Can be:
+ *   - Primitive values (string, number, boolean)
+ *   - State references (using $ syntax to reference state properties)
+ *   - Objects
+ *   - Arrays
+ * If no args provided, logs entire state
+ * @returns {Operation}
+ */
+export function debug(...args) {
+  return state => {
+    const [resolvedArgs] = newExpandReferences(state, args);
+    if (resolvedArgs.length === 0 || !resolvedArgs) {
+      console.debug(state);
+    } else {
+      console.debug(...resolvedArgs);
     }
 
     return state;

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -934,17 +934,16 @@ export function assert(expression, errorMessage) {
 }
 
 /**
- * Outputs a message to the console.
+ * Outputs a message, like calling `console.log`. Use this at the top level of your job code, but not inside callbacks.
  * @public
  * @function
- * @example <caption>Log specific values</caption>
- * log('Hello', 'World')
- * // Logs: Hello World
- * log($.user.name)
- * // Logs value of state.user.name
- * @example <caption>Multiple arguments including state references</caption>
- * log('User:', $.user.name, 'Age:', $.user.age)
- * // Logs: User: John Age: 30
+ * @example <caption>Log values from state</caption>
+ * log('Patient List::', $.patients);
+ * @example <caption>Use console.log inside a callback or fn block</caption>
+ * fn((state) => {
+ *   console.log(state.data);
+ *   return state;
+ * })
  * @param {any} args - A value or message to display in the logs
  * @returns {Operation}
  */
@@ -957,17 +956,17 @@ export function log(...args) {
 }
 
 /**
- * Outputs a message to the console with the debug log level.
+ * Outputs a message to the console with the debug log level. This is usually filtered out by default. Use this at the top level of your job code, but not inside callbacks.
  * @public
  * @function
- * @example <caption>Log specific values</caption>
- * debug('Hello', 'World')
- * // Logs: Hello World
- * debug($.user.name)
- * // Logs value of state.user.name
- * @example <caption>Multiple arguments including state references</caption>
- * debug('User:', $.user.name, 'Age:', $.user.age)
- * // Logs: User: John Age: 30
+ * @example <caption>Log values from state</caption>
+ * debug('Patient List::', $.patients);
+ * @example <caption>Use console.debug inside a callback or fn block</caption>
+ * fn((state) => {
+ *   console.debug(state.data);
+ *   return state;
+ * })
+
  * @param {any} args - A value or message to display in the logs
  * @returns {Operation}
  */

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -31,6 +31,7 @@ import {
   toArray,
   validate,
   assert as assertCommon,
+  log,
 } from '../src/Adaptor';
 import { startOfToday } from 'date-fns';
 
@@ -1108,5 +1109,45 @@ describe('assert', () => {
     }
 
     expect(error.message).to.eql(`assertion statement failed with false`);
+  });
+});
+
+describe('log', () => {
+  const input = { x: 'a', y: { z: 'b' } };
+  let originalLog;
+  let consoleOutput = [];
+  beforeEach(() => {
+    originalLog = console.log;
+    console.log = (...args) => (consoleOutput = args);
+  });
+
+  it('should log a message', () => {
+    const result = log('test')(input);
+    expect(result).to.eq(input);
+    expect(consoleOutput[0]).to.eq('test');
+  });
+
+  it('should log multiple messages', () => {
+    log('test', 'test2')(input);
+    expect(consoleOutput[0]).to.eq('test');
+    expect(consoleOutput[1]).to.eq('test2');
+  });
+  it('should log multiple messages with state', () => {
+    log(
+      'test',
+      state => state.x,
+      state => `test ${state.y.z}`
+    )(input);
+    expect(consoleOutput[0]).to.eq('test');
+    expect(consoleOutput[1]).to.eq('a');
+    expect(consoleOutput[2]).to.eq('test b');
+  });
+  it('shoudl log state if no arguments are passed', () => {
+    const result = log()(input);
+    expect(result).to.eq(input);
+    expect(consoleOutput[0]).to.eq(input);
+  });
+  afterEach(() => {
+    console.log = originalLog;
   });
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -1143,11 +1143,6 @@ describe('log', () => {
     expect(consoleOutput[1]).to.eq('a');
     expect(consoleOutput[2]).to.eq('test b');
   });
-  it('shoudl log state if no arguments are passed', () => {
-    const result = log()(input);
-    expect(result).to.eq(input);
-    expect(consoleOutput[0]).to.eq(input);
-  });
   it('should log undefined if key is not found', () => {
     log(state => state.a)({});
     expect(consoleOutput[0]).to.eq(undefined);
@@ -1196,13 +1191,6 @@ describe('debug', () => {
     expect(consoleOutput[0]).to.eq('test');
     expect(consoleOutput[1]).to.eq('a');
     expect(consoleOutput[2]).to.eq('test b');
-  });
-
-  it('should debug state if no arguments are passed', () => {
-    const result = debug()(input);
-    expect(result).to.eq(input);
-
-    expect(consoleOutput[0]).to.eq(input);
   });
 
   it('should debug undefined if key is not found', () => {

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -1165,7 +1165,7 @@ describe('debug', () => {
   let consoleOutput = [];
 
   beforeEach(() => {
-    originalDebug = console.debug; // Using console.log since we changed debug to use it
+    originalDebug = console.debug;
     console.debug = (...args) => consoleOutput.push(...args);
   });
 
@@ -1208,6 +1208,6 @@ describe('debug', () => {
 
   afterEach(() => {
     consoleOutput = [];
-    console.log = originalDebug;
+    console.debug = originalDebug;
   });
 });


### PR DESCRIPTION
## Summary

This PR adds `log` and `debug` function in common adaptor

Fixes #496, #1117

## Details

- Add `log(...args)` function with unit tests + jsdocs examples
- Add `debug(...args)` function with unit tests + jsdocs examples

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA: If this is a new adaptor, added the adaptor on marketing website ?
- NA: If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [x] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
