### PR TITLE
common: Implement wrapper around `util.throwError`

### DIFF
--- a/.changeset/poor-flies-warn.md
+++ b/.changeset/poor-flies-warn.md
@@ -1,0 +1,12 @@
+---
+'@openfn/language-common': minor
+---
+
+Implement a wrapper function around `util.throwError`.
+
+The function can be accessed by doing this in the job code:
+
+```
+throwError(500,'Something Failed', 'Fix it')
+
+```

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1598,6 +1598,79 @@
       "valid": true
     },
     {
+      "name": "throwError",
+      "params": [
+        "statusCode",
+        "description",
+        "fix",
+        "extras"
+      ],
+      "docs": {
+        "description": "Creates a strucutred error message with tips and descriptions for a failing request",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "example",
+            "description": "assert('a' === 'b', '\"a\" is not equal to \"b\"')"
+          },
+          {
+            "title": "param",
+            "description": "The status code of the failing request",
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            },
+            "name": "statusCode"
+          },
+          {
+            "title": "param",
+            "description": "The unique description for the error",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "description"
+          },
+          {
+            "title": "param",
+            "description": "The tips for how to fix the error",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "fix"
+          },
+          {
+            "title": "param",
+            "description": "An optional object containing any other error information that can be displayed",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "extras"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "map",
       "params": [
         "path",

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -10,6 +10,7 @@ import { Readable } from 'node:stream';
 
 import { request } from 'undici';
 import dateFns from 'date-fns';
+import throwErrorUtil from './util/throw-error';
 
 import { expandReferences as newExpandReferences, parseDate } from './util';
 
@@ -930,5 +931,34 @@ export function assert(expression, errorMessage) {
     }
 
     return state;
+  };
+}
+
+/**
+ * Creates a strucutured error message with tips and descriptions for a failing request
+ * @public
+ * @function
+ * @example
+ * throwError(500,'Request failed', 'Fix the baseUrl')
+ * @param {any} statusCode  - The status code of the failing request
+ * @param {string} description - The unique description for the error
+ * @param {string} fix - The tips for how to fix the error
+ * @param {object} extras - An optional object containing any other error information that can be displayed
+ * @returns {operation}
+ */
+export function throwError(statusCode, description, fix, extras = {}) {
+  return state => {
+    const [
+      resolvedStatusCode,
+      resolvedDescription,
+      resolvedFix,
+      resolvedExtras,
+    ] = newExpandReferences(state, statusCode, description, fix, extras);
+
+    return throwErrorUtil(resolvedStatusCode, {
+      description: resolvedDescription,
+      fix: resolvedFix,
+      ...resolvedExtras,
+    });
   };
 }


### PR DESCRIPTION
## Summary

Wrap `util.throwError` in `common` with a `throwError()` function.

Fixes #1050

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
