### PR TITLE
Http fixes

### DIFF
--- a/.changeset/blue-lies-swim.md
+++ b/.changeset/blue-lies-swim.md
@@ -1,0 +1,36 @@
+---
+'@openfn/language-salesforce': patch
+'@openfn/language-ghana-bdr': patch
+'@openfn/language-ghana-nia': patch
+'@openfn/language-openboxes': patch
+'@openfn/language-satusehat': patch
+'@openfn/language-wigal-sms': patch
+'@openfn/language-commcare': patch
+'@openfn/language-openlmis': patch
+'@openfn/language-mojatax': patch
+'@openfn/language-msupply': patch
+'@openfn/language-openmrs': patch
+'@openfn/language-primero': patch
+'@openfn/language-senaite': patch
+'@openfn/language-common': patch
+'@openfn/language-hubtel': patch
+'@openfn/language-intuit': patch
+'@openfn/language-divoc': patch
+'@openfn/language-gmail': patch
+'@openfn/language-mpesa': patch
+'@openfn/language-redis': patch
+'@openfn/language-fhir': patch
+'@openfn/language-http': patch
+'@openfn/language-odoo': patch
+'@openfn/language-odk': patch
+'@openfn/language-asana': patch
+'@openfn/language-chatgpt': patch
+'@openfn/language-cht': patch
+'@openfn/language-claude': patch
+'@openfn/language-fhir-4': patch
+'@openfn/language-kobotoolbox': patch
+'@openfn/language-pesapal': patch
+'@openfn/language-surveycto': patch
+---
+
+Better handling of HTML content in http requests

--- a/.changeset/two-terms-enjoy.md
+++ b/.changeset/two-terms-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-http': patch
+---
+
+Fix parseAs option in all operations

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -244,8 +244,9 @@ function encodeRequestBody(body) {
 }
 
 async function readResponseBody(response, parseAs) {
-  const contentLength =
-    response.headers['content-length'] ?? response.body?.readableLength;
+  const contentLength = parseInt(
+    response.headers['content-length'] ?? response.body?.readableLength
+  );
   const contentType = response.headers['content-type'];
   try {
     if (Number.isNaN(contentLength) || contentLength === 0) {

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -244,7 +244,8 @@ function encodeRequestBody(body) {
 }
 
 async function readResponseBody(response, parseAs) {
-  const contentLength = response.body?.readableLength ?? 0;
+  const contentLength =
+    response.headers['content-length'] ?? response.body?.readableLength;
   const contentType = response.headers['content-type'];
   try {
     if (Number.isNaN(contentLength) || contentLength === 0) {

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -672,7 +672,7 @@ describe('helpers', () => {
   });
 
   describe('parseAs', () => {
-    it('should auto parse as json', async () => {
+    it('should auto parse as json if content-type is application/json', async () => {
       client
         .intercept({
           path: '/api',
@@ -695,7 +695,7 @@ describe('helpers', () => {
       expect(result.body).to.eql({ name: 'mutchi' });
     });
 
-    it('should auto parse as text by default', async () => {
+    it('should auto parse as text by default (no content type)', async () => {
       client
         .intercept({
           path: '/api',

--- a/packages/http/src/util.js
+++ b/packages/http/src/util.js
@@ -70,7 +70,7 @@ export function request(method, path, params) {
       params
     );
 
-    let { body, contentType = 'json', headers = {} } = resolvedParams;
+    let { body, contentType = 'json', headers = {}, parseAs } = resolvedParams;
 
     const contentTypeHeader = Object.keys(headers).find(
       key => key.toLowerCase() === 'content-type'
@@ -117,6 +117,7 @@ export function request(method, path, params) {
       body,
       tls,
       maxRedirections,
+      parseAs,
     };
 
     return commonRequest(method, resolvedPath, options)

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -113,6 +113,38 @@ describe('request()', () => {
 
     expect(err.code).to.eql('BASE_URL_MISMATCH');
   });
+
+  it('should accept parseAs to force parsed content', async () => {
+    testServer
+      .intercept({ path: '/json' })
+      .reply(
+        200,
+        {},
+        {
+          headers: {
+            'content-type': 'application/json',
+          },
+        }
+      )
+      .times(2);
+
+    const state = {
+      configuration: {
+        baseUrl: 'https://www.example.com',
+      },
+    };
+
+    // get json by
+    const result1 = await execute(request('GET', '/json'))(state);
+    expect(result1.data).to.eql({});
+
+    // force string
+    const result2 = await execute(request('GET', '/json', { parseAs: 'text' }))(
+      state
+    );
+
+    expect(result2.data).to.eql('{}');
+  });
 });
 
 describe('get()', () => {
@@ -440,7 +472,6 @@ describe('get()', () => {
 
     expect(response.statusCode).to.eql(404);
   });
-
 });
 
 describe('contentType', () => {
@@ -494,7 +525,6 @@ describe('contentType', () => {
       )
     )(state);
 
-    
     expect(req.body).to.equal(JSON.stringify({ name: 'a', age: 42 }));
     expect(JSON.parse(response.data).id).to.eql(1);
     expect(req.headers['Content-Type']).to.equal('application/json');
@@ -642,7 +672,6 @@ describe('put', () => {
     expect(response.statusCode).to.eql(200);
     expect(req.body).to.equal(JSON.stringify(body));
   });
-
 });
 
 describe('patch', () => {
@@ -669,7 +698,6 @@ describe('patch', () => {
     expect(response.statusCode).to.eql(200);
     expect(req.body).to.equal(JSON.stringify(body));
   });
-
 });
 
 describe('delete', () => {

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -134,7 +134,7 @@ describe('request()', () => {
       },
     };
 
-    // get json by
+    // get json by default
     const result1 = await execute(request('GET', '/json'))(state);
     expect(result1.data).to.eql({});
 


### PR DESCRIPTION
## Summary

Various fixes around common HTTP:

* Fix an issue where HTML content does not have a stream length, so where available we prefer the content-length header
* Fix an issue where parseAs is not fed through in the http adaptor

Fixes #1155 ##1154 #1153 (lol)


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
