### PR TITLE
common: remove map

### DIFF
--- a/.changeset/beige-penguins-pump.md
+++ b/.changeset/beige-penguins-pump.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': major
+---
+
+remove `map()`

--- a/.changeset/beige-penguins-pump.md
+++ b/.changeset/beige-penguins-pump.md
@@ -2,4 +2,4 @@
 '@openfn/language-common': major
 ---
 
-remove `map()`
+Remove `map()`

--- a/.changeset/silver-pets-dance.md
+++ b/.changeset/silver-pets-dance.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-mogli': minor
+---
+
+Removed map() function, exported from common

--- a/.changeset/thirty-papayas-unite.md
+++ b/.changeset/thirty-papayas-unite.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-salesforce': major
+---
+
+remove map() function (exported from common)

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1694,69 +1694,6 @@
         ]
       },
       "valid": true
-    },
-    {
-      "name": "map",
-      "params": [
-        "path",
-        "operation",
-        "state"
-      ],
-      "docs": {
-        "description": "Scopes an array of data based on a JSONPath.\nUseful when the source data has `n` items you would like to map to\nan operation.\nThe operation will receive a slice of the data based of each item\nof the JSONPath provided.",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "example",
-            "description": "map(\"$.[*]\",\n  create(\"SObject\",\n    field(\"FirstName\", sourceValue(\"$.firstName\"))\n  )\n)"
-          },
-          {
-            "title": "param",
-            "description": "JSONPath referencing a point in `state.data`.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "path"
-          },
-          {
-            "title": "param",
-            "description": "The operation needed to be repeated.",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "operation"
-          },
-          {
-            "title": "param",
-            "description": "Runtime state.",
-            "type": {
-              "type": "NameExpression",
-              "name": "State"
-            },
-            "name": "state"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "State"
-            }
-          }
-        ]
-      },
-      "valid": true
     }
   ],
   "exports": [],

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -197,41 +197,6 @@ export function lastReferenceValue(path) {
 }
 
 /**
- * Scopes an array of data based on a JSONPath.
- * Useful when the source data has `n` items you would like to map to
- * an operation.
- * The operation will receive a slice of the data based of each item
- * of the JSONPath provided.
- * @public
- * @function
- * @example
- * map("$.[*]",
- *   create("SObject",
- *     field("FirstName", sourceValue("$.firstName"))
- *   )
- * )
- * @param {string} path - JSONPath referencing a point in `state.data`.
- * @param {function} operation - The operation needed to be repeated.
- * @param {State} state - Runtime state.
- * @returns {State}
- */
-export const map = curry(function (path, operation, state) {
-  switch (typeof path) {
-    case 'string':
-      source(path)(state).map(function (data) {
-        return operation({ data, references: state.references });
-      });
-      return state;
-
-    case 'object':
-      path.map(function (data) {
-        return operation({ data, references: state.references });
-      });
-      return state;
-  }
-});
-
-/**
  * Simple switcher allowing other expressions to use either a JSONPath or
  * object literals as a data source.
  * - JSONPath referencing a point in `state`

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -19,7 +19,6 @@ import {
   join,
   jsonValue,
   lastReferenceValue,
-  map,
   merge,
   group,
   parseCsv,
@@ -97,28 +96,6 @@ describe('source', () => {
   it('references a given path', () => {
     let value = source('$.store.bicycle.color')(testData);
     expect(value).to.eql(['red']);
-  });
-});
-
-describe('map', () => {
-  xit('[DEPRECATED] can produce a one to one from an array', () => {
-    let items = [];
-
-    let state = { data: testData, references: [] };
-    let results = map(
-      '$.data.store.book[*]',
-      function (state) {
-        return { references: [1, ...state.references], ...state };
-      },
-      state
-    );
-
-    expect(results.references).to.eql([
-      { title: 'Sayings of the Century' },
-      { title: 'Sword of Honour' },
-      { title: 'Moby Dick' },
-      { title: 'The Lord of the Rings' },
-    ]);
   });
 });
 

--- a/packages/mogli/src/Adaptor.js
+++ b/packages/mogli/src/Adaptor.js
@@ -205,7 +205,6 @@ export {
   field,
   source,
   sourceValue,
-  map,
   combine,
   merge,
   dataPath,

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -760,7 +760,6 @@ export {
   group,
   jsonValue,
   lastReferenceValue,
-  map,
   merge,
   referencePath,
   scrubEmojis,


### PR DESCRIPTION
## Summary

This PR removes the existing `map()` operation from common.

This leaves us free to introduce a new, better map function later. See #499

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
