### PR TITLE
Update changelogs

### DIFF
--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-asana
 
-## 4.0.12
+## 4.0.12 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 4.0.11 - 16 April 2025

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-azure-storage
 
-## 2.0.12
+## 2.0.12 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 2.0.11 - 16 April 2025

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-beyonic
 
-## 0.3.14
+## 0.3.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.3.13 - 16 April 2025

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-bigquery
 
-## 3.0.13
+## 3.0.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 3.0.12 - 16 April 2025

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-cartodb
 
-## 0.4.15
+## 0.4.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.4.14 - 16 April 2025

--- a/packages/chatgpt/CHANGELOG.md
+++ b/packages/chatgpt/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-chatgpt
 
-## 1.0.6
+## 1.0.6 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.5 - 16 April 2025

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-cht
 
-## 1.0.12
+## 1.0.12 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.11 - 16 April 2025

--- a/packages/claude/CHANGELOG.md
+++ b/packages/claude/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-claude
 
-## 1.0.7
+## 1.0.7 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.6 - 16 April 2025

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-collections
 
-## 0.7.8
+## 0.7.8 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.7.7 - 16 April 2025

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-commcare
 
-## 3.2.13
+## 3.2.13 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 3.2.12 - 16 April 2025

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -256,7 +256,7 @@ content type to JSON.
 ### Minor Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 
 ## 1.9.0 - 23 June 2023
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,6 +1,4 @@
-## 2.3.0 - 16 January 2025
-
-## 2.4.0
+## 2.4.0 - 22 April 2025
 
 ### Minor Changes
 
@@ -29,6 +27,8 @@
 
 - 23ccb01: Allow the errorMap passed into the request helper to be false, which
   suppresses all errors
+
+## 2.3.0 - 16 January 2025
 
 ### Minor Changes
 

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-dhis2
 
-## 6.3.4
+## 6.3.4 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 6.3.3 - 16 April 2025

--- a/packages/divoc/CHANGELOG.md
+++ b/packages/divoc/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-divoc
 
-## 0.1.3
+## 0.1.3 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.1.2 - 16 April 2025

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-dynamics
 
-## 0.5.16
+## 0.5.16 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.5.15 - 16 April 2025

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -211,7 +211,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -125,7 +125,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-facebook
 
-## 0.4.14
+## 0.4.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.4.13 - 16 April 2025

--- a/packages/fhir-4/CHANGELOG.md
+++ b/packages/fhir-4/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-fhir-4
 
-## 0.1.5
+## 0.1.5 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.1.4 - 16 April 2025

--- a/packages/fhir-fr/CHANGELOG.md
+++ b/packages/fhir-fr/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-fhir-fr
 
-## 1.0.11
+## 1.0.11 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.10 - 16 April 2025

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-fhir-ndr-et
 
-## 0.1.14
+## 0.1.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
   - @openfn/language-fhir@5.0.4
 

--- a/packages/fhir/CHANGELOG.md
+++ b/packages/fhir/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-fhir
 
-## 5.0.4
+## 5.0.4 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 5.0.3 - 28 October 2024

--- a/packages/ghana-bdr/CHANGELOG.md
+++ b/packages/ghana-bdr/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-ghana-bdr
 
-## 0.1.7
+## 0.1.7 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.1.6 - 16 April 2025

--- a/packages/ghana-nia/CHANGELOG.md
+++ b/packages/ghana-nia/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-ghana-nia
 
-## 0.1.7
+## 0.1.7 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.1.6 - 16 April 2025

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-gmail
 
-## 1.2.0
+## 1.2.0 - 22 April 2025
 
 ### Minor Changes
 
@@ -11,8 +11,8 @@
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.1.4 - 16 April 2025

--- a/packages/godata/CHANGELOG.md
+++ b/packages/godata/CHANGELOG.md
@@ -4,62 +4,62 @@
 
 ### Patch Changes
 
-* Updated docs for each()
-* Updated dependencies
-  * @openfn/language-common@2.1.1
+- Updated docs for each()
+- Updated dependencies
+  - @openfn/language-common@2.1.1
 
 ## 3.5.3 - 09 October 2024
 
 ### Patch Changes
 
-* 3fd13c2: Update axios to 1.7.7
+- 3fd13c2: Update axios to 1.7.7
 
 ## 3.5.2 - 16 August 2024
 
 ### Patch Changes
 
-* 8146c23: Fix typings in package.json
-* Updated dependencies \[8146c23]
-  * @openfn/language-common@2.0.1
+- 8146c23: Fix typings in package.json
+- Updated dependencies \[8146c23]
+  - @openfn/language-common@2.0.1
 
 ## 3.5.1 - 01 August 2024
 
 ### Patch Changes
 
-* Updated dependencies \[4fe527c]
-  * @openfn/language-common@2.0.0
+- Updated dependencies \[4fe527c]
+  - @openfn/language-common@2.0.0
 
 ## 3.5.0 - 13 June 2024
 
 ### Minor Changes
 
-* 3d9d564c: Add `fn` and `fnIf` operation
+- 3d9d564c: Add `fn` and `fnIf` operation
 
 ### Patch Changes
 
-* Updated dependencies \[106ecf6d]
-  * @openfn/language-common@1.14.0
+- Updated dependencies \[106ecf6d]
+  - @openfn/language-common@1.14.0
 
 ## 3.4.0 - 14 December 2023
 
 ### Minor Changes
 
-* df4cfca: Switch from `'writeOnly: true'` to `'format: email'` in the godata
+- df4cfca: Switch from `'writeOnly: true'` to `'format: email'` in the godata
   configuration schema.
 
 ## 3.3.1 - 19 June 2023
 
 ### Patch Changes
 
-* Update lock files
-* Updated dependencies
-  * @openfn/language-common@1.8.1
+- Update lock files
+- Updated dependencies
+  - @openfn/language-common@1.8.1
 
 ## 3.3.0
 
 ### Minor Changes
 
-* 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -71,43 +71,43 @@
 
 ### Patch Changes
 
-* Updated dependencies \[2c1d603]
-  * @openfn/language-common@1.8.0
+- Updated dependencies \[2c1d603]
+  - @openfn/language-common@1.8.0
 
 ## 3.2.4 - 30 March 2023
 
 ### Patch Changes
 
-* ef828e7: update old urls in readme
-* 14f481e: mark execute as private
-* Updated dependencies \[2b4c61a]
-  * @openfn/language-common@1.7.6
+- ef828e7: update old urls in readme
+- 14f481e: mark execute as private
+- Updated dependencies \[2b4c61a]
+  - @openfn/language-common@1.7.6
 
 ## 3.2.3 - 15 February 2023
 
 ### Patch Changes
 
-* f7ebd3c: remove sample configuration
+- f7ebd3c: remove sample configuration
 
 ## 3.2.2 - 15 February 2023
 
 ### Patch Changes
 
-* f2aed32: add examples
+- f2aed32: add examples
 
 ## 3.2.1 - 13 January 2023
 
 ### Patch Changes
 
-* 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 3.2.0 - 25 November 2022
 
 ### Minor Changes
 
-* 8e7a79e: Migrate Godata
+- 8e7a79e: Migrate Godata
 
 ### Patch Changes
 
-* cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
-* e81561f: Updated ast and package.json
+- cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
+- e81561f: Updated ast and package.json

--- a/packages/googledrive/CHANGELOG.md
+++ b/packages/googledrive/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-googledrive
 
-## 1.0.1
+## 1.0.1 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.0

--- a/packages/googlehealthcare/CHANGELOG.md
+++ b/packages/googlehealthcare/CHANGELOG.md
@@ -4,49 +4,49 @@
 
 ### Patch Changes
 
-* Updated docs for each()
-* Updated dependencies
-  * @openfn/language-common@2.1.1
+- Updated docs for each()
+- Updated dependencies
+  - @openfn/language-common@2.1.1
 
 ## 1.1.2 - 16 August 2024
 
 ### Patch Changes
 
-* 8146c23: Fix typings in package.json
-* Updated dependencies \[8146c23]
-  * @openfn/language-common@2.0.1
+- 8146c23: Fix typings in package.json
+- Updated dependencies \[8146c23]
+  - @openfn/language-common@2.0.1
 
 ## 1.1.1 - 01 August 2024
 
 ### Patch Changes
 
-* Updated dependencies \[4fe527c]
-  * @openfn/language-common@2.0.0
+- Updated dependencies \[4fe527c]
+  - @openfn/language-common@2.0.0
 
 ## 1.1.0 - 13 June 2024
 
 ### Minor Changes
 
-* 73433c20: Add `fnIf` operation
+- 73433c20: Add `fnIf` operation
 
 ### Patch Changes
 
-* Updated dependencies \[106ecf6d]
-  * @openfn/language-common@1.14.0
+- Updated dependencies \[106ecf6d]
+  - @openfn/language-common@1.14.0
 
 ## 1.0.1 - 08 May 2024
 
 ### Patch Changes
 
-* Security updates (lodash,undici)
-* Updated dependencies
-  * @openfn/language-common@1.13.2
+- Security updates (lodash,undici)
+- Updated dependencies
+  - @openfn/language-common@1.13.2
 
 ## 1.0.0 - 21 July 2023
 
 ### Major Changes
 
-* 7df7e20: remove `projectId`, `dataSetId`, `cloudRegion`, and `fhirStoreId` out
+- 7df7e20: remove `projectId`, `dataSetId`, `cloudRegion`, and `fhirStoreId` out
   of configuration
 
   The new implementation of `createFhirResource(fhirStore, resource, callback)`
@@ -59,11 +59,11 @@
 
 ### Minor Changes
 
-* 861d774: add createFhirResource function
+- 861d774: add createFhirResource function
 
 ### Patch Changes
 
-* aad9549: Ensure that standard OAuth2 credentials with snake-cased
+- aad9549: Ensure that standard OAuth2 credentials with snake-cased
   "access\_token" keys can be used for OAuth2-reliant adaptors
-* Updated dependencies \[aad9549]
-  * @openfn/language-common@1.10.0
+- Updated dependencies \[aad9549]
+  - @openfn/language-common@1.10.0

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-googlesheets
 
-## 3.0.13
+## 3.0.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 3.0.12 - 16 April 2025

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -161,7 +161,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-hive
 
-## 0.3.14
+## 0.3.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.3.13 - 16 April 2025

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,14 +1,14 @@
 # @openfn/language-http
 
-## 7.0.6
+## 7.0.6 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
 - 99e4b48: Fix parseAs option in all operations
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 7.0.5 - 16 April 2025

--- a/packages/hubtel/CHANGELOG.md
+++ b/packages/hubtel/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-hubtel
 
-## 1.0.5
+## 1.0.5 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.4 - 16 April 2025

--- a/packages/intuit/CHANGELOG.md
+++ b/packages/intuit/CHANGELOG.md
@@ -4,32 +4,32 @@
 
 ### Patch Changes
 
-* 99e4b48: - Better handling of HTML content in http requests
-  * When logging HTTP requests, include query parameters
-* Updated dependencies \[99e4b48]
-* Updated dependencies \[13bf08f]
-  * @openfn/language-common@2.4.0
+- 99e4b48: - Better handling of HTML content in http requests
+  - When logging HTTP requests, include query parameters
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
+  - @openfn/language-common@2.4.0
 
 ## 1.0.3 - 16 April 2025
 
 ### Patch Changes
 
-* Updated dependencies \[b089c56]
-  * @openfn/language-common@2.3.3
+- Updated dependencies \[b089c56]
+  - @openfn/language-common@2.3.3
 
 ## 1.0.2 - 11 April 2025
 
 ### Patch Changes
 
-* Updated dependencies \[d7105c0]
-  * @openfn/language-common@2.3.2
+- Updated dependencies \[d7105c0]
+  - @openfn/language-common@2.3.2
 
 ## 1.0.1 - 14 March 2025
 
 ### Patch Changes
 
-* Updated dependencies \[23ccb01]
-  * @openfn/language-common@2.3.1
+- Updated dependencies \[23ccb01]
+  - @openfn/language-common@2.3.1
 
 ## 1.0.0 - 30 January 2025
 

--- a/packages/intuit/CHANGELOG.md
+++ b/packages/intuit/CHANGELOG.md
@@ -1,35 +1,35 @@
 # @openfn/language-intuit
 
-## 1.0.4
+## 1.0.4 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
-  - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
-  - @openfn/language-common@2.4.0
+* 99e4b48: - Better handling of HTML content in http requests
+  * When logging HTTP requests, include query parameters
+* Updated dependencies \[99e4b48]
+* Updated dependencies \[13bf08f]
+  * @openfn/language-common@2.4.0
 
 ## 1.0.3 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
-  - @openfn/language-common@2.3.3
+* Updated dependencies \[b089c56]
+  * @openfn/language-common@2.3.3
 
 ## 1.0.2 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
-  - @openfn/language-common@2.3.2
+* Updated dependencies \[d7105c0]
+  * @openfn/language-common@2.3.2
 
 ## 1.0.1 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
-  - @openfn/language-common@2.3.1
+* Updated dependencies \[23ccb01]
+  * @openfn/language-common@2.3.1
 
 ## 1.0.0 - 30 January 2025
 

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-khanacademy
 
-## 0.5.14
+## 0.5.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.5.13 - 16 April 2025

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-kobotoolbox
 
-## 3.0.5
+## 3.0.5 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 3.0.4 - 16 April 2025

--- a/packages/magpi/CHANGELOG.md
+++ b/packages/magpi/CHANGELOG.md
@@ -4,61 +4,61 @@
 
 ### Patch Changes
 
-* Updated docs for each()
-* Updated dependencies
-  * @openfn/language-common@2.1.1
+- Updated docs for each()
+- Updated dependencies
+  - @openfn/language-common@2.1.1
 
 ## 1.2.3 - 09 October 2024
 
 ### Patch Changes
 
-* 8d866e4: Update tough-cookie dependency
+- 8d866e4: Update tough-cookie dependency
 
 ## 1.2.2 - 16 August 2024
 
 ### Patch Changes
 
-* 8146c23: Fix typings in package.json
-* Updated dependencies \[8146c23]
-  * @openfn/language-common@2.0.1
+- 8146c23: Fix typings in package.json
+- Updated dependencies \[8146c23]
+  - @openfn/language-common@2.0.1
 
 ## 1.2.1 - 01 August 2024
 
 ### Patch Changes
 
-* Updated dependencies \[4fe527c]
-  * @openfn/language-common@2.0.0
+- Updated dependencies \[4fe527c]
+  - @openfn/language-common@2.0.0
 
 ## 1.2.0 - 13 June 2024
 
 ### Minor Changes
 
-* 73433c20: Add `fnIf` operation
+- 73433c20: Add `fnIf` operation
 
 ### Patch Changes
 
-* Updated dependencies \[106ecf6d]
-  * @openfn/language-common@1.14.0
+- Updated dependencies \[106ecf6d]
+  - @openfn/language-common@1.14.0
 
 ## 1.1.2 - 24 January 2024
 
 ### Patch Changes
 
-* 6afba70: Fix variable reference in submitRecord
+- 6afba70: Fix variable reference in submitRecord
 
 ## 1.1.1 - 19 June 2023
 
 ### Patch Changes
 
-* Update lock files
-* Updated dependencies
-  * @openfn/language-common@1.8.1
+- Update lock files
+- Updated dependencies
+  - @openfn/language-common@1.8.1
 
 ## 1.1.0
 
 ### Minor Changes
 
-* 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -70,47 +70,47 @@
 
 ### Patch Changes
 
-* Updated dependencies \[2c1d603]
-  * @openfn/language-common@1.8.0
+- Updated dependencies \[2c1d603]
+  - @openfn/language-common@1.8.0
 
 ## 1.0.5 - 20 April 2023
 
 ### Patch Changes
 
-* 86fb813: dependencies update
+- 86fb813: dependencies update
 
 ## 1.0.4 - 30 March 2023
 
 ### Patch Changes
 
-* 14f481e: mark execute as private
-* Updated dependencies \[2b4c61a]
-  * @openfn/language-common@1.7.6
+- 14f481e: mark execute as private
+- Updated dependencies \[2b4c61a]
+  - @openfn/language-common@1.7.6
 
 ## 1.0.3 - 15 February 2023
 
 ### Patch Changes
 
-* f7ebd3c: remove sample configuration
+- f7ebd3c: remove sample configuration
 
 ## 1.0.2 - 15 February 2023
 
 ### Patch Changes
 
-* f2aed32: add examples
+- f2aed32: add examples
 
 ## 1.0.1 - 13 January 2023
 
 ### Patch Changes
 
-* 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 1.0.0 - 25 November 2022
 
 ### Major Changes
 
-* e6c2b4a: Update xml2js parser
+- e6c2b4a: Update xml2js parser
 
 ### Minor Changes
 
-* df5dd2e: migrate magpi
+- df5dd2e: migrate magpi

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-mailchimp
 
-## 1.0.15
+## 1.0.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.14 - 16 April 2025

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-mailgun
 
-## 0.5.13
+## 0.5.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.5.12 - 16 April 2025

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-maximo
 
-## 0.5.16
+## 0.5.16 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.5.15 - 16 April 2025

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-medicmobile
 
-## 0.5.14
+## 0.5.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.5.13 - 16 April 2025

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -1,11 +1,11 @@
 v0.1.6
 
-## 0.5.15
+## 0.5.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.5.14 - 16 April 2025

--- a/packages/mojatax/CHANGELOG.md
+++ b/packages/mojatax/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-mojatax
 
-## 1.0.9
+## 1.0.9 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.8 - 16 April 2025

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-mongodb
 
-## 2.1.14
+## 2.1.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 2.1.13 - 16 April 2025

--- a/packages/mpesa/CHANGELOG.md
+++ b/packages/mpesa/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- d1f7851: Fixed the title for the consumer_secret on the configuration schema
+- d1f7851: Fixed the title for the consumer\_secret on the configuration schema
 - Updated dependencies \[99e4b48]
 - Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0

--- a/packages/mpesa/CHANGELOG.md
+++ b/packages/mpesa/CHANGELOG.md
@@ -1,14 +1,14 @@
 # @openfn/language-mpesa
 
-## 1.0.3
+## 1.0.3 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
 - d1f7851: Fixed the title for the consumer_secret on the configuration schema
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.2 - 16 April 2025

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-msgraph
 
-## 0.7.14
+## 0.7.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.7.13 - 16 April 2025

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -248,7 +248,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-mssql
 
-## 5.0.14
+## 5.0.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 5.0.13 - 16 April 2025

--- a/packages/msupply/CHANGELOG.md
+++ b/packages/msupply/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-msupply
 
-## 1.0.2
+## 1.0.2 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.1 - 16 April 2025

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-mysql
 
-## 2.1.4
+## 2.1.4 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 2.1.3 - 16 April 2025

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-nexmo
 
-## 0.5.16
+## 0.5.16 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.5.15 - 16 April 2025

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-ocl
 
-## 1.2.15
+## 1.2.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.2.14 - 16 April 2025

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-odk
 
-## 3.0.15
+## 3.0.15 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 3.0.14 - 16 April 2025

--- a/packages/odoo/CHANGELOG.md
+++ b/packages/odoo/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-odoo
 
-## 1.0.6
+## 1.0.6 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.5 - 16 April 2025

--- a/packages/openboxes/CHANGELOG.md
+++ b/packages/openboxes/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-openboxes
 
-## 1.0.3
+## 1.0.3 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.2 - 16 April 2025

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-openfn
 
-## 2.0.13
+## 2.0.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 2.0.12 - 16 April 2025

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-openhim
 
-## 0.3.13
+## 0.3.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.3.12 - 16 April 2025

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-openimis
 
-## 2.0.13
+## 2.0.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 2.0.12 - 16 April 2025

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-openlmis
 
-## 1.0.14
+## 1.0.14 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.13 - 16 April 2025

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-openmrs
 
-## 5.0.2
+## 5.0.2 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 5.0.1 - 16 April 2025

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-openspp
 
-## 2.0.12
+## 2.0.12 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 2.0.11 - 16 April 2025

--- a/packages/pesapal/CHANGELOG.md
+++ b/packages/pesapal/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-pesapal
 
-## 1.0.2
+## 1.0.2 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.1 - 16 April 2025

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-postgresql
 
-## 6.0.12
+## 6.0.12 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 6.0.11 - 16 April 2025

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-primero
 
-## 3.1.3
+## 3.1.3 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 3.1.2 - 16 April 2025

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -4,159 +4,159 @@
 
 ### Patch Changes
 
-* Security fix: update jsonpath-plus version
+- Security fix: update jsonpath-plus version
 
 ## 1.4.5 - 09 October 2024
 
 ### Patch Changes
 
-* 3fd13c2: Update axios to 1.7.7
+- 3fd13c2: Update axios to 1.7.7
 
 ## 1.4.4 - 16 August 2024
 
 ### Patch Changes
 
-* 8146c23: Fix typings in package.json
-* Updated dependencies \[8146c23]
-  * @openfn/language-common@2.0.1
+- 8146c23: Fix typings in package.json
+- Updated dependencies \[8146c23]
+  - @openfn/language-common@2.0.1
 
 ## 1.4.3 - 01 August 2024
 
 ### Patch Changes
 
-* Updated dependencies \[4fe527c]
-  * @openfn/language-common@2.0.0
+- Updated dependencies \[4fe527c]
+  - @openfn/language-common@2.0.0
 
 ## 1.4.2 - 25 July 2024
 
 ### Patch Changes
 
-* Updated dependencies \[4c08444]
-* Updated dependencies \[73d0a02]
-  * @openfn/language-common@1.15.1
+- Updated dependencies \[4c08444]
+- Updated dependencies \[73d0a02]
+  - @openfn/language-common@1.15.1
 
 ## 1.4.1 - 19 June 2024
 
 ### Patch Changes
 
-* Updated dependencies \[5fb82f07]
-  * @openfn/language-common@1.15.0
+- Updated dependencies \[5fb82f07]
+  - @openfn/language-common@1.15.0
 
 ## 1.4.0 - 13 June 2024
 
 ### Minor Changes
 
-* 3d9d564c: Add `fn` and `fnIf` operation
+- 3d9d564c: Add `fn` and `fnIf` operation
 
 ### Patch Changes
 
-* Updated dependencies \[106ecf6d]
-  * @openfn/language-common@1.14.0
+- Updated dependencies \[106ecf6d]
+  - @openfn/language-common@1.14.0
 
 ## 1.3.14 - 11 June 2024
 
 ### Patch Changes
 
-* Updated dependencies
-  * @openfn/language-common@1.13.5
+- Updated dependencies
+  - @openfn/language-common@1.13.5
 
 ## 1.3.13 - 21 May 2024
 
 ### Patch Changes
 
-* Updated dependencies \[12f02ed5]
-  * @openfn/language-common@1.13.4
+- Updated dependencies \[12f02ed5]
+  - @openfn/language-common@1.13.4
 
 ## 1.3.12 - 08 May 2024
 
 ### Patch Changes
 
-* Updated dependencies \[88f99a8f]
-  * @openfn/language-common@1.13.3
+- Updated dependencies \[88f99a8f]
+  - @openfn/language-common@1.13.3
 
 ## 1.3.11 - 08 May 2024
 
 ### Patch Changes
 
-* Updated dependencies
-  * @openfn/language-common@1.13.2
+- Updated dependencies
+  - @openfn/language-common@1.13.2
 
 ## 1.3.10 - 12 April 2024
 
 ### Patch Changes
 
-* Updated dependencies
-  * @openfn/language-common@1.13.1
+- Updated dependencies
+  - @openfn/language-common@1.13.1
 
 ## 1.3.9 - 12 April 2024
 
 ### Patch Changes
 
-* Updated dependencies \[1ad86651]
-  * @openfn/language-common@1.13.0
+- Updated dependencies \[1ad86651]
+  - @openfn/language-common@1.13.0
 
 ## 1.3.8 - 20 September 2023
 
 ### Patch Changes
 
-* Updated dependencies \[c19efbe]
-  * @openfn/language-common@1.11.1
+- Updated dependencies \[c19efbe]
+  - @openfn/language-common@1.11.1
 
 ## 1.3.7 - 08 September 2023
 
 ### Patch Changes
 
-* Updated dependencies \[85c35b8]
-  * @openfn/language-common@1.11.0
+- Updated dependencies \[85c35b8]
+  - @openfn/language-common@1.11.0
 
 ## 1.3.6 - 14 August 2023
 
 ### Patch Changes
 
-* Updated dependencies \[df09270]
-  * @openfn/language-common@1.10.3
+- Updated dependencies \[df09270]
+  - @openfn/language-common@1.10.3
 
 ## 1.3.5 - 14 July 2023
 
 ### Patch Changes
 
-* Updated dependencies \[26a303e]
-  * @openfn/language-common@1.10.2
+- Updated dependencies \[26a303e]
+  - @openfn/language-common@1.10.2
 
 ## 1.3.4 - 14 July 2023
 
 ### Patch Changes
 
-* Updated dependencies \[8c32eb3]
-  * @openfn/language-common@1.10.1
+- Updated dependencies \[8c32eb3]
+  - @openfn/language-common@1.10.1
 
 ## 1.3.3 - 30 June 2023
 
 ### Patch Changes
 
-* Updated dependencies \[aad9549]
-  * @openfn/language-common@1.10.0
+- Updated dependencies \[aad9549]
+  - @openfn/language-common@1.10.0
 
 ## 1.3.2 - 23 June 2023
 
 ### Patch Changes
 
-* Updated dependencies \[111807f]
-  * @openfn/language-common@1.9.0
+- Updated dependencies \[111807f]
+  - @openfn/language-common@1.9.0
 
 ## 1.3.1 - 19 June 2023
 
 ### Patch Changes
 
-* Update lock files
-* Updated dependencies
-  * @openfn/language-common@1.8.1
+- Update lock files
+- Updated dependencies
+  - @openfn/language-common@1.8.1
 
 ## 1.3.0
 
 ### Minor Changes
 
-* 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -168,50 +168,50 @@
 
 ### Patch Changes
 
-* Updated dependencies \[2c1d603]
-  * @openfn/language-common@1.8.0
+- Updated dependencies \[2c1d603]
+  - @openfn/language-common@1.8.0
 
 ## 1.2.5 - 31 March 2023
 
 ### Patch Changes
 
-* Updated dependencies \[929bca6]
-  * @openfn/language-common@1.7.7
+- Updated dependencies \[929bca6]
+  - @openfn/language-common@1.7.7
 
 ## 1.2.4 - 30 March 2023
 
 ### Patch Changes
 
-* ef828e7: update old urls in readme
-* 14f481e: mark execute as private
-* Updated dependencies \[2b4c61a]
-  * @openfn/language-common@1.7.6
+- ef828e7: update old urls in readme
+- 14f481e: mark execute as private
+- Updated dependencies \[2b4c61a]
+  - @openfn/language-common@1.7.6
 
 ## 1.2.3 - 15 February 2023
 
 ### Patch Changes
 
-* f7ebd3c: remove sample configuration
+- f7ebd3c: remove sample configuration
 
 ## 1.2.2 - 15 February 2023
 
 ### Patch Changes
 
-* f2aed32: add examples
+- f2aed32: add examples
 
 ## 1.2.1 - 13 January 2023
 
 ### Patch Changes
 
-* 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 1.2.0 - 18 November 2022
 
 ### Minor Changes
 
-* 039ca0b: Migrate Progres
+- 039ca0b: Migrate Progres
 
 ### Patch Changes
 
-* Updated dependencies \[f2a91a4]
-  * @openfn/language-common@1.7.5
+- Updated dependencies \[f2a91a4]
+  - @openfn/language-common@1.7.5

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -4,152 +4,152 @@
 
 ### Patch Changes
 
-* Security fix: update jsonpath-plus version
+- Security fix: update jsonpath-plus version
 
 ## 1.1.4 - 09 October 2024
 
 ### Patch Changes
 
-* 3fd13c2: Update axios to 1.7.7
+- 3fd13c2: Update axios to 1.7.7
 
 ## 1.1.3 - 16 August 2024
 
 ### Patch Changes
 
-* 8146c23: Fix typings in package.json
-* Updated dependencies \[8146c23]
-  * @openfn/language-common@2.0.1
+- 8146c23: Fix typings in package.json
+- Updated dependencies \[8146c23]
+  - @openfn/language-common@2.0.1
 
 ## 1.1.2 - 25 July 2024
 
 ### Patch Changes
 
-* Updated dependencies \[4c08444]
-* Updated dependencies \[73d0a02]
-  * @openfn/language-common@1.15.1
+- Updated dependencies \[4c08444]
+- Updated dependencies \[73d0a02]
+  - @openfn/language-common@1.15.1
 
 ## 1.1.1 - 19 June 2024
 
 ### Patch Changes
 
-* Updated dependencies \[5fb82f07]
-  * @openfn/language-common@1.15.0
+- Updated dependencies \[5fb82f07]
+  - @openfn/language-common@1.15.0
 
 ## 1.1.0 - 13 June 2024
 
 ### Minor Changes
 
-* 73433c20: Add `fnIf` operation
+- 73433c20: Add `fnIf` operation
 
 ### Patch Changes
 
-* Updated dependencies \[106ecf6d]
-  * @openfn/language-common@1.14.0
+- Updated dependencies \[106ecf6d]
+  - @openfn/language-common@1.14.0
 
 ## 1.0.14 - 11 June 2024
 
 ### Patch Changes
 
-* Updated dependencies
-  * @openfn/language-common@1.13.5
+- Updated dependencies
+  - @openfn/language-common@1.13.5
 
 ## 1.0.13 - 21 May 2024
 
 ### Patch Changes
 
-* Updated dependencies \[12f02ed5]
-  * @openfn/language-common@1.13.4
+- Updated dependencies \[12f02ed5]
+  - @openfn/language-common@1.13.4
 
 ## 1.0.12 - 08 May 2024
 
 ### Patch Changes
 
-* Updated dependencies \[88f99a8f]
-  * @openfn/language-common@1.13.3
+- Updated dependencies \[88f99a8f]
+  - @openfn/language-common@1.13.3
 
 ## 1.0.11 - 08 May 2024
 
 ### Patch Changes
 
-* Updated dependencies
-  * @openfn/language-common@1.13.2
+- Updated dependencies
+  - @openfn/language-common@1.13.2
 
 ## 1.0.10 - 12 April 2024
 
 ### Patch Changes
 
-* Updated dependencies
-  * @openfn/language-common@1.13.1
+- Updated dependencies
+  - @openfn/language-common@1.13.1
 
 ## 1.0.9 - 12 April 2024
 
 ### Patch Changes
 
-* Updated dependencies \[1ad86651]
-  * @openfn/language-common@1.13.0
+- Updated dependencies \[1ad86651]
+  - @openfn/language-common@1.13.0
 
 ## 1.0.8 - 20 September 2023
 
 ### Patch Changes
 
-* Updated dependencies \[c19efbe]
-  * @openfn/language-common@1.11.1
+- Updated dependencies \[c19efbe]
+  - @openfn/language-common@1.11.1
 
 ## 1.0.7 - 08 September 2023
 
 ### Patch Changes
 
-* Updated dependencies \[85c35b8]
-  * @openfn/language-common@1.11.0
+- Updated dependencies \[85c35b8]
+  - @openfn/language-common@1.11.0
 
 ## 1.0.6 - 14 August 2023
 
 ### Patch Changes
 
-* Updated dependencies \[df09270]
-  * @openfn/language-common@1.10.3
+- Updated dependencies \[df09270]
+  - @openfn/language-common@1.10.3
 
 ## 1.0.5 - 14 July 2023
 
 ### Patch Changes
 
-* Updated dependencies \[26a303e]
-  * @openfn/language-common@1.10.2
+- Updated dependencies \[26a303e]
+  - @openfn/language-common@1.10.2
 
 ## 1.0.4 - 14 July 2023
 
 ### Patch Changes
 
-* Updated dependencies \[8c32eb3]
-  * @openfn/language-common@1.10.1
+- Updated dependencies \[8c32eb3]
+  - @openfn/language-common@1.10.1
 
 ## 1.0.3 - 30 June 2023
 
 ### Patch Changes
 
-* Updated dependencies \[aad9549]
-  * @openfn/language-common@1.10.0
+- Updated dependencies \[aad9549]
+  - @openfn/language-common@1.10.0
 
 ## 1.0.2 - 23 June 2023
 
 ### Patch Changes
 
-* Updated dependencies \[111807f]
-  * @openfn/language-common@1.9.0
+- Updated dependencies \[111807f]
+  - @openfn/language-common@1.9.0
 
 ## 1.0.1 - 19 June 2023
 
 ### Patch Changes
 
-* Update lock files
-* Updated dependencies
-  * @openfn/language-common@1.8.1
+- Update lock files
+- Updated dependencies
+  - @openfn/language-common@1.8.1
 
 ## 1.0.0
 
 ### Major Changes
 
-* 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -161,56 +161,56 @@
 
 ### Patch Changes
 
-* Updated dependencies \[2c1d603]
-  * @openfn/language-common@1.8.0
+- Updated dependencies \[2c1d603]
+  - @openfn/language-common@1.8.0
 
 ## 0.5.6 - 31 March 2023
 
 ### Patch Changes
 
-* Updated dependencies \[929bca6]
-  * @openfn/language-common@1.7.7
+- Updated dependencies \[929bca6]
+  - @openfn/language-common@1.7.7
 
 ## 0.5.5 - 30 March 2023
 
 ### Patch Changes
 
-* ef828e7: update old urls in readme
-* 14f481e: mark execute as private
-* Updated dependencies \[2b4c61a]
-  * @openfn/language-common@1.7.6
+- ef828e7: update old urls in readme
+- 14f481e: mark execute as private
+- Updated dependencies \[2b4c61a]
+  - @openfn/language-common@1.7.6
 
 ## 0.5.4 - 15 February 2023
 
 ### Patch Changes
 
-* f7ebd3c: remove sample configuration
+- f7ebd3c: remove sample configuration
 
 ## 0.5.3 - 15 February 2023
 
 ### Patch Changes
 
-* f2aed32: add examples
+- f2aed32: add examples
 
 ## 0.5.2 - 13 January 2023
 
 ### Patch Changes
 
-* 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.5.1 - 25 November 2022
 
 ### Patch Changes
 
-* cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
+- cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
 
 ## 0.5.0 - 18 November 2022
 
 ### Minor Changes
 
-* 11f83ff: Migrate RapidPro
+- 11f83ff: Migrate RapidPro
 
 ### Patch Changes
 
-* Updated dependencies \[f2a91a4]
-  * @openfn/language-common@1.7.5
+- Updated dependencies \[f2a91a4]
+  - @openfn/language-common@1.7.5

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-redis
 
-## 1.3.3
+## 1.3.3 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.3.2 - 16 April 2025

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-resourcemap
 
-## 0.4.15
+## 0.4.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.4.14 - 16 April 2025

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-salesforce
 
-## 6.0.3
+## 6.0.3 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 6.0.2 - 16 April 2025

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-satusehat
 
-## 2.0.14
+## 2.0.14 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 2.0.13 - 16 April 2025

--- a/packages/senaite/CHANGELOG.md
+++ b/packages/senaite/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-senaite
 
-## 1.0.2
+## 1.0.2 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.1 - 16 April 2025

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-sftp
 
-## 2.0.12
+## 2.0.12 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 2.0.11 - 16 April 2025

--- a/packages/surveycto/CHANGELOG.md
+++ b/packages/surveycto/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-surveycto
 
-## 2.2.4
+## 2.2.4 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 2.2.3 - 16 August 2024

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-telerivet
 
-## 0.3.13
+## 0.3.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.3.12 - 16 April 2025

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -4,75 +4,75 @@
 
 ### Patch Changes
 
-* Updated dependencies \[b3d7f59]
-* Updated dependencies \[2d709ff]
-* Updated dependencies \[41e8cc3]
-  * @openfn/language-common@2.3.0
+- Updated dependencies \[b3d7f59]
+- Updated dependencies \[2d709ff]
+- Updated dependencies \[41e8cc3]
+  - @openfn/language-common@2.3.0
 
 ## 1.0.9 - 16 January 2025
 
 ### Patch Changes
 
-* Updated dependencies \[6dffdbd]
-  * @openfn/language-common@2.2.1
+- Updated dependencies \[6dffdbd]
+  - @openfn/language-common@2.2.1
 
 ## 1.0.8 - 09 January 2025
 
 ### Patch Changes
 
-* Updated dependencies \[a47d8d5]
-* Updated dependencies \[9240428]
-  * @openfn/language-common@2.2.0
+- Updated dependencies \[a47d8d5]
+- Updated dependencies \[9240428]
+  - @openfn/language-common@2.2.0
 
 ## 1.0.7 - 18 October 2024
 
 ### Patch Changes
 
-* Updated dependencies \[03a1a74]
-  * @openfn/language-common@2.1.0
+- Updated dependencies \[03a1a74]
+  - @openfn/language-common@2.1.0
 
 ## 1.0.6 - 15 October 2024
 
 ### Patch Changes
 
-* Fixed security vulnerability in jsonpath-plus \[33973a2]
-  * @openfn/language-common@2.0.3
+- Fixed security vulnerability in jsonpath-plus \[33973a2]
+  - @openfn/language-common@2.0.3
 
 ## 1.0.5 - 24 September 2024
 
 ### Patch Changes
 
-* Updated dependencies \[77a690f]
-  * @openfn/language-common@2.0.2
+- Updated dependencies \[77a690f]
+  - @openfn/language-common@2.0.2
 
 ## 1.0.4 - 16 August 2024
 
 ### Patch Changes
 
-* 8146c23: Fix typings in package.json
-* Updated dependencies \[8146c23]
-  * @openfn/language-common@2.0.1
+- 8146c23: Fix typings in package.json
+- Updated dependencies \[8146c23]
+  - @openfn/language-common@2.0.1
 
 ## 1.0.3 - 01 August 2024
 
 ### Patch Changes
 
-* Updated dependencies \[4fe527c]
-  * @openfn/language-common@2.0.0
+- Updated dependencies \[4fe527c]
+  - @openfn/language-common@2.0.0
 
 ## 1.0.2 - 25 July 2024
 
 ### Patch Changes
 
-* Updated dependencies \[4c08444]
-* Updated dependencies \[73d0a02]
-  * @openfn/language-common@1.15.1
+- Updated dependencies \[4c08444]
+- Updated dependencies \[73d0a02]
+  - @openfn/language-common@1.15.1
 
 ## 1.0.1 - 19 June 2024
 
 ### Patch Changes
 
-* Updated dependencies \[5fb82f07]
-  * @openfn/language-common@1.15.0
+- Updated dependencies \[5fb82f07]
+  - @openfn/language-common@1.15.0
 
 .

--- a/packages/twilio/CHANGELOG.md
+++ b/packages/twilio/CHANGELOG.md
@@ -4,46 +4,46 @@
 
 ### Patch Changes
 
-* Security fix: update jsonpath-plus version
+- Security fix: update jsonpath-plus version
 
 ## 0.5.1 - 16 August 2024
 
 ### Patch Changes
 
-* 8146c23: Fix typings in package.json
-* Updated dependencies \[8146c23]
-  * @openfn/language-common@2.0.1
+- 8146c23: Fix typings in package.json
+- Updated dependencies \[8146c23]
+  - @openfn/language-common@2.0.1
 
 ## 0.5.0 - 13 June 2024
 
 ### Minor Changes
 
-* 73433c20: Add `fnIf` operation
+- 73433c20: Add `fnIf` operation
 
 ### Patch Changes
 
-* Updated dependencies \[106ecf6d]
-  * @openfn/language-common@1.14.0
+- Updated dependencies \[106ecf6d]
+  - @openfn/language-common@1.14.0
 
 ## 0.4.2 - 24 January 2024
 
 ### Patch Changes
 
-* 6afba70: Fix sendSMS
+- 6afba70: Fix sendSMS
 
 ## 0.4.1 - 19 June 2023
 
 ### Patch Changes
 
-* Update lock files
-* Updated dependencies
-  * @openfn/language-common@1.8.1
+- Update lock files
+- Updated dependencies
+  - @openfn/language-common@1.8.1
 
 ## 0.4.0
 
 ### Minor Changes
 
-* 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -55,42 +55,42 @@
 
 ### Patch Changes
 
-* Updated dependencies \[2c1d603]
-  * @openfn/language-common@1.8.0
+- Updated dependencies \[2c1d603]
+  - @openfn/language-common@1.8.0
 
 ## 0.3.4 - 06 April 2023
 
 ### Patch Changes
 
-* a22daa6: rename credential-schema to configuration-schemawq
+- a22daa6: rename credential-schema to configuration-schemawq
 
 ## 0.3.3 - 30 March 2023
 
 ### Patch Changes
 
-* 14f481e: mark execute as private
-* Updated dependencies \[2b4c61a]
-  * @openfn/language-common@1.7.6
+- 14f481e: mark execute as private
+- Updated dependencies \[2b4c61a]
+  - @openfn/language-common@1.7.6
 
 ## 0.3.2 - 15 February 2023
 
 ### Patch Changes
 
-* f7ebd3c: remove sample configuration
+- f7ebd3c: remove sample configuration
 
 ## 0.3.1 - 15 February 2023
 
 ### Patch Changes
 
-* f2aed32: add examples
+- f2aed32: add examples
 
 ## 0.3.0 - 18 November 2022
 
 ### Minor Changes
 
-* a36a072: ymigrated twilio to monorepo
+- a36a072: ymigrated twilio to monorepo
 
 ### Patch Changes
 
-* Updated dependencies \[f2a91a4]
-  * @openfn/language-common@1.7.5
+- Updated dependencies \[f2a91a4]
+  - @openfn/language-common@1.7.5

--- a/packages/varo/CHANGELOG.md
+++ b/packages/varo/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-varo
 
-## 1.0.3
+## 1.0.3 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.0.2 - 16 April 2025

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-vtiger
 
-## 1.3.14
+## 1.3.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 1.3.13 - 16 April 2025

--- a/packages/wigal-sms/CHANGELOG.md
+++ b/packages/wigal-sms/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @openfn/language-wigal-sms
 
-## 0.1.7
+## 0.1.7 - 22 April 2025
 
 ### Patch Changes
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.1.6 - 16 April 2025

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-zoho
 
-## 0.4.13
+## 0.4.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies [99e4b48]
-- Updated dependencies [13bf08f]
+- Updated dependencies \[99e4b48]
+- Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
 ## 0.4.12 - 16 April 2025

--- a/tools/changelog/src/updateChangelog.js
+++ b/tools/changelog/src/updateChangelog.js
@@ -62,7 +62,13 @@ export async function updateChangelog(adaptorName, adaptorVersionList = null) {
 
   const file = await remark().use(stringify).run(updatedAst);
 
-  const updatedMarkdown = String(await remark().use(stringify).stringify(file));
+  const updatedMarkdown = String(
+    await remark()
+      .use(stringify, {
+        bullet: '-',
+      })
+      .stringify(file)
+  );
 
   await writeFile(changelogPath, updatedMarkdown, 'utf8');
   console.log(`✔ ${adaptorName} changelog updated`);


### PR DESCRIPTION
Caught a couple of issues in the changelogs

The last release is missing dates - that's likely to be my fault for not using the latest version command :innocent: 

I also notice that whenever I run the versions script, bulleted list s change from `- thing` to `* thing`. But then when committing they get changed back somehow?? Weird. Anyway I've updated remark to prefer the `-` style

This should prevent weird diffs coming in next time I run the script

