### PR TITLE
dhis2: Remove options from `get` and `create`

### DIFF
--- a/.changeset/early-hotels-behave.md
+++ b/.changeset/early-hotels-behave.md
@@ -1,0 +1,26 @@
+---
+'@openfn/language-dhis2': major
+---
+
+- The options parameter has been removed entirely from the `get` and `create` functions.
+- You can no longer pass `headers` or `content types` or `base64` to the `get` and `create` functions, use `http.get()` or `http.post()` for this.
+
+### Migration Guide:
+
+- If you used to do this `get(resourceType, options)` where:
+
+```
+get('tracker/enrollments', {
+ query:{ orgUnit: 'TSyzvBiovKh'}
+});
+
+```
+
+- You can now do this `get(path, params)`:
+
+```
+get('tracker/enrollments', {
+  orgUnit: 'TSyzvBiovKh',
+});
+
+```

--- a/packages/dhis2/ast.json
+++ b/packages/dhis2/ast.json
@@ -128,11 +128,11 @@
     {
       "name": "get",
       "params": [
-        "resourceType",
-        "options"
+        "path",
+        "params"
       ],
       "docs": {
-        "description": "Get data. Generic helper method for getting data of any kind from DHIS2.\n- This can be used to get `DataValueSets`,`events`,`trackers`,`etc.`",
+        "description": "Get any resource, as JSON, from DHIS2. Pass in any valid DHIS2 REST path, excluding /api and the version.\n- For the new tracker API, see `tracker.export()`",
         "tags": [
           {
             "title": "public",
@@ -146,24 +146,21 @@
           },
           {
             "title": "param",
-            "description": "The type of resource to get(use its `plural` name). E.g. `dataElements`, `tracker/trackedEntities`,`organisationUnits`, etc.",
+            "description": "Path to the resource",
             "type": {
               "type": "NameExpression",
               "name": "string"
             },
-            "name": "resourceType"
+            "name": "path"
           },
           {
             "title": "param",
-            "description": "An optional object containing query, parseAs,and headers for the request",
+            "description": "Optional object of query parameters to include in the request",
             "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "RequestOptions"
-              }
+              "type": "NameExpression",
+              "name": "object"
             },
-            "name": "options"
+            "name": "params"
           },
           {
             "title": "state",
@@ -179,12 +176,12 @@
           },
           {
             "title": "example",
-            "description": "get('dataValueSets', {\n query:{\n  dataSet: 'pBOMPrpg1QX',\n  orgUnit: 'DiszpKrYNg8',\n  period: '201401',\n  fields: '*',\n}\n});",
+            "description": "get('dataValueSets', {\n  dataSet: 'pBOMPrpg1QX',\n  orgUnit: 'DiszpKrYNg8',\n  period: '201401',\n  fields: '*',\n});",
             "caption": "Get all data values for the 'pBOMPrpg1QX' dataset"
           },
           {
             "title": "example",
-            "description": "get('programs', { query : { orgUnit: 'TSyzvBiovKh', fields: '*' } });",
+            "description": "get('programs', { orgUnit: 'TSyzvBiovKh', fields: '*' });",
             "caption": "Get all programs for an organization unit"
           },
           {
@@ -204,13 +201,8 @@
           },
           {
             "title": "example",
-            "description": "get('tracker/relationships', {\n  query: { trackedEntity:['F8yKM85NbxW'] }\n});",
+            "description": "get('tracker/relationships', {\n trackedEntity:['F8yKM85NbxW']\n});",
             "caption": "Get the relationship between two tracker entities. The only required parameters are 'trackedEntity', 'enrollment' or 'event'. See [Relationships docs](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-241/tracker.html#relationships-get-apitrackerrelationships)"
-          },
-          {
-            "title": "example",
-            "description": "get('trackedEntityInstances/qHVDKszQmdx/BqaEWTBG3RB/image', {\n  headers:{\n      Accept: 'image/*'\n  },\n  parseAs: 'base64',\n});",
-            "caption": "Get an image from a trackedEntityInstance."
           }
         ]
       },

--- a/packages/dhis2/test/index.test.js
+++ b/packages/dhis2/test/index.test.js
@@ -90,10 +90,8 @@ describe(' get', () => {
 
     const finalState = await execute(
       get('dataValueSets', {
-        query: {
           ...query,
           fields: '*',
-        },
       })
     )(state);
 
@@ -126,10 +124,8 @@ describe(' get', () => {
 
     const finalState = await execute(
       get('dataValueSets', {
-        query: {
           ...query,
           fields: '*',
-        },
       })
     )(state);
 
@@ -160,30 +156,6 @@ describe(' get', () => {
     });
   });
 
-  it('should support base64 for images', async () => {
-    testServer
-      .intercept({
-        path: getPath('trackedEntityInstances/qHVDKszQmdx/BqaEWTBG3RB/image'),
-        method: 'GET',
-      })
-      .reply(
-        200,
-        '����\x00\x10JFIF\x00\x01\x02\x00\x00\x01\x00\x01\x00\x00��\x00C\x00\b\x06\x06\x07\x06\x05\b\x07\x07\x07\t\t\b\n'
-      );
-
-    const finalState = await execute(
-      get('trackedEntityInstances/qHVDKszQmdx/BqaEWTBG3RB/image', {
-        headers: {
-          Accept: 'image/*',
-        },
-        parseAs: 'base64',
-      })
-    )(state);
-    expect(finalState.response).to.eql(undefined);
-    expect(finalState.data).to.eql(
-      '77+977+977+977+9ABBKRklGAAECAAABAAEAAO+/ve+/vQBDAAgGBgcGBQgHBwcJCQgK'
-    );
-  });
 });
 
 describe('helperfunctions', () => {

--- a/packages/dhis2/test/integration.js
+++ b/packages/dhis2/test/integration.js
@@ -254,12 +254,10 @@ describe('Integration tests', () => {
     it('should get dataValueSets matching the query specified', async () => {
       const finalState = await execute(
         get('dataValueSets', {
-          query: {
             dataSet: 'pBOMPrpg1QX',
             orgUnit: 'sx4lYrYvpJ2',
             period: '201401',
             fields: '*',
-          },
         })
       )(state);
 
@@ -269,11 +267,9 @@ describe('Integration tests', () => {
     it('should get a single TEI based on multiple filters', async () => {
       const finalState = await execute(
         get('tracker/trackedEntities', {
-          query: {
             program: 'fDd25txQckK',
             orgUnit: 'DiszpKrYNg8',
             filter: ['w75KJ2mc4zz:Eq:Elanor'],
-          },
         })
       )(state);
 


### PR DESCRIPTION
## Summary

Remove options from `get` and `create` and replace with `params`.
Remove support for passing content type, headers, and base64 in `get` and `create`.

Fixes #1162

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
