### PR TITLE
Remove `format:uri` property from sftp configuration

### DIFF
--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-sftp
 
+## 2.0.13 - 03 June 2025
+
+### Patch Changes
+
+- remove `format:uri` from configuration-schema
+
 ## 2.0.12 - 22 April 2025
 
 ### Patch Changes

--- a/packages/sftp/configuration-schema.json
+++ b/packages/sftp/configuration-schema.json
@@ -5,10 +5,10 @@
       "title": "Host URL",
       "type": "string",
       "description": "The SFTP server host url or ip address",
-      "format": "uri",
       "minLength": 1,
       "examples": [
-        "191.173.128.88"
+        "191.173.128.88",
+        "sftp.example.com"
       ]
     },
     "port": {
@@ -20,7 +20,6 @@
       "examples": [
         22
       ]
-
     },
     "username": {
       "title": "Username",
@@ -44,5 +43,7 @@
   },
   "type": "object",
   "additionalProperties": true,
-  "required": ["host"]
+  "required": [
+    "host"
+  ]
 }

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-sftp",
   "label": "SFTP",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "An SFTP language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {


### PR DESCRIPTION
## Summary

Remove `format: uri` property from `configuration-schema.json`. 

Fixes #1199 

## Details

The format property enforces several requirements for a valid URI like `("http://" or "https://")`. This is not a good UX when creating `sftp` credential because it forces your `hostUrl` to be a valid URI which is not always the case. Sometimes you would want to input an ip address without `scheme/protocol`. Eg: `34.234.123.452`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA: If this is a new adaptor, added the adaptor on marketing website ?
- NA: If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- NA: Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
