### PR TITLE
`kobo` Add support for `sort` and `start` params in `getSubmission`

### DIFF
--- a/.changeset/seven-penguins-swim.md
+++ b/.changeset/seven-penguins-swim.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-kobotoolbox': minor
+---
+
+Add support for `sort` and `start` option in `getSubmissions` function

--- a/.changeset/seven-penguins-swim.md
+++ b/.changeset/seven-penguins-swim.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-kobotoolbox': minor
----
-
-Add support for `sort` and `start` option in `getSubmissions` function

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-kobotoolbox
 
+## 4.1.0 - 06 June 2025
+
+### Minor Changes
+
+- 2123876: Add support for `sort` and `start` option in `getSubmissions`
+  function
+
 ## 4.0.0 - 30 May 2025
 
 ### Major Changes

--- a/packages/kobotoolbox/ast.json
+++ b/packages/kobotoolbox/ast.json
@@ -61,6 +61,16 @@
             "caption": "Get form submissions with a query"
           },
           {
+            "title": "example",
+            "description": "getSubmissions('aXecHjmbATuF6iGFmvBLBX', { sort: { _submission_time: -1 } });",
+            "caption": "Get form submissions with sorting"
+          },
+          {
+            "title": "example",
+            "description": "getSubmissions('aXecHjmbATuF6iGFmvBLBX', { start: 10 });",
+            "caption": "Get form submissions with specific start index"
+          },
+          {
             "title": "function",
             "description": null,
             "name": null
@@ -94,7 +104,7 @@
           },
           {
             "title": "param",
-            "description": "Field and direction to sort submissions by. Specify 1 for ascending or -1 for descending order (e.g. {\"field_name\": 1} or {\"field_name\": -1})",
+            "description": "Field and direction to sort submissions by.",
             "type": {
               "type": "OptionalType",
               "expression": {
@@ -118,7 +128,7 @@
           },
           {
             "title": "param",
-            "description": "The index of the first submission to return. Used for pagination.",
+            "description": "The index of the first submission to return.",
             "type": {
               "type": "OptionalType",
               "expression": {

--- a/packages/kobotoolbox/ast.json
+++ b/packages/kobotoolbox/ast.json
@@ -94,6 +94,18 @@
           },
           {
             "title": "param",
+            "description": "Field and direction to sort submissions by. Specify 1 for ascending or -1 for descending order (e.g. {\"field_name\": 1} or {\"field_name\": -1})",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "object"
+              }
+            },
+            "name": "options.sort"
+          },
+          {
+            "title": "param",
             "description": "Query options to filter the submissions. See query operators {@link http://docs.mongodb.org/manual/reference/operator/query/.}",
             "type": {
               "type": "OptionalType",
@@ -103,6 +115,19 @@
               }
             },
             "name": "options.query"
+          },
+          {
+            "title": "param",
+            "description": "The index of the first submission to return. Used for pagination.",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "number"
+              }
+            },
+            "name": "options.start",
+            "default": "0"
           },
           {
             "title": "param",

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-kobotoolbox",
   "label": "KoboToolbox",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A KoboToolbox Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -61,13 +61,17 @@ export function getForms() {
  * getSubmissions('aXecHjmbATuF6iGFmvBLBX', { limit: Infinity });
  * @example <caption>Get form submissions with a query</caption>
  * getSubmissions('aXecHjmbATuF6iGFmvBLBX', { query: { _submission_time:{ $gte: "2025-03-12T21:54:20" } } });
+ * @example <caption>Get form submissions with sorting</caption>
+ * getSubmissions('aXecHjmbATuF6iGFmvBLBX', { sort: { _submission_time: -1 } });
+ * @example <caption>Get form submissions with specific start index</caption>
+ * getSubmissions('aXecHjmbATuF6iGFmvBLBX', { start: 10 });
  * @function
  * @public
  * @param {string} formId - Form Id to get the specific submissions
  * @param {object} [options={}] - Options to control the request
- * @param {object} [options.sort] - Field and direction to sort submissions by. Specify 1 for ascending or -1 for descending order (e.g. {"field_name": 1} or {"field_name": -1})
+ * @param {object} [options.sort] - Field and direction to sort submissions by.
  * @param {object} [options.query] - Query options to filter the submissions. See query operators {@link http://docs.mongodb.org/manual/reference/operator/query/.}
- * @param {number} [options.start=0] - The index of the first submission to return. Used for pagination.
+ * @param {number} [options.start=0] - The index of the first submission to return.
  * @param {number} [options.limit=30000] - Maximum number of submissions to fetch. Pass Infinity to disable the limit and download all submissions
  * @param {number} [options.pageSize=10000] - Limits the size of each page of submissions. Maximum value is 30000.
  * @state data - an array of submission objects

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -95,7 +95,8 @@ export function getSubmissions(formId, options) {
       qs.sort = util.maybeStringify(sort);
     }
     const requestOptions = {
-      query: { ...qs, start },
+      query: { ...qs },
+      start,
       limit,
       pageSize,
     };

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -65,7 +65,9 @@ export function getForms() {
  * @public
  * @param {string} formId - Form Id to get the specific submissions
  * @param {object} [options={}] - Options to control the request
+ * @param {object} [options.sort] - Field and direction to sort submissions by. Specify 1 for ascending or -1 for descending order (e.g. {"field_name": 1} or {"field_name": -1})
  * @param {object} [options.query] - Query options to filter the submissions. See query operators {@link http://docs.mongodb.org/manual/reference/operator/query/.}
+ * @param {number} [options.start=0] - The index of the first submission to return. Used for pagination.
  * @param {number} [options.limit=30000] - Maximum number of submissions to fetch. Pass Infinity to disable the limit and download all submissions
  * @param {number} [options.pageSize=10000] - Limits the size of each page of submissions. Maximum value is 30000.
  * @state data - an array of submission objects
@@ -79,18 +81,17 @@ export function getSubmissions(formId, options) {
       options
     );
 
-    const { query, limit, pageSize } = resolvedOptions;
+    const { query, limit, pageSize, sort, start } = resolvedOptions;
     const path = `/assets/${resolvedFormId}/data/`;
     const qs = {};
     if (query) {
-      if (typeof query === 'string') {
-        qs.query = query;
-      } else {
-        qs.query = JSON.stringify(query);
-      }
+      qs.query = util.queryStringify(query);
+    }
+    if (sort) {
+      qs.sort = util.queryStringify(sort);
     }
     const requestOptions = {
-      query: { ...qs },
+      query: { ...qs, start },
       limit,
       pageSize,
     };

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -89,10 +89,10 @@ export function getSubmissions(formId, options) {
     const path = `/assets/${resolvedFormId}/data/`;
     const qs = {};
     if (query) {
-      qs.query = util.queryStringify(query);
+      qs.query = util.maybeStringify(query);
     }
     if (sort) {
-      qs.sort = util.queryStringify(sort);
+      qs.sort = util.maybeStringify(sort);
     }
     const requestOptions = {
       query: { ...qs, start },

--- a/packages/kobotoolbox/src/util.js
+++ b/packages/kobotoolbox/src/util.js
@@ -77,6 +77,7 @@ export async function requestWithPagination(state, path, options = {}) {
       requestOptions.query.limit = pageSize;
     }
 
+    console.log({ requestOptions });
     const response = await request(state, 'GET', path, requestOptions);
 
     if (response.body?.results) {
@@ -112,4 +113,8 @@ export async function requestWithPagination(state, path, options = {}) {
   } while (shouldFetchMoreContent);
 
   return results;
+}
+
+export function queryStringify(query) {
+  return typeof query === 'string' ? query : JSON.stringify(query);
 }

--- a/packages/kobotoolbox/src/util.js
+++ b/packages/kobotoolbox/src/util.js
@@ -77,7 +77,6 @@ export async function requestWithPagination(state, path, options = {}) {
       requestOptions.query.limit = pageSize;
     }
 
-    console.log({ requestOptions });
     const response = await request(state, 'GET', path, requestOptions);
 
     if (response.body?.results) {

--- a/packages/kobotoolbox/src/util.js
+++ b/packages/kobotoolbox/src/util.js
@@ -114,6 +114,6 @@ export async function requestWithPagination(state, path, options = {}) {
   return results;
 }
 
-export function queryStringify(query) {
+export function maybeStringify(query) {
   return typeof query === 'string' ? query : JSON.stringify(query);
 }

--- a/packages/kobotoolbox/test/adaptor.test.js
+++ b/packages/kobotoolbox/test/adaptor.test.js
@@ -85,40 +85,7 @@ describe('getSubmissions', () => {
     expect(requestCount).to.eql(6);
     expect(data[0]).to.eql({ uid: '3', name: 'User 3' });
   });
-  it('should sort items by uid in descending order', async () => {
-    testServer
-      .intercept({
-        path: /\/api\/v2\/assets\/aXecHjmbATuF6iGFmvBLBX\/data/,
-        method: 'GET',
-      })
-      .reply(
-        200,
-        req => {
-          const { query, origin, path } = req;
-          const results = responseWithPagination(
-            sampleData,
-            {
-              limit: query.limit,
-              start: query.start,
-              sort: query.sort,
-            },
-            {
-              url: `${origin}${path}`,
-            }
-          );
-          return results;
-        },
-        {
-          ...jsonHeaders,
-        }
-      );
 
-    const { data } = await getSubmissions('aXecHjmbATuF6iGFmvBLBX', {
-      sort: { uid: -1 },
-    })(state);
-
-    expect(data[0].uid).to.eql('4');
-  });
   it('should start from the specified index', async () => {
     testServer
       .intercept({

--- a/packages/kobotoolbox/test/adaptor.test.js
+++ b/packages/kobotoolbox/test/adaptor.test.js
@@ -38,6 +38,39 @@ describe('getSubmissions', () => {
     console.warn = (...args) => consoleOutput.push(...args);
   });
 
+  it.only('should sort items by uid in descending order', async () => {
+    testServer
+      .intercept({
+        path: /\/api\/v2\/assets\/aXecHjmbATuF6iGFmvBLBX\/data/,
+        method: 'GET',
+      })
+      .reply(
+        200,
+        req => {
+          const { query, origin, path } = req;
+          const results = responseWithPagination(
+            sampleData,
+            {
+              limit: query.limit,
+              start: query.start,
+            },
+            {
+              url: `${origin}${path}`,
+            }
+          );
+          return results;
+        },
+        {
+          ...jsonHeaders,
+        }
+      );
+
+    const { data } = await getSubmissions('aXecHjmbATuF6iGFmvBLBX', {
+      sort: { uid: -1 },
+    })(state);
+    console.log({ data });
+    expect(data[0].uid).to.eql('2');
+  });
   it('should not return more items than the default limit', async () => {
     let requestCount = 0;
     const items = Array.from({ length: 4e4 }, (_, i) => ({

--- a/packages/kobotoolbox/test/helper.js
+++ b/packages/kobotoolbox/test/helper.js
@@ -65,7 +65,6 @@ export function responseWithPagination(items, query, settings) {
     const sortParse = JSON.parse(sort);
     const key = Object.keys(sortParse)[0];
     const order = sortParse[key];
-    console.log({ key, order });
     response.results = sortBy(response.results, key, order);
   }
   return response;

--- a/packages/kobotoolbox/test/helper.js
+++ b/packages/kobotoolbox/test/helper.js
@@ -6,7 +6,7 @@ export function responseWithPagination(items, query, settings) {
     pageLimit = DEFAULT_PAGE_SIZE,
     defaultLimit = DEFAULT_LIMIT,
   } = settings;
-  const { start = 0, limit, sort } = query;
+  const { start = 0, limit } = query;
 
   const response = {
     results: [],
@@ -61,19 +61,6 @@ export function responseWithPagination(items, query, settings) {
             startIndex - effectiveLimit
           )}&limit=${effectiveLimit}`;
   } while (shouldFetchMoreContent);
-  if (sort) {
-    const sortParse = JSON.parse(sort);
-    const key = Object.keys(sortParse)[0];
-    const order = sortParse[key];
-    response.results = sortBy(response.results, key, order);
-  }
-  return response;
-}
 
-function sortBy(array, field, order = 1) {
-  return array.sort((a, b) => {
-    if (a[field] < b[field]) return -1 * order;
-    if (a[field] > b[field]) return 1 * order;
-    return 0;
-  });
+  return response;
 }

--- a/packages/kobotoolbox/test/helper.js
+++ b/packages/kobotoolbox/test/helper.js
@@ -6,7 +6,7 @@ export function responseWithPagination(items, query, settings) {
     pageLimit = DEFAULT_PAGE_SIZE,
     defaultLimit = DEFAULT_LIMIT,
   } = settings;
-  const { start = 0, limit } = query;
+  const { start = 0, limit, sort } = query;
 
   const response = {
     results: [],
@@ -61,5 +61,20 @@ export function responseWithPagination(items, query, settings) {
             startIndex - effectiveLimit
           )}&limit=${effectiveLimit}`;
   } while (shouldFetchMoreContent);
+  if (sort) {
+    const sortParse = JSON.parse(sort);
+    const key = Object.keys(sortParse)[0];
+    const order = sortParse[key];
+    console.log({ key, order });
+    response.results = sortBy(response.results, key, order);
+  }
   return response;
+}
+
+function sortBy(array, field, order = 1) {
+  return array.sort((a, b) => {
+    if (a[field] < b[field]) return -1 * order;
+    if (a[field] > b[field]) return 1 * order;
+    return 0;
+  });
 }

--- a/packages/kobotoolbox/test/integration.js
+++ b/packages/kobotoolbox/test/integration.js
@@ -71,6 +71,15 @@ describe('Integration tests', () => {
   });
 
   describe('getSubmissions', () => {
+    it('should return the first submission', async () => {
+      const firstSubmissionUid = '7054126b-2b4e-4c8e-a48d-8c0f47c706e9';
+      const { data } = await execute(
+        getSubmissions('aUe2eV8pHK9DUEUxT9rCcs', { start: 0, limit: 1 })
+      )(state);
+
+      expect(data[0]._uuid).to.eq(firstSubmissionUid);
+      expect(data.length).to.eq(1);
+    });
     it('should get a list of submissions', async () => {
       const { data } = await execute(
         getSubmissions('aUe2eV8pHK9DUEUxT9rCcs', { pageSize: 3 })


### PR DESCRIPTION
## Summary

Add `sort` and `start` options in `getSubmission` function

Fixes #1216

## Details

- Update `getSubmission` options to include `sort` and `start` with examples
- Add `queryStringify` util function for stringify `query` and `sort` option
- Add `sortBy` function in `helper.js` to help with sorting results when `sort` param is passed
- Add unit test for `sort` and `start` option

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA: If this is a new adaptor, added the adaptor on marketing website ?
- NA: If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [x] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
