### PR TITLE
common: update `map()` to work like Array.map

### DIFF
--- a/.changeset/fifty-monkeys-smash.md
+++ b/.changeset/fifty-monkeys-smash.md
@@ -1,0 +1,29 @@
+---
+'@openfn/language-common': major
+---
+
+- Update `map()` to work like Array.map in js
+
+### Migration Guide
+
+- `map()` will return an array mapped into `state.data` if you used to do this:
+
+```
+
+map("$.[*]",
+ create("SObject",
+   field("FirstName", sourceValue("$.firstName"))
+ )
+)
+
+```
+
+You can do this instead:
+
+```
+
+map('$.[*]', data => {
+  return { firstName: data.firstName };
+});
+
+```

--- a/.changeset/fifty-monkeys-smash.md
+++ b/.changeset/fifty-monkeys-smash.md
@@ -2,28 +2,26 @@
 '@openfn/language-common': major
 ---
 
-- Update `map()` to work like Array.map in js
+- Re-write `map()` to work more like JavaScript's `Array.map()`.
 
 ### Migration Guide
 
-- `map()` will return an array mapped into `state.data` if you used to do this:
+The behaviour of the `map()` function has changed subtly but significantly.
 
+Workflows using common <3.0 should replace `map()` with `each()`, which has the
+same functionality.
+
+If you used to do this:
+
+```js
+map('$.[*]', create('SObject', field('FirstName', sourceValue('$.firstName'))));
 ```
 
-map("$.[*]",
- create("SObject",
-   field("FirstName", sourceValue("$.firstName"))
- )
-)
+You must do this instead:
 
-```
-
-You can do this instead:
-
-```
-
-map('$.[*]', data => {
-  return { firstName: data.firstName };
-});
-
+```js
+each(
+  '$.[*]',
+  create('SObject', field('FirstName', sourceValue('$.firstName')))
+);
 ```

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1713,7 +1713,13 @@
           },
           {
             "title": "example",
-            "description": "map('$.data[*]', (data, index, state) => {\n  return {\n    id: index + 1,\n    name: data.name,\n    createdAt: state.cursor,\n  };\n});"
+            "description": "map('$.data[*]', (data, index, state) => {\n  return {\n    id: index + 1,\n    name: data.name,\n    createdAt: state.cursor,\n  };\n});",
+            "caption": "Transform an array of items in state"
+          },
+          {
+            "title": "example",
+            "description": "map('$.data[*]', async (data, index, state) => {\n  const userInfo = await fetchUserInfo(data.userId);\n  return {\n    id: index + 1,\n    name: data.name,\n    extra: userInfo,\n  };\n});",
+            "caption": "Map items asynchronously (e.g. fetch extra info)"
           },
           {
             "title": "param",

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1697,11 +1697,7 @@
     },
     {
       "name": "map",
-      "params": [
-        "path",
-        "operation",
-        "state"
-      ],
+      "params": {},
       "docs": {
         "description": "Scopes an array of data based on a JSONPath.\nUseful when the source data has `n` items you would like to map to\nan operation.\nThe operation will receive a slice of the data based of each item\nof the JSONPath provided.",
         "tags": [
@@ -1735,16 +1731,7 @@
               "type": "NameExpression",
               "name": "function"
             },
-            "name": "operation"
-          },
-          {
-            "title": "param",
-            "description": "Runtime state.",
-            "type": {
-              "type": "NameExpression",
-              "name": "State"
-            },
-            "name": "state"
+            "name": "callback"
           },
           {
             "title": "returns",
@@ -1756,7 +1743,7 @@
           }
         ]
       },
-      "valid": true
+      "valid": false
     }
   ],
   "exports": [],

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -1647,7 +1647,7 @@
       "name": "map",
       "params": {},
       "docs": {
-        "description": "Maps over a collection of items to produce a new `state.data` array.\n\nThis utility is useful when the source data contains multiple items and you want\nto perform an operation for each one, generating an array of transformed results.\n\nThe provided `callback` will be invoked once per item in the array, and each result\nwill be collected into `state.data` as an array. The `path` argument determines where the array\nis sourced from, either via a JSONPath string or directly as a static array.",
+        "description": "Iterates over a collection of items and returns a new array of mapped values,\nlike Javascript's `Array.map()` function.\n\nEach item in the source array will be passed into the callback function. The returned value\nwill be added to the new array. The callback is passed the original item, the current index\nin the source array (ie, the nth item number), and the state object.\n\nWrites a new array to `state.data` with transformed values.c array.",
         "tags": [
           {
             "title": "public",
@@ -1661,17 +1661,17 @@
           },
           {
             "title": "example",
-            "description": "map('$.data[*]', (data, index, state) => {\n  return {\n    id: index + 1,\n    name: data.name,\n    createdAt: state.cursor,\n  };\n});",
+            "description": "map($.items', (data, index, state) => {\n  return {\n    id: index + 1,\n    name: data.name,\n    createdAt: state.cursor,\n  };\n});",
             "caption": "Transform an array of items in state"
           },
           {
             "title": "example",
-            "description": "map('$.data[*]', async (data, index, state) => {\n  const userInfo = await fetchUserInfo(data.userId);\n  return {\n    id: index + 1,\n    name: data.name,\n    extra: userInfo,\n  };\n});",
+            "description": "map($.items, async (data, index, state) => {\n  const userInfo = await fetchUserInfo(data.userId);\n  return {\n    id: index + 1,\n    name: data.name,\n    extra: userInfo,\n  };\n});",
             "caption": "Map items asynchronously (e.g. fetch extra info)"
           },
           {
             "title": "param",
-            "description": "A JSONPath string to or an array of items to map directly.",
+            "description": "An array of items or a a JSONPath string which points to an array of items.",
             "type": {
               "type": "UnionType",
               "elements": [
@@ -1689,7 +1689,7 @@
           },
           {
             "title": "param",
-            "description": "The function invoked with `(data, index, state)` for each item in the array.",
+            "description": "The mapping function, invoked with `(data, index, state)` for each item in the array.",
             "type": {
               "type": "NameExpression",
               "name": "function"

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -469,59 +469,6 @@
       "valid": true
     },
     {
-      "name": "map",
-      "params": [
-        "path",
-        "callback"
-      ],
-      "docs": {
-        "description": "Scopes an array of data based on a JSONPath.\nUseful when the source data has `n` items you would like to map to\nan operation.\nThe operation will receive a single item during each iteration based off of the JSONPath provided.\nThe output will be an array of results mapped into `state.data`",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "example",
-            "description": "map('$.data[*]', (data, index, state) => {\n  return {\n    id: index + 1,\n    name: data.name,\n    createdAt: state.cursor,\n  };\n});"
-          },
-          {
-            "title": "param",
-            "description": "JSONPath referencing a point in `state.data`.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "path"
-          },
-          {
-            "title": "param",
-            "description": "The operation needed to be repeated.",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "callback"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "State"
-            }
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
       "name": "asData",
       "params": [
         "data",
@@ -1747,6 +1694,65 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "map",
+      "params": {},
+      "docs": {
+        "description": "Maps over a collection of items to produce a new `state.data` array.\n\nThis utility is useful when the source data contains multiple items and you want\nto perform an operation for each one, generating an array of transformed results.\n\nThe provided `callback` will be invoked once per item in the array, and each result\nwill be collected into `state.data` as an array. The `path` argument determines where the array\nis sourced from, either via a JSONPath string or directly as a static array.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "example",
+            "description": "map('$.data[*]', (data, index, state) => {\n  return {\n    id: index + 1,\n    name: data.name,\n    createdAt: state.cursor,\n  };\n});"
+          },
+          {
+            "title": "param",
+            "description": "A JSONPath string to or an array of items to map directly.",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "string"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Array"
+                }
+              ]
+            },
+            "name": "path"
+          },
+          {
+            "title": "param",
+            "description": "The function invoked with `(data, index, state)` for each item in the array.",
+            "type": {
+              "type": "NameExpression",
+              "name": "function"
+            },
+            "name": "callback"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "State"
+            }
+          }
+        ]
+      },
+      "valid": false
     }
   ],
   "exports": [],

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -469,6 +469,59 @@
       "valid": true
     },
     {
+      "name": "map",
+      "params": [
+        "path",
+        "callback"
+      ],
+      "docs": {
+        "description": "Scopes an array of data based on a JSONPath.\nUseful when the source data has `n` items you would like to map to\nan operation.\nThe operation will receive a single item during each iteration based off of the JSONPath provided.\nThe output will be an array of results mapped into `state.data`",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "example",
+            "description": "map('$.data[*]', (data, index, state) => {\n  return {\n    id: index + 1,\n    name: data.name,\n    createdAt: state.cursor,\n  };\n});"
+          },
+          {
+            "title": "param",
+            "description": "JSONPath referencing a point in `state.data`.",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "path"
+          },
+          {
+            "title": "param",
+            "description": "The operation needed to be repeated.",
+            "type": {
+              "type": "NameExpression",
+              "name": "function"
+            },
+            "name": "callback"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "State"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "asData",
       "params": [
         "data",
@@ -1694,56 +1747,6 @@
         ]
       },
       "valid": true
-    },
-    {
-      "name": "map",
-      "params": {},
-      "docs": {
-        "description": "Scopes an array of data based on a JSONPath.\nUseful when the source data has `n` items you would like to map to\nan operation.\nThe operation will receive a slice of the data based of each item\nof the JSONPath provided.",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "example",
-            "description": "map(\"$.[*]\",\n  create(\"SObject\",\n    field(\"FirstName\", sourceValue(\"$.firstName\"))\n  )\n)"
-          },
-          {
-            "title": "param",
-            "description": "JSONPath referencing a point in `state.data`.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "path"
-          },
-          {
-            "title": "param",
-            "description": "The operation needed to be repeated.",
-            "type": {
-              "type": "NameExpression",
-              "name": "function"
-            },
-            "name": "callback"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "State"
-            }
-          }
-        ]
-      },
-      "valid": false
     }
   ],
   "exports": [],

--- a/packages/common/ast.json
+++ b/packages/common/ast.json
@@ -705,58 +705,6 @@
       "valid": true
     },
     {
-      "name": "expandReferences",
-      "params": [
-        "value",
-        "skipFilter"
-      ],
-      "docs": {
-        "description": "Recursively resolves objects that have resolvable values (functions).",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "data",
-            "type": {
-              "type": "NameExpression",
-              "name": "object"
-            },
-            "name": "value"
-          },
-          {
-            "title": "param",
-            "description": "a function which returns true if a value should be skipped",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "Function"
-              }
-            },
-            "name": "skipFilter"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "Operation"
-            }
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
       "name": "field",
       "params": [
         "key",

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -197,11 +197,15 @@ export function lastReferenceValue(path) {
 }
 
 /**
- * Scopes an array of data based on a JSONPath.
- * Useful when the source data has `n` items you would like to map to
- * an operation.
- * The operation will receive a single item during each iteration based off of the JSONPath provided.
- * The output will be an array of results mapped into `state.data`
+ * Maps over a collection of items to produce a new `state.data` array.
+ *
+ * This utility is useful when the source data contains multiple items and you want
+ * to perform an operation for each one, generating an array of transformed results.
+ *
+ * The provided `callback` will be invoked once per item in the array, and each result
+ * will be collected into `state.data` as an array. The `path` argument determines where the array
+ * is sourced from, either via a JSONPath string or directly as a static array.
+ *
  * @public
  * @function
  * @example
@@ -212,8 +216,8 @@ export function lastReferenceValue(path) {
  *     createdAt: state.cursor,
  *   };
  * });
- * @param {string} path - JSONPath referencing a point in `state.data`.
- * @param {function} callback - The operation needed to be repeated.
+ * @param {string|Array} path - A JSONPath string to or an array of items to map directly.
+ * @param {function} callback - The function invoked with `(data, index, state)` for each item in the array.
  * @returns {State}
  */
 export const map = function (path, callback) {

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -208,7 +208,7 @@ export function lastReferenceValue(path) {
  *
  * @public
  * @function
- * @example
+ * @example <caption> Transform an array of items in state</caption>
  * map('$.data[*]', (data, index, state) => {
  *   return {
  *     id: index + 1,
@@ -216,33 +216,32 @@ export function lastReferenceValue(path) {
  *     createdAt: state.cursor,
  *   };
  * });
+ * @example <caption>Map items asynchronously (e.g. fetch extra info)</caption>
+ * map('$.data[*]', async (data, index, state) => {
+ *   const userInfo = await fetchUserInfo(data.userId);
+ *   return {
+ *     id: index + 1,
+ *     name: data.name,
+ *     extra: userInfo,
+ *   };
+ * });
  * @param {string|Array} path - A JSONPath string to or an array of items to map directly.
  * @param {function} callback - The function invoked with `(data, index, state)` for each item in the array.
  * @returns {State}
  */
 export const map = function (path, callback) {
-  const results = [];
-  return state => {
-    switch (typeof path) {
-      case 'string':
-        source(path)(state).map(function (data, index) {
-          const value = callback(data, index, state);
+  return async state => {
+    const results = [];
+    const values = typeof path === 'string' ? source(path)(state) : path;
 
-          results.push(value);
-
-          return results;
-        });
-        return { ...state, data: results };
-
-      case 'object':
-        path.map(function (data, index) {
-          const value = callback(data, index, state);
-
-          results.push(value);
-          return results;
-        });
-        return { ...state, data: results };
+    let index = 0;
+    for (const item of values) {
+      const value = await callback(item, index, state);
+      results.push(value);
+      index++;
     }
+
+    return { ...state, data: results };
   };
 };
 

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -196,19 +196,18 @@ export function lastReferenceValue(path) {
 }
 
 /**
- * Maps over a collection of items to produce a new `state.data` array.
+ * Iterates over a collection of items and returns a new array of mapped values,
+ * like Javascript's `Array.map()` function.
  *
- * This utility is useful when the source data contains multiple items and you want
- * to perform an operation for each one, generating an array of transformed results.
+ * Each item in the source array will be passed into the callback function. The returned value
+ * will be added to the new array. The callback is passed the original item, the current index
+ * in the source array (ie, the nth item number), and the state object.
  *
- * The provided `callback` will be invoked once per item in the array, and each result
- * will be collected into `state.data` as an array. The `path` argument determines where the array
- * is sourced from, either via a JSONPath string or directly as a static array.
- *
+ * Writes a new array to `state.data` with transformed values.c array.
  * @public
  * @function
  * @example <caption> Transform an array of items in state</caption>
- * map('$.data[*]', (data, index, state) => {
+ * map($.items', (data, index, state) => {
  *   return {
  *     id: index + 1,
  *     name: data.name,
@@ -216,7 +215,7 @@ export function lastReferenceValue(path) {
  *   };
  * });
  * @example <caption>Map items asynchronously (e.g. fetch extra info)</caption>
- * map('$.data[*]', async (data, index, state) => {
+ * map($.items, async (data, index, state) => {
  *   const userInfo = await fetchUserInfo(data.userId);
  *   return {
  *     id: index + 1,
@@ -224,8 +223,8 @@ export function lastReferenceValue(path) {
  *     extra: userInfo,
  *   };
  * });
- * @param {string|Array} path - A JSONPath string to or an array of items to map directly.
- * @param {function} callback - The function invoked with `(data, index, state)` for each item in the array.
+ * @param {string|Array} path - An array of items or a a JSONPath string which points to an array of items.
+ * @param {function} callback - The mapping function, invoked with `(data, index, state)` for each item in the array.
  * @returns {State}
  */
 export const map = function (path, callback) {
@@ -237,7 +236,6 @@ export const map = function (path, callback) {
     for (const item of values) {
       const value = await callback(item, index++, state);
       results.push(value);
-  
     }
 
     return { ...state, data: results };

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -236,9 +236,9 @@ export const map = function (path, callback) {
 
     let index = 0;
     for (const item of values) {
-      const value = await callback(item, index, state);
+      const value = await callback(item, index++, state);
       results.push(value);
-      index++;
+  
     }
 
     return { ...state, data: results };

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -101,11 +101,12 @@ describe('source', () => {
 });
 
 describe('map', () => {
-  it('can map a single item from an array', () => {
+  it('can map a single item from an array', async () => {
     let state = { data: testData, references: [] };
-    let results = map('$.data.store.book[*]', function (data) {
+    let results = await map('$.data.store.book[*]', function (data) {
       return { label: data.title };
     })(state);
+
     expect(results.data).to.eql([
       { label: 'Sayings of the Century' },
       { label: 'Sword of Honour' },
@@ -113,9 +114,9 @@ describe('map', () => {
       { label: 'The Lord of the Rings' },
     ]);
   });
-  it('can map items from an array and add values', () => {
+  it('can map items from an array and add values', async () => {
     let state = { data: testData, references: [] };
-    let results = map(state.data.store.book, function (data, index) {
+    let results = await map(state.data.store.book, function (data, index) {
       return {
         id: index + 1,
         title: data.title,
@@ -141,19 +142,42 @@ describe('map', () => {
       },
     ]);
   });
-  it('can use state to map items', () => {
+  it('can use state to map items', async () => {
     let state = { data: testData, references: [] };
     state.baseId = 'book-';
-    let results = map('$.data.store.book[*]', function (data, index, state) {
-      return {
-        id: state.baseId + index,
-      };
-    })(state);
+    let results = await map(
+      '$.data.store.book[*]',
+      function (data, index, state) {
+        return {
+          id: state.baseId + index,
+        };
+      }
+    )(state);
     expect(results.data).to.eql([
       { id: 'book-0' },
       { id: 'book-1' },
       { id: 'book-2' },
       { id: 'book-3' },
+    ]);
+  });
+  it('can use async callback to map items with state', async () => {
+    let state = { data: testData, references: [] };
+    state.baseId = 'book-';
+    let results = await map(
+      '$.data.store.book[*]',
+      async function (data, index, state) {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        return {
+          id: state.baseId + index,
+          label: data.title,
+        };
+      }
+    )(state);
+    expect(results.data).to.eql([
+      { id: 'book-0', label: 'Sayings of the Century' },
+      { id: 'book-1', label: 'Sword of Honour' },
+      { id: 'book-2', label: 'Moby Dick' },
+      { id: 'book-3', label: 'The Lord of the Rings' },
     ]);
   });
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -101,23 +101,45 @@ describe('source', () => {
 });
 
 describe('map', () => {
-  xit('[DEPRECATED] can produce a one to one from an array', () => {
-    let items = [];
-
+  it('can map a single item from an array', () => {
     let state = { data: testData, references: [] };
-    let results = map(
-      '$.data.store.book[*]',
-      function (state) {
-        return { references: [1, ...state.references], ...state };
-      },
-      state
-    );
+    let results = map('$.data.store.book[*]', function (data) {
+      return { title: data.title };
+    })(state);
 
-    expect(results.references).to.eql([
+    expect(results.data).to.eql([
       { title: 'Sayings of the Century' },
       { title: 'Sword of Honour' },
       { title: 'Moby Dick' },
       { title: 'The Lord of the Rings' },
+    ]);
+  });
+  it('can map items from an array and add values', () => {
+    let state = { data: testData, references: [] };
+    let results = map('$.data.store.book[*]', function (data, index) {
+      return {
+        id: index + 1,
+        title: data.title,
+        price: data.price,
+        expensive: data.price > 10,
+      };
+    })(state);
+
+    expect(results.data).to.eql([
+      {
+        id: 1,
+        title: 'Sayings of the Century',
+        price: 8.95,
+        expensive: false,
+      },
+      { id: 2, title: 'Sword of Honour', price: 12.99, expensive: true },
+      { id: 3, title: 'Moby Dick', price: 8.99, expensive: false },
+      {
+        id: 4,
+        title: 'The Lord of the Rings',
+        price: 22.99,
+        expensive: true,
+      },
     ]);
   });
 });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -180,6 +180,14 @@ describe('map', () => {
       { id: 'book-3', label: 'The Lord of the Rings' },
     ]);
   });
+  it('ensures the index value is correct', async () => {
+    let state = { data: testData, references: [] };
+    let results = await map('$.data.store.book[*]', function (data, index) {
+      return index;
+    })(state);
+
+    expect(results.data).to.eql([0, 1, 2, 3]);
+  });
 });
 
 describe('combine', () => {

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -31,6 +31,7 @@ import {
   assert as assertCommon,
   log,
   debug,
+  map
 } from '../src/Adaptor';
 import { startOfToday } from 'date-fns';
 

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -104,19 +104,18 @@ describe('map', () => {
   it('can map a single item from an array', () => {
     let state = { data: testData, references: [] };
     let results = map('$.data.store.book[*]', function (data) {
-      return { title: data.title };
+      return { label: data.title };
     })(state);
-
     expect(results.data).to.eql([
-      { title: 'Sayings of the Century' },
-      { title: 'Sword of Honour' },
-      { title: 'Moby Dick' },
-      { title: 'The Lord of the Rings' },
+      { label: 'Sayings of the Century' },
+      { label: 'Sword of Honour' },
+      { label: 'Moby Dick' },
+      { label: 'The Lord of the Rings' },
     ]);
   });
   it('can map items from an array and add values', () => {
     let state = { data: testData, references: [] };
-    let results = map('$.data.store.book[*]', function (data, index) {
+    let results = map(state.data.store.book, function (data, index) {
       return {
         id: index + 1,
         title: data.title,
@@ -140,6 +139,21 @@ describe('map', () => {
         price: 22.99,
         expensive: true,
       },
+    ]);
+  });
+  it('can use state to map items', () => {
+    let state = { data: testData, references: [] };
+    state.baseId = 'book-';
+    let results = map('$.data.store.book[*]', function (data, index, state) {
+      return {
+        id: state.baseId + index,
+      };
+    })(state);
+    expect(results.data).to.eql([
+      { id: 'book-0' },
+      { id: 'book-1' },
+      { id: 'book-2' },
+      { id: 'book-3' },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Update `map()` to work like Array.map in js
Update documentation to reflect map changes

Fixes #499 

## Details

Change the current `map()` implementation which is similar to `each()` and make it resemble the workings of `Array.map` in js.
- The mapped result is returned as an array and mapped into `state.data`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
