### PR TITLE
fix docs build by removing extra ' * '

### DIFF
--- a/packages/fhir-4/src/datatypes.ts
+++ b/packages/fhir-4/src/datatypes.ts
@@ -198,7 +198,7 @@ export const value = (value, system, ...extra) =>
  * @param {object} extra - Extra properties to write to the coding
  * @example <caption><Create a codeableConcept</caption>
  * const myConcept = util.concept(['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])
- * * @example <caption><Create a codeableConcept with text</caption>
+ * @example <caption><Create a codeableConcept with text</caption>
  * const myConcept = util.concept('smart care id', ['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])
  */
 type ConceptCoding =

--- a/packages/fhir-4/types/builders.d.ts
+++ b/packages/fhir-4/types/builders.d.ts
@@ -5250,7 +5250,7 @@ declare const value: (value: any, system: any, ...extra: any[]) => any;
  * @param {object} extra - Extra properties to write to the coding
  * @example <caption><Create a codeableConcept</caption>
  * const myConcept = util.concept(['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])
- * * @example <caption><Create a codeableConcept with text</caption>
+ * @example <caption><Create a codeableConcept with text</caption>
  * const myConcept = util.concept('smart care id', ['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])
  */
 declare type ConceptCoding = Coding | [string, string, Omit<Coding, 'code' | 'system'>?];

--- a/packages/fhir-fr/src/utils.js
+++ b/packages/fhir-fr/src/utils.js
@@ -145,7 +145,7 @@ export const coding = (code, system) => ({ code, system: mapSystems(system) });
  * @function
  * @example <caption><Create a codeableConcept</caption>
  * const myConcept = util.concept(['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])
- * * @example <caption><Create a codeableConcept with text</caption>
+ * @example <caption><Create a codeableConcept with text</caption>
  * const myConcept = util.concept('smart care id', ['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])
  */
 export const concept = (text, ...codings) => {

--- a/packages/fhir-ndr-et/src/utils.js
+++ b/packages/fhir-ndr-et/src/utils.js
@@ -142,7 +142,7 @@ export const coding = (code, system) => ({ code, system: mapSystems(system) });
  * @function
  * @example <caption><Create a codeableConcept</caption>
  * const myConcept = util.concept(['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])  
- * * @example <caption><Create a codeableConcept with text</caption>
+ * @example <caption><Create a codeableConcept with text</caption>
  * const myConcept = util.concept('smart care id', ['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])  
  */
 export const concept = (text, ...codings) => {

--- a/tools/generate-fhir/template/src/datatypes.ts
+++ b/tools/generate-fhir/template/src/datatypes.ts
@@ -188,7 +188,7 @@ export const value = (value, system, ...extra) =>
  * @function
  * @example <caption><Create a codeableConcept</caption>
  * const myConcept = util.concept(['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])
- * * @example <caption><Create a codeableConcept with text</caption>
+ * @example <caption><Create a codeableConcept with text</caption>
  * const myConcept = util.concept('smart care id', ['abc', 'http://moh.gov.et/fhir/hiv/identifier/SmartCareID'])
  */
 export const concept = (text, ...codings) => {


### PR DESCRIPTION
## Summary

When upgrading Docusaurus to v3, we have much stricter markdown parsing. It caught these errors in the auto-generated documentation.

<img width="963" alt="image" src="https://github.com/user-attachments/assets/1ff34caa-b09f-4019-b2ec-84a596f8c933" />

With the double asterisk, we get the code above. On the old (less strict) MDX parser, it would render as this:

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/6ed8a834-6d27-470b-a352-76a2b55f8b0f" />

But now it fails with:

<img width="1692" alt="image" src="https://github.com/user-attachments/assets/dd2f4f63-4f7f-4e9e-b7ea-51710d906b59" />


## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
