### PR TITLE
OpenMRS: Fix upsert logic

### DIFF
--- a/.changeset/chilled-days-walk.md
+++ b/.changeset/chilled-days-walk.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-openmrs': patch
+---
+
+Fix an issue where upsert will wrongly trigger creation of an existing item

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -345,16 +345,23 @@ export function upsert(path, data, params = {}) {
         : resolvedPath.split('/').slice(0, -1).join('/'); // remove the ID
       return create(path, resolvedData)(state);
     } else {
-      // try to find the target uuid in the result
-      let uuid = res.body.uuid;
-      if (res.body.results) {
-        uuid = res.body.results[0].uuid;
+      let finalPath = resolvedPath;
+
+      // If there are no query params and there are multiple resources in the path
+      // Then the path probably includes a UUID and we can just re-use it
+      const parts = path.split('/').length;
+      if (parts % 2 > 0 && Object.keys(resolvedParams).length > 0) {
+        // Otherwise, if there doesn't seem to be a UUID in the URL,
+        // find one from th original GET
+        let uuid = res.body.uuid;
+        if (res.body.results) {
+          uuid = res.body.results[0].uuid;
+        }
+        finalPath = `${resolvedPath}/${uuid}`;
       }
-      const path = uuid
-        ? `${resolvedPath}/${uuid}` // append the ID
-        : resolvedPath;
-      console.log(`${path} found: updating existing resource`);
-      return update(path, resolvedData)(state);
+
+      console.log(`${finalPath} found: updating existing resource`);
+      return update(finalPath, resolvedData)(state);
     }
   };
 }

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -345,8 +345,13 @@ export function upsert(path, data, params = {}) {
         : resolvedPath.split('/').slice(0, -1).join('/'); // remove the ID
       return create(path, resolvedData)(state);
     } else {
-      const path = resolvedParams.q
-        ? `${resolvedPath}/${res.body.results[0].uuid}` // append the ID
+      // try to find the target uuid in the result
+      let uuid = res.body.uuid;
+      if (res.body.results) {
+        uuid = res.body.results[0].uuid;
+      }
+      const path = uuid
+        ? `${resolvedPath}/${uuid}` // append the ID
         : resolvedPath;
       console.log(`${path} found: updating existing resource`);
       return update(path, resolvedData)(state);

--- a/packages/openmrs/src/Utils.js
+++ b/packages/openmrs/src/Utils.js
@@ -98,7 +98,6 @@ export async function requestWithPagination(state, path, options = {}) {
 
     // Fetch a page of data
     const response = await request(state, 'GET', path, requestOptions);
-
     // If a search, the data will be in the form { results }
     // otherwise just return the data verbatim (in an array)
     if (response.body.results) {

--- a/packages/openmrs/test/adaptor.test.js
+++ b/packages/openmrs/test/adaptor.test.js
@@ -366,20 +366,41 @@ describe('upsert', () => {
       });
   };
 
-  it('should update an existing patient with a uuid', async () => {
-    mock({ path: `patient/${existingUuid}`, data: testData.patient });
+  it('should update an existing patient with a uuid in the path', async () => {
+    mock({ path: `patient/${testData.patient.uuid}`, data: testData.patient });
     mock({
       method: 'POST',
-      path: `patient/${existingUuid}`,
+      path: `patient/${testData.patient.uuid}`,
       data: ({ body }) => body,
     });
 
     const result = await upsert(
-      `patient/${existingUuid}`,
+      `patient/${testData.patient.uuid}`,
       state => state.patient
     )(state);
 
     expect(result.data.person.display).to.eql(testData.patient.person.display);
+  });
+
+  it('should update a subresource with a uuid in the path', async () => {
+    mock({
+      path: `patient/123/identifier/xyz`,
+      data: testData.patient,
+    });
+    mock({
+      method: 'POST',
+      path: `patient/123/identifier/xyz`,
+      data: () => ({
+        identifier: 'xyz',
+      }),
+    });
+
+    const result = await upsert(
+      `patient/123/identifier/xyz`,
+      state => state.patient
+    )(state);
+
+    expect(result.data.identifier).to.eql('xyz');
   });
 
   it('update an existing patient with a query parameter', async () => {
@@ -401,8 +422,7 @@ describe('upsert', () => {
     expect(result.data.person.display).to.eql(testData.patient.person.display);
   });
 
-  // TODO this fails on this branch - see https://github.com/OpenFn/adaptors/issues/1233
-  it.skip('update an existing encounter with another parameter', async () => {
+  it('update an existing encounter with another parameter', async () => {
     mock({
       path: `patient`,
       data: { results: testData.patientResults },
@@ -452,7 +472,7 @@ describe('upsert', () => {
   });
 
   // TODO this is expected to fail - see https://github.com/OpenFn/adaptors/issues/1236
-  it.only('create a new patient with another parameter', async () => {
+  it.skip('create a new patient with another parameter', async () => {
     mock({ code: 404, path: `patient`, query: { id: testData.patient.uuid } });
     mock({
       method: 'POST',


### PR DESCRIPTION
## Summary

This PR tweaks the upsert logic to ensure it properly updates a resource.

Fixes #1233 

See https://community.openfn.org/t/openmrs-adapter-5-0-2-not-updating-resources/980

## QA

Using the openmrs sandbox:
```
"instanceUrl": "https://o3.openmrs.org/openmrs",
"username": "admin",
"password": "Admin123"
```

I have this code:
```
upsert(
  'encounter',
  {
    display: 'Vitals 02/07/2024 1',
  },
  {
    patient: 'bddfc2a9-150b-4a54-9494-1bdb18b9f91a',
    encounterType: '67a71486-1a54-468f-ac3e-7091a9a79584',
    limit: 1,
  }
);
```

On this branch, I get this output:
```
Preparing composed upsert on encounter
GET /ws/rest/v1/encounter?patient=bddfc2a9-150b-4a54-9494-1bdb18b9f91a&encounterType=67a71486-1a54-468f-ac3e-7091a9a79584&limit=1 - 200 in 505ms
encounter/94c4a0a7-22f6-418e-b6a3-8bf57a046784 found: updating existing resource
Preparing to update encounter/94c4a0a7-22f6-418e-b6a3-8bf57a046784
POST /ws/rest/v1/encounter/94c4a0a7-22f6-418e-b6a3-8bf57a046784 - 200 in 690ms
Successfully updated encounter/94c4a0a7-22f6-418e-b6a3-8bf57a046784
```

On the prod release, I get:
```
Preparing composed upsert on encounter
GET /ws/rest/v1/encounter?patient=bddfc2a9-150b-4a54-9494-1bdb18b9f91a&encounterType=67a71486-1a54-468f-ac3e-7091a9a79584&limit=1 - 200 in 458ms
encounter found: updating existing resource
Preparing to update encounter
[R/T] ✘ job-1 aborted with error (911ms)

[R/T] ✘ Error reported by "upsert()" operation line 24:
[R/T] ✘ Error: POST to https://o3.openmrs.org/openmrs/ws/rest/v1/encounter returned 400: Bad Request

POST to https://o3.openmrs.org/openmrs/ws/rest/v1/encounter returned 400: Bad Request
```

I think this is good: this branch has posted to the correct URL and got a 200. The prod adaptor has tried to create a new encounter and returned an error (because I haven't passed a complete encounter)

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
