### PR TITLE
Ensure upsert-create works if there's no UUID in the path

### DIFF
--- a/.changeset/wicked-keys-warn.md
+++ b/.changeset/wicked-keys-warn.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-openmrs': patch
+---
+
+Fix an issue where upsert will create to the wrong URL if there is no UUID in
+the path

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -340,10 +340,17 @@ export function upsert(path, data, params = {}) {
     } else if (!found || count === 0) {
       console.log(`${resolvedPath} not found: creating new resource`);
 
-      const path = resolvedParams.q
+      // How many resources are in the url?
+      // If an even number, the UUID is in the URL
+      // resource/uuid
+      // resource/uuid/subresource
+      // resource/uuid/subresource/uuid
+      const parts = path.split('/').length;
+      const dropUuid = parts % 2 > 0 && Object.keys(resolvedParams).length;
+      const finalPath = dropUuid
         ? resolvedPath
         : resolvedPath.split('/').slice(0, -1).join('/'); // remove the ID
-      return create(path, resolvedData)(state);
+      return create(finalPath, resolvedData)(state);
     } else {
       let finalPath = resolvedPath;
 

--- a/packages/openmrs/test/adaptor.test.js
+++ b/packages/openmrs/test/adaptor.test.js
@@ -441,7 +441,7 @@ describe('upsert', () => {
     expect(result.data.person.display).to.eql(testData.patient.person.display);
   });
 
-  it('should create a new patient', async () => {
+  it('should create a new patient with a UUID in the URL', async () => {
     mock({ code: 404, path: `patient/${nonExistingUuid}` });
     mock({
       method: 'POST',
@@ -471,8 +471,7 @@ describe('upsert', () => {
     expect(result.data.person.display).to.eql(testData.patient.person.display);
   });
 
-  // TODO this is expected to fail - see https://github.com/OpenFn/adaptors/issues/1236
-  it.skip('create a new patient with another parameter', async () => {
+  it('create a new patient with another parameter', async () => {
     mock({ code: 404, path: `patient`, query: { id: testData.patient.uuid } });
     mock({
       method: 'POST',


### PR DESCRIPTION
## Summary

If doing upsert with no id in the URL, don't break the URL

Fixes #1236


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
