### PR TITLE
Fix import in `update-version-histories.js`

### DIFF
--- a/packages/googledrive/CHANGELOG.md
+++ b/packages/googledrive/CHANGELOG.md
@@ -8,6 +8,6 @@
 - Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0
 
-## 1.0.0
+## 1.0.0 - 17 April 2025
 
 Initial release.

--- a/packages/kobotoolbox/ast.json
+++ b/packages/kobotoolbox/ast.json
@@ -141,7 +141,7 @@
           },
           {
             "title": "param",
-            "description": "Maximum number of submissions to fetch. Pass Infinity to disable the limit and download all submissions",
+            "description": "Maximum number of submissions to fetch. Pass `Infinity` to disable the limit and download all submissions",
             "type": {
               "type": "OptionalType",
               "expression": {

--- a/packages/kobotoolbox/src/Adaptor.js
+++ b/packages/kobotoolbox/src/Adaptor.js
@@ -72,7 +72,7 @@ export function getForms() {
  * @param {object} [options.sort] - Field and direction to sort submissions by.
  * @param {object} [options.query] - Query options to filter the submissions. See query operators {@link http://docs.mongodb.org/manual/reference/operator/query/.}
  * @param {number} [options.start=0] - The index of the first submission to return.
- * @param {number} [options.limit=30000] - Maximum number of submissions to fetch. Pass Infinity to disable the limit and download all submissions
+ * @param {number} [options.limit=30000] - Maximum number of submissions to fetch. Pass `Infinity` to disable the limit and download all submissions
  * @param {number} [options.pageSize=10000] - Limits the size of each page of submissions. Maximum value is 30000.
  * @state data - an array of submission objects
  * @returns {Operation}

--- a/packages/senaite/CHANGELOG.md
+++ b/packages/senaite/CHANGELOG.md
@@ -17,6 +17,6 @@
 - Updated dependencies \[b089c56]
   - @openfn/language-common@2.3.3
 
-## 1.0.0
+## 1.0.0 - 14 April 2025
 
 Initial release.

--- a/tools/changelog/src/update-version-histories.js
+++ b/tools/changelog/src/update-version-histories.js
@@ -1,7 +1,5 @@
-
-import { updateChangelog } from './updateChangelog';
-import getAdaptorsFromDir from './utils';
-
+import { updateChangelog } from './updateChangelog.js';
+import getAdaptorsFromDir from './utils.js';
 
 async function fetchVersions(adaptor) {
   try {
@@ -27,9 +25,8 @@ async function getVersionHistory() {
     const adaptorName = `@openfn/language-${adaptor}`;
     const data = await fetchVersions(adaptorName);
     console.log(`Fetching ${adaptor}`);
-    
 
-    if (!data.error) {      
+    if (!data.error) {
       await updateChangelog(adaptor, data);
     }
   }


### PR DESCRIPTION
## Summary

Fix import in `update-version-histories.js`, ran `pnpm update-historical-versions` and commit updated changelogs.


## Details

- Fix import in `update-version-histories.js`, 
- Ran `pnpm update-historical-versions` and commit updated changelogs.
- Update `option.limit` docs for `getSubmission() ` to say `Infinity` instead of ~Infinity~. 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA: If this is a new adaptor, added the adaptor on marketing website ?
- NA: If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- NA: Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
