### PR TITLE
Remove `query` from `logResponse`, add `response.query` in `request()`

### DIFF
--- a/.changeset/empty-nails-push.md
+++ b/.changeset/empty-nails-push.md
@@ -1,24 +1,6 @@
 ---
-'@openfn/language-common': major
+'@openfn/language-common': minor
 ---
 
-### Key Changes
-
-**`logResponse` function:**
-
-- **Simplified API**: Removed the need to pass `query` parameters as a separate
-  argument
-- **Enhanced functionality**: Now automatically extracts `query` parameters from
-  the response object
-
-**`request` function:**
-
-- **Enhanced response structure**: Now includes `query` parameters in the
-  response object
-- **Better tracking**: Query parameters are attached to the response for
-  consistent logging
-
-### Breaking Changes
-
-- **API signature change**: `logResponse(response, query)` →
-  `logResponse(response)`
+- Updated internal `logResponse` API
+- Update request to response to include `query` parameters

--- a/.changeset/empty-nails-push.md
+++ b/.changeset/empty-nails-push.md
@@ -1,0 +1,24 @@
+---
+'@openfn/language-common': major
+---
+
+### Key Changes
+
+**`logResponse` function:**
+
+- **Simplified API**: Removed the need to pass `query` parameters as a separate
+  argument
+- **Enhanced functionality**: Now automatically extracts `query` parameters from
+  the response object
+
+**`request` function:**
+
+- **Enhanced response structure**: Now includes `query` parameters in the
+  response object
+- **Better tracking**: Query parameters are attached to the response for
+  consistent logging
+
+### Breaking Changes
+
+- **API signature change**: `logResponse(response, query)` →
+  `logResponse(response)`

--- a/.changeset/tidy-rabbits-itch.md
+++ b/.changeset/tidy-rabbits-itch.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-fhir-4': patch
+'@openfn/language-inform': patch
+---
+
+Remove query option from `logResponse` function

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -32,7 +32,6 @@ export const logResponse = response => {
     }
   }
 
-  console.log(Object.keys(response));
   return response;
 };
 

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -14,8 +14,8 @@ export const makeBasicAuthHeader = (username, password) => {
   return { Authorization: `Basic ${credentials}` };
 };
 
-export const logResponse = (response, query = {}) => {
-  const { method, url, statusCode, duration } = response;
+export const logResponse = response => {
+  const { method, url, statusCode, duration, query } = response;
 
   if (method && url && duration && statusCode) {
     const urlWithQuery = Object.keys(query || {}).length
@@ -31,6 +31,8 @@ export const logResponse = (response, query = {}) => {
       console.log(message);
     }
   }
+
+  console.log(Object.keys(response));
   return response;
 };
 
@@ -185,12 +187,14 @@ export async function request(method, fullUrlOrPath, options = {}) {
 
   const client = getClient(baseUrl, { tls });
 
+  const queryParams = {
+    ...optionQuery,
+    ...urlQuery,
+  };
+
   const response = await client.request({
     path,
-    query: {
-      ...optionQuery,
-      ...urlQuery,
-    },
+    query: queryParams,
     method,
     headers,
     body: encodeRequestBody(body),
@@ -210,7 +214,7 @@ export async function request(method, fullUrlOrPath, options = {}) {
   const endTime = Date.now();
   const duration = endTime - startTime;
 
-  return {
+  const requestResponse = {
     url,
     method,
     statusCode: response.statusCode,
@@ -219,6 +223,10 @@ export async function request(method, fullUrlOrPath, options = {}) {
     body: responseBody,
     duration,
   };
+  if (Object.keys(queryParams).length > 0) {
+    requestResponse.query = queryParams;
+  }
+  return requestResponse;
 }
 
 function encodeRequestBody(body) {

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -358,6 +358,40 @@ describe('request function', () => {
     expect(response.url).to.eql('https://www.example.com/api');
   });
 
+  it('should include response.query when request has query parameters', async () => {
+    client
+      .intercept({
+        path: '/api',
+        method: 'GET',
+        query: {
+          name: 'homelander',
+          age: '25',
+        },
+      })
+      .reply(200, {});
+
+    const response = await request('GET', 'https://www.example.com/api', {
+      query: { name: 'homelander', age: '25' },
+    });
+
+    expect(response.statusCode).to.eql(200);
+    expect(response.query).to.eql({ name: 'homelander', age: '25' });
+  });
+
+  it('should not include response.query when request has no query parameters', async () => {
+    client
+      .intercept({
+        path: '/api',
+        method: 'GET',
+      })
+      .reply(200, {});
+
+    const response = await request('GET', 'https://www.example.com/api');
+
+    expect(response.statusCode).to.eql(200);
+    expect(response.query).to.be.undefined;
+  });
+
   it('should return undefined if response body is empty and parseAs is json', async () => {
     client
       .intercept({

--- a/packages/fhir-4/src/util.ts
+++ b/packages/fhir-4/src/util.ts
@@ -93,7 +93,7 @@ export const request = (method, path, options: RequestOptions) => {
 
   // TODO add common error handlers for 404, 401
   return commonRequest(method, fullPath, opts)
-    .then(response => logResponse(response, opts.query))
+    .then(logResponse)
     .catch(async e => {
       if (
         e.headers &&

--- a/packages/inform/src/Utils.js
+++ b/packages/inform/src/Utils.js
@@ -48,7 +48,5 @@ export const request = (configuration = {}, method, path, options = {}) => {
 
   const safePath = nodepath.join(path);
 
-  return commonRequest(method, safePath, opts).then(response =>
-    logResponse(response, query)
-  );
+  return commonRequest(method, safePath, opts).then(logResponse);
 };


### PR DESCRIPTION
## Summary

Remove `query` argument from `logResponse` and add `response.query` in `request()` function.

Fixes #1163

## Details

- Remove `query()` argument in `logResponse`
- Refactor `logResponse` to use `response.query`
- Add `resposne.query` in `request` function
- Add unit test for `response.query` in `request()` func
- Add unit test for `logResponse`
- Update `inform` and `fhir-4`  to use the improved `logResponse` function 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA: If this is a new adaptor, added the adaptor on marketing website ?
- NA: If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [x] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
