### PR TITLE
Add `language` support in `OpenMRS`

### DIFF
--- a/.changeset/happy-pets-occur.md
+++ b/.changeset/happy-pets-occur.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-openmrs': minor
+---
+
+Add support for `langauge` option

--- a/.changeset/happy-pets-occur.md
+++ b/.changeset/happy-pets-occur.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-openmrs': minor
----
-
-Add support for `langauge` option

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-openmrs
 
+## 5.1.0
+
+### Minor Changes
+
+- 3a97556: Add support for `langauge` option
+
 ## 5.0.4 - 20 June 2025
 
 ### Patch Changes

--- a/packages/openmrs/ast.json
+++ b/packages/openmrs/ast.json
@@ -50,6 +50,11 @@
             "caption": "Get allergy subresource by its UUID and parent patient UUID"
           },
           {
+            "title": "example",
+            "description": "get(\"patient/abc\", { language: \"fr\" })",
+            "caption": "Get patient by UUID and set the language to French"
+          },
+          {
             "title": "function",
             "description": null,
             "name": null

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openmrs",
   "label": "OpenMRS",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "OpenMRS Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -9,6 +9,7 @@ import { request, cleanPath, requestWithPagination } from './Utils';
  * Options to append to the request. Unless otherwise specified, options are appended to the URL as query parameters - see the [OpenMRS Docs](https://rest.openmrs.org/) for all supported parameters.
  * @typedef {object} GetOptions
  * @property {string} [query] - (OpenFn only) Query string. Maps to `q` in OpenMRS.
+ * @property {string} [language] - (OpenFn only) Language code. Maps to `Accept-Language` in OpenMRS.
  * @property {number} [max=10000] - (OpenFn only) Restrict the maximum number of retrieved records. May be fetched in several pages. Not used if `limit` is set.
  * @property {number} [pageSize=1000] - (OpenFn only) Limits the size of each page of data. Not used if limit is set.
  * @property {boolean} [singleton] - (OpenFn only) If set to true, only the first result will be returned. Useful for "get by id" APIs.
@@ -63,6 +64,8 @@ export function execute(...operations) {
  * get("patient/abc/allergy")
  * @example <caption>Get allergy subresource by its UUID and parent patient UUID</caption>
  * get("patient/abc/allergy/xyz")
+ * @example <caption>Get patient by UUID and set the language to French</caption>
+ * get("patient/abc", { language: "fr" })
  * @function
  * @public
  * @param {string} path - Path to resource (excluding `/ws/rest/v1/`)

--- a/packages/openmrs/src/Adaptor.js
+++ b/packages/openmrs/src/Adaptor.js
@@ -92,7 +92,7 @@ export function get(path, options = {}) {
         delete resolvedOptions.pageSize;
       }
     }
-    let { max, singleton, limit, pageSize, query, ...queryParams } =
+    let { max, singleton, limit, pageSize, query, language, ...queryParams } =
       resolvedOptions;
 
     if (singleton) {
@@ -110,6 +110,7 @@ export function get(path, options = {}) {
       max,
       limit,
       pageSize,
+      language,
     };
 
     try {

--- a/packages/openmrs/src/Utils.js
+++ b/packages/openmrs/src/Utils.js
@@ -34,6 +34,7 @@ export async function fetchAndLog(method, url, opts = {}) {
       url: urlWithQuery,
       query: opts.query,
       method,
+      headers: opts.headers,
     });
 
     return response;
@@ -153,6 +154,7 @@ export async function request(state, method, path, options = {}) {
     parseAs = 'json',
     _onrequest,
     errors,
+    language,
   } = options; // secret option for debug & test
 
   if (baseUrl.length <= 0) {
@@ -170,12 +172,19 @@ export async function request(state, method, path, options = {}) {
 
   const authHeaders = makeBasicAuthHeader(username, password);
 
+  // Add Accept-Language header if language is specified
+  const finalHeaders = {
+    ...authHeaders,
+    ...headers,
+  };
+
+  if (language) {
+    finalHeaders['Accept-Language'] = language;
+  }
+
   const requestOptions = {
     body: data,
-    headers: {
-      ...authHeaders,
-      ...headers,
-    },
+    headers: finalHeaders,
     query,
     parseAs,
     baseUrl,

--- a/packages/openmrs/src/Utils.js
+++ b/packages/openmrs/src/Utils.js
@@ -152,10 +152,10 @@ export async function request(state, method, path, options = {}) {
     data = {},
     headers = { 'content-type': 'application/json' },
     parseAs = 'json',
-    _onrequest,
     errors,
     language,
-  } = options; // secret option for debug & test
+    _onrequest, // secret option for debug & test
+  } = options;
 
   if (baseUrl.length <= 0) {
     throw new Error(
@@ -172,7 +172,6 @@ export async function request(state, method, path, options = {}) {
 
   const authHeaders = makeBasicAuthHeader(username, password);
 
-  // Add Accept-Language header if language is specified
   const finalHeaders = {
     ...authHeaders,
     ...headers,

--- a/packages/openmrs/test/utils.test.js
+++ b/packages/openmrs/test/utils.test.js
@@ -327,6 +327,66 @@ describe('request()', () => {
     // Should not include a next link
     expect(response.body.links.length).to.eql(0);
   });
+
+  it('should include Accept-Language header when language option is provided', async () => {
+    const requests = [];
+    const response = await request(state, 'GET', '/ws/rest/v1/patient', {
+      query: { q: 'bill' },
+      language: 'fr-FR',
+      _onrequest: r => {
+        requests.push(r);
+      },
+    });
+
+    expect(response.statusCode).to.eql(200);
+    expect(requests.length).to.eql(1);
+
+    const requestInfo = requests[0];
+    expect(requestInfo.headers).to.include({
+      'Accept-Language': 'fr-FR',
+    });
+  });
+
+  it('should not include Accept-Language header when language option is not provided', async () => {
+    const requests = [];
+    const response = await request(state, 'GET', '/ws/rest/v1/patient', {
+      query: { q: 'bill' },
+      _onrequest: r => {
+        requests.push(r);
+      },
+    });
+
+    expect(response.statusCode).to.eql(200);
+    expect(requests.length).to.eql(1);
+
+    const requestInfo = requests[0];
+    expect(requestInfo.headers).to.not.have.property('Accept-Language');
+  });
+
+  it('should preserve existing headers when adding Accept-Language', async () => {
+    const requests = [];
+    const response = await request(state, 'GET', '/ws/rest/v1/patient', {
+      query: { q: 'bill' },
+      language: 'de-DE',
+      headers: {
+        'X-Custom-Header': 'custom-value',
+        'content-type': 'application/json',
+      },
+      _onrequest: r => {
+        requests.push(r);
+      },
+    });
+
+    expect(response.statusCode).to.eql(200);
+    expect(requests.length).to.eql(1);
+
+    const requestInfo = requests[0];
+    expect(requestInfo.headers).to.include({
+      'Accept-Language': 'de-DE',
+      'X-Custom-Header': 'custom-value',
+      'content-type': 'application/json',
+    });
+  });
 });
 
 describe('requestWithPagination', () => {


### PR DESCRIPTION
## Summary

Add `language` support in `request()` util and get function 

Fixes #1246 

## Details

- Add `language` option in `get()` function and `request()` util function. The option is mapped to `Accept-Language` in headers
- Add unit test in `util.test.js`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [x] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA:  If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [x] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
