### PR TITLE
Alternate fix to common response

### DIFF
--- a/.changeset/empty-timers-compare.md
+++ b/.changeset/empty-timers-compare.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': patch
+---
+
+Fix an issue parsing empty response bodies in the http helpers

--- a/.changeset/empty-timers-compare.md
+++ b/.changeset/empty-timers-compare.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-common': patch
----
-
-Fix an issue parsing empty response bodies in the http helpers

--- a/.changeset/good-rules-fail.md
+++ b/.changeset/good-rules-fail.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-common': patch
----
-
-Fix an issue where JSON responses without a content-type header could return
-undefined

--- a/.changeset/good-rules-fail.md
+++ b/.changeset/good-rules-fail.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-common': patch
+---
+
+Fix an issue where JSON responses without a content-type header could return
+undefined

--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-asana
 
+## 4.2.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 4.2.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-asana",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "label": "Asana",
   "description": "An adaptor to access objects in Asana",
   "homepage": "https://docs.openfn.org",

--- a/packages/asana/test/adaptor.test.js
+++ b/packages/asana/test/adaptor.test.js
@@ -67,7 +67,7 @@ describe('Adaptor Test', () => {
   });
 
   describe('getTask', () => {
-    it.only('should fetch a task by GID', async () => {
+    it('should fetch a task by GID', async () => {
       const taskGid = '12345';
       const params = { opt_fields: 'name,notes' };
       const mockData = { gid: taskGid, name: 'Test Task', notes: 'Some notes' };

--- a/packages/asana/test/adaptor.test.js
+++ b/packages/asana/test/adaptor.test.js
@@ -67,7 +67,7 @@ describe('Adaptor Test', () => {
   });
 
   describe('getTask', () => {
-    it('should fetch a task by GID', async () => {
+    it.only('should fetch a task by GID', async () => {
       const taskGid = '12345';
       const params = { opt_fields: 'name,notes' };
       const mockData = { gid: taskGid, name: 'Test Task', notes: 'Some notes' };

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-azure-storage
 
+## 2.0.15 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.0.14 - 10 July 2025
 
 ### Patch Changes

--- a/packages/azure-storage/package.json
+++ b/packages/azure-storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-azure-storage",
   "label": "Azure Storage",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "OpenFn adaptor for Azure Storage",
   "type": "module",
   "exports": {

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-beyonic
 
+## 0.3.17 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.3.16 - 10 July 2025
 
 ### Patch Changes

--- a/packages/beyonic/package.json
+++ b/packages/beyonic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-beyonic",
   "label": "Beyonic",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "beyonic Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-bigquery
 
+## 3.0.16 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 3.0.15 - 10 July 2025
 
 ### Patch Changes

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-bigquery",
   "label": "BigQuery",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "A Google BigQuery language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cartodb
 
+## 0.4.18 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.4.17 - 10 July 2025
 
 ### Patch Changes

--- a/packages/cartodb/package.json
+++ b/packages/cartodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-cartodb",
   "label": "CartoDB",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "cartodb Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/chatgpt/CHANGELOG.md
+++ b/packages/chatgpt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-chatgpt
 
+## 1.0.9 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.8 - 10 July 2025
 
 ### Patch Changes

--- a/packages/chatgpt/package.json
+++ b/packages/chatgpt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-chatgpt",
   "label": "ChatGPT",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "OpenFn chatgpt adaptor",
   "type": "module",
   "exports": {

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cht
 
+## 1.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/cht/package.json
+++ b/packages/cht/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-cht",
   "label": "Community Health Toolkit (CHT)",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenFn CHT adaptor",
   "type": "module",
   "exports": {

--- a/packages/claude/CHANGELOG.md
+++ b/packages/claude/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-claude
 
+## 1.0.10 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.9 - 10 July 2025
 
 ### Patch Changes

--- a/packages/claude/package.json
+++ b/packages/claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-claude",
   "label": "Claude",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "OpenFn claude adaptor",
   "type": "module",
   "exports": {

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-collections
 
+## 0.7.11 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.7.10 - 10 July 2025
 
 ### Patch Changes

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-collections",
   "label": "Collections",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "OpenFn collections adaptor",
   "type": "module",
   "exports": {

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-commcare
 
+## 3.3.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 3.3.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-commcare",
   "label": "CommCare",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Commcare Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 3.0.0 - 10 July 2025
 
+## 3.0.1 - 10 July 2025
+
+### Patch Changes
+
+- cf9c09f: Fix an issue where JSON responses without a content-type header could
+  return undefined
+
 The 3.0 release of the common adaptor restructures some key internal
 functionality and re-writes the `map()` function to feel more modern.
 
@@ -20,16 +27,13 @@ convenience function.
 
 The behaviour of the `map()` function has changed subtly but significantly.
 
-Existing workflows should replace `map()` with `each()`, which has the
-same functionality.
+Existing workflows should replace `map()` with `each()`, which has the same
+functionality.
 
 So if you used to do this:
 
 ```js
-map(
-  '$.[*]',
-  create('SObject', field('FirstName', sourceValue('$.firstName')))
-);
+map('$.[*]', create('SObject', field('FirstName', sourceValue('$.firstName'))));
 ```
 
 You must do this instead:
@@ -306,7 +310,7 @@ content type to JSON.
 ### Minor Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 
 ## 1.9.0 - 23 June 2023
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,11 +1,11 @@
-## 3.0.0 - 10 July 2025
-
-## 3.0.1 - 10 July 2025
+## 3.0.1 - 11 July 2025
 
 ### Patch Changes
 
 - cf9c09f: Fix an issue where JSON responses without a content-type header could
   return undefined
+
+## 3.0.0 - 10 July 2025
 
 The 3.0 release of the common adaptor restructures some key internal
 functionality and re-writes the `map()` function to feel more modern.
@@ -310,7 +310,7 @@ content type to JSON.
 ### Minor Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access\_token" keys can be used for OAuth2-reliant adaptors
+  "access_token" keys can be used for OAuth2-reliant adaptors
 
 ## 1.9.0 - 23 June 2023
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-common",
   "label": "Common",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Common Expressions for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -261,7 +261,14 @@ async function readResponseBody(response, parseAs) {
     contentLength = parseInt(response.headers['content-length']);
   }
 
-  if (contentLength == 0 || response.statusCode === 204) {
+  // Try to work out if the response is empty
+  // If so, we should just return without trying to parse it
+  // (turns out that this isn't easy to do!)
+  if (
+    contentLength == 0 ||
+    response.statusCode === 204 ||
+    (response.statusCode >= 300 && response.statusCode < 400)
+  ) {
     return;
   }
 

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -257,11 +257,11 @@ function encodeRequestBody(body) {
 
 async function readResponseBody(response, parseAs) {
   let contentLength = -1;
-  if (`content-length` in response.headers) {
+  if ('content-length' in response.headers) {
     contentLength = parseInt(response.headers['content-length']);
   }
 
-  if (contentLength < 0 || response.statusCode === 204) {
+  if (contentLength == 0 || response.statusCode === 204) {
     return;
   }
 

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -43,13 +43,60 @@ const getClient = (baseUrl, options) => {
   return clients.get(baseUrl);
 };
 
-export const enableMockClient = baseUrl => {
+export const enableMockClient = (baseUrl, options = {}) => {
+  const { defaultContentType = 'application/json' } = options;
+
   const mockAgent = new MockAgent({ connections: 1 });
   mockAgent.disableNetConnect();
   const client = mockAgent.get(baseUrl);
   if (!clients.has(baseUrl)) {
+    if (defaultContentType) {
+      const _intercept = client.intercept;
+      // because so many unit test use mock json,
+      // force the content-type header if a body is specified
+      client.intercept = (...args) => {
+        const interceptor = _intercept.apply(client, args);
+
+        const _reply = interceptor.reply;
+
+        const ensureJsonHeader = (headers = {}) => {
+          const hasJsonHeader = Object.keys(headers).find(k =>
+            /content-type/i.test(k)
+          );
+          if (!hasJsonHeader) {
+            headers['content-type'] = defaultContentType;
+          }
+        };
+
+        const reply = (...args) => {
+          if (typeof args[0] === 'function') {
+            // call the function
+            // in the resulting object, set the headers
+            const response = _reply.apply(interceptor, args);
+            if (response.body) {
+              response.headers ??= {};
+              ensureJsonHeader(response.headers);
+            }
+            return response;
+          } else {
+            const [code, data, options = {}] = args;
+            if (data) {
+              options.headers ??= {};
+              ensureJsonHeader(options.headers);
+            }
+            return _reply.call(interceptor, code, data, options);
+          }
+        };
+
+        interceptor.reply = reply;
+
+        return interceptor;
+      };
+    }
+
     clients.set(baseUrl, client);
   }
+
   return client;
 };
 
@@ -260,19 +307,14 @@ async function readResponseBody(response, parseAs) {
   if ('content-length' in response.headers) {
     contentLength = parseInt(response.headers['content-length']);
   }
+  const contentType = response.headers['content-type'];
 
   // Try to work out if the response is empty
-  // If so, we should just return without trying to parse it
-  // (turns out that this isn't easy to do!)
-  if (
-    contentLength == 0 ||
-    response.statusCode === 204 ||
-    (response.statusCode >= 300 && response.statusCode < 400)
-  ) {
+  // HTTP spec says content type must be defined if there's a body
+  if (contentLength === 0 || !contentType || response.statusCode === 204) {
     return;
   }
 
-  const contentType = response.headers['content-type'];
   try {
     switch (parseAs) {
       case 'json':

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -267,10 +267,6 @@ async function readResponseBody(response, parseAs) {
 
   const contentType = response.headers['content-type'];
   try {
-    if (Number.isNaN(contentLength) || contentLength === 0) {
-      return undefined;
-    }
-
     switch (parseAs) {
       case 'json':
         return await response.body.json();

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -256,9 +256,15 @@ function encodeRequestBody(body) {
 }
 
 async function readResponseBody(response, parseAs) {
-  const contentLength = parseInt(
-    response.headers['content-length'] ?? response.body?.readableLength
-  );
+  let contentLength = -1;
+  if (`content-length` in response.headers) {
+    contentLength = parseInt(response.headers['content-length']);
+  }
+
+  if (contentLength < 0 || response.statusCode === 204) {
+    return;
+  }
+
   const contentType = response.headers['content-type'];
   try {
     if (Number.isNaN(contentLength) || contentLength === 0) {

--- a/packages/common/test/http.test.js
+++ b/packages/common/test/http.test.js
@@ -2,7 +2,9 @@ import { expect, assert } from 'chai';
 import { request, get, post, options } from '../src/http';
 import { assertRelativeUrl, enableMockClient } from '../src/util/http';
 
-const client = enableMockClient('https://a.com');
+const client = enableMockClient('https://a.com', {
+  defaultContentType: 'text',
+});
 
 describe('options', () => {
   it('should return an object', () => {

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -411,6 +411,101 @@ describe('request function', () => {
     expect(response.body).to.eql(undefined);
   });
 
+  it('should return undefined if no response body and no headers', async () => {
+    client
+      .intercept({
+        path: '/api',
+        method: 'PUT',
+      })
+      .reply(200, undefined, {
+        headers: {},
+      });
+
+    const response = await request('PUT', 'https://www.example.com/api', {
+      parseAs: 'json',
+      body: { id: 2 },
+    });
+
+    expect(response.statusCode).to.eql(200);
+    expect(response.body).to.eql(undefined);
+  });
+
+  // TODO OK we can remove this
+  // This leniency is super useful in unit tests
+  it.skip('should return undefined if no response body and but content-type header is present', async () => {
+    client
+      .intercept({
+        path: '/api',
+        method: 'PUT',
+      })
+      .reply(200, undefined, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    const response = await request('PUT', 'https://www.example.com/api', {
+      parseAs: 'json',
+      body: { id: 2 },
+    });
+
+    expect(response.statusCode).to.eql(200);
+    expect(response.body).to.eql(undefined);
+  });
+
+  it('should accept a JSON response with content-length', async () => {
+    const body = { jam: 'jar ' };
+    client
+      .intercept({
+        path: '/api/json',
+        method: 'GET',
+      })
+      .reply(200, body, {
+        headers: { 'Content-Length': JSON.stringify(body).length },
+      });
+
+    const response = await request('GET', 'https://www.example.com/api/json');
+
+    expect(response.statusCode).to.eql(200);
+    expect(response.body).to.eql(body);
+  });
+
+  it('should accept a JSON response without content-length', async () => {
+    const body = { jam: 'jar ' };
+    client
+      .intercept({
+        path: '/api/json',
+        method: 'GET',
+      })
+      .reply(200, body, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+    const response = await request('GET', 'https://www.example.com/api/json');
+
+    expect(response.statusCode).to.eql(200);
+    expect(response.body).to.eql(body);
+  });
+
+  it('should accept a JSON response with content-length', async () => {
+    const body = { jam: 'jar ' };
+    client
+      .intercept({
+        path: '/api/json',
+        method: 'GET',
+      })
+      .reply(200, body, {
+        headers: { 'Content-Length': JSON.stringify(body).length },
+      });
+
+    const response = await request('GET', 'https://www.example.com/api/json', {
+      parseAs: 'json',
+    });
+
+    expect(response.statusCode).to.eql(200);
+    expect(response.body).to.eql(body);
+  });
+
   it('should throw an error if there is no content-length header and an empty response body', async () => {
     client
       .intercept({
@@ -871,19 +966,21 @@ describe('helpers', () => {
       expect(result.body).to.eql({ name: 'mutchi' });
     });
 
-    it('should auto parse as text by default (no content type)', async () => {
+    it('should auto parse as text by default (unknown content type)', async () => {
       client
         .intercept({
           path: '/api',
           method: 'GET',
         })
-        .reply(200, {
-          name: 'joe',
+        .reply(200, 'joe', {
+          headers: {
+            'content-type': 'application/xml',
+          },
         });
 
       const result = await request('GET', 'https://www.example.com/api');
 
-      expect(result.body).to.eql(JSON.stringify({ name: 'joe' }));
+      expect(result.body).to.eql('joe');
     });
 
     it('should auto parse as text in any other case', async () => {
@@ -909,9 +1006,17 @@ describe('helpers', () => {
           path: '/api',
           method: 'GET',
         })
-        .reply(200, {
-          name: 'aissa',
-        });
+        .reply(
+          200,
+          {
+            name: 'aissa',
+          },
+          {
+            headers: {
+              'content-type': 'application/json',
+            },
+          }
+        );
 
       const result = await request('GET', 'https://www.example.com/api', {
         parseAs: 'json',
@@ -951,9 +1056,17 @@ describe('helpers', () => {
           path: '/api',
           method: 'GET',
         })
-        .reply(200, {
-          name: 'iam stream',
-        });
+        .reply(
+          200,
+          {
+            name: 'iam stream',
+          },
+          {
+            headers: {
+              'content-type': 'application/text',
+            },
+          }
+        );
 
       const result = await request('GET', 'https://www.example.com/api', {
         parseAs: 'stream',
@@ -995,7 +1108,11 @@ describe('helpers', () => {
           path: '/api',
           method: 'GET',
         })
-        .reply(200, binaryData);
+        .reply(200, binaryData, {
+          headers: {
+            'content-type': 'application/octet-stream',
+          },
+        });
 
       const result = await request('GET', 'https://www.example.com/api', {
         parseAs: 'base64',

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -430,27 +430,6 @@ describe('request function', () => {
     expect(response.body).to.eql(undefined);
   });
 
-  // TODO OK we can remove this
-  // This leniency is super useful in unit tests
-  it.skip('should return undefined if no response body and but content-type header is present', async () => {
-    client
-      .intercept({
-        path: '/api',
-        method: 'PUT',
-      })
-      .reply(200, undefined, {
-        headers: { 'Content-Type': 'application/json' },
-      });
-
-    const response = await request('PUT', 'https://www.example.com/api', {
-      parseAs: 'json',
-      body: { id: 2 },
-    });
-
-    expect(response.statusCode).to.eql(200);
-    expect(response.body).to.eql(undefined);
-  });
-
   it('should accept a JSON response with content-length', async () => {
     const body = { jam: 'jar ' };
     client

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dhis2
 
+## 7.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 7.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-dhis2",
   "label": "DHIS2",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "DHIS2 Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/divoc/CHANGELOG.md
+++ b/packages/divoc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-divoc
 
+## 0.1.6 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.1.5 - 10 July 2025
 
 ### Patch Changes

--- a/packages/divoc/package.json
+++ b/packages/divoc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-divoc",
   "label": "Divoc",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "OpenFn divoc adaptor",
   "type": "module",
   "exports": {

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dynamics
 
+## 0.5.19 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.5.18 - 10 July 2025
 
 ### Patch Changes

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-dynamics",
   "label": "Dynamics",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "A Microsoft Dynamics Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-facebook
 
+## 0.4.17 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.4.16 - 10 July 2025
 
 ### Patch Changes

--- a/packages/facebook/package.json
+++ b/packages/facebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-facebook",
   "label": "Facebook",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "An Language Package for Facebook Messenger API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/fhir-4/CHANGELOG.md
+++ b/packages/fhir-4/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir-4
 
+## 0.1.8 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.1.7 - 10 July 2025
 
 ### Patch Changes

--- a/packages/fhir-4/package.json
+++ b/packages/fhir-4/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir-4",
   "label": "FHIR r4",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "OpenFn FHIR r4 adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-4 src docs",

--- a/packages/fhir-fr/CHANGELOG.md
+++ b/packages/fhir-fr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir-fr
 
+## 1.0.14 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.13 - 10 July 2025
 
 ### Patch Changes

--- a/packages/fhir-fr/package.json
+++ b/packages/fhir-fr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir-fr",
   "label": "FHIR-FR",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "OpenFn fhir-fr adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-fr src ast docs",

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-fhir-ndr-et
 
+## 0.1.17 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+  - @openfn/language-fhir@5.0.6
+
 ## 0.1.16 - 10 July 2025
 
 ### Patch Changes

--- a/packages/fhir-ndr-et/package.json
+++ b/packages/fhir-ndr-et/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir-ndr-et",
   "label": "FHIR NDR Ehtiopia",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "OpenFn fhir adaptor for NDR HIV in Ehtiopia",
   "type": "module",
   "exports": {
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@openfn/language-common": "workspace:*",
-    "@openfn/language-fhir": "^5.0.5",
+    "@openfn/language-fhir": "^5.0.6",
     "@types/fhir": "^0.0.41",
     "ast-types": "^0.14.2",
     "lodash": "^4.17.21",

--- a/packages/fhir/CHANGELOG.md
+++ b/packages/fhir/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir
 
+## 5.0.6 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 5.0.5 - 10 July 2025
 
 ### Patch Changes

--- a/packages/fhir/package.json
+++ b/packages/fhir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir",
   "label": "FHIR",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "A FHIR adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/fhir/test/Adaptor.test.js
+++ b/packages/fhir/test/Adaptor.test.js
@@ -217,7 +217,11 @@ describe('post', () => {
         path: 'baseR4/noAccess',
         method: 'POST',
       })
-      .reply(404, fixtures.noAccessResponse);
+      .reply(404, fixtures.noAccessResponse, {
+        headers: {
+          'content-type': 'application/text',
+        },
+      });
 
     const state = {
       configuration,

--- a/packages/ghana-bdr/CHANGELOG.md
+++ b/packages/ghana-bdr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ghana-bdr
 
+## 0.1.10 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.1.9 - 10 July 2025
 
 ### Patch Changes

--- a/packages/ghana-bdr/package.json
+++ b/packages/ghana-bdr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-ghana-bdr",
   "label": "Ghana BDR",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "OpenFn ghana-bdr adaptor",
   "type": "module",
   "exports": {

--- a/packages/ghana-nia/CHANGELOG.md
+++ b/packages/ghana-nia/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ghana-nia
 
+## 0.1.10 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.1.9 - 10 July 2025
 
 ### Patch Changes

--- a/packages/ghana-nia/package.json
+++ b/packages/ghana-nia/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-ghana-nia",
   "label": "Ghana NIA",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "OpenFn ghana-nia adaptor",
   "type": "module",
   "exports": {

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-gmail
 
+## 1.3.4 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.3.3 - 10 July 2025
 
 ### Patch Changes

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-gmail",
   "label": "Gmail",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "OpenFn gmail adaptor",
   "type": "module",
   "exports": {

--- a/packages/godata/CHANGELOG.md
+++ b/packages/godata/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-godata
 
+## 3.5.6 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 3.5.5 - 10 July 2025
 
 ### Patch Changes

--- a/packages/godata/package.json
+++ b/packages/godata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-godata",
   "label": "GoData",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "description": "An OpenFn adaptor for use with the WHO's GoData API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/googledrive/CHANGELOG.md
+++ b/packages/googledrive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googledrive
 
+## 1.0.4 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.3 - 10 July 2025
 
 ### Patch Changes

--- a/packages/googledrive/package.json
+++ b/packages/googledrive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-googledrive",
   "label": "Google Drive",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "OpenFn Google Drive adaptor",
   "type": "module",
   "exports": {

--- a/packages/googlehealthcare/CHANGELOG.md
+++ b/packages/googlehealthcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googlehealthcare
 
+## 1.1.5 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.1.4 - 10 July 2025
 
 ### Patch Changes

--- a/packages/googlehealthcare/package.json
+++ b/packages/googlehealthcare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-googlehealthcare",
   "label": "Google Health Care",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A Google Health Care language package for use with Open Function",
   "type": "module",
   "exports": {

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googlesheets
 
+## 3.0.16 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 3.0.15 - 10 July 2025
 
 ### Patch Changes

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-googlesheets",
   "label": "Google Sheets",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "A Google Sheets Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-hive
 
+## 0.3.17 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.3.16 - 10 July 2025
 
 ### Patch Changes

--- a/packages/hive/package.json
+++ b/packages/hive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-hive",
   "label": "Apache HIVE",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "An Apache HIVE adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-http
 
+## 7.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 7.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-http",
   "label": "HTTP",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -1,11 +1,12 @@
 import { execute, request, get, post, put, patch, del, fn } from '../src';
-import { each, parseCsv } from '@openfn/language-common';
 import { enableMockClient } from '@openfn/language-common/util';
 import { expect, assert } from 'chai';
 
 const jsonHeaders = { 'Content-Type': 'application/json' };
 
-const testServer = enableMockClient('https://www.example.com');
+const testServer = enableMockClient('https://www.example.com', {
+  defaultContentType: 'text',
+});
 
 describe('execute()', () => {
   it('executes each operation in sequence', () => {

--- a/packages/hubtel/CHANGELOG.md
+++ b/packages/hubtel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-hubtel
 
+## 1.0.8 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.7 - 10 July 2025
 
 ### Patch Changes

--- a/packages/hubtel/package.json
+++ b/packages/hubtel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-hubtel",
   "label": "Hubtel",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OpenFn hubtel adaptor",
   "type": "module",
   "exports": {

--- a/packages/inform/CHANGELOG.md
+++ b/packages/inform/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-inform
 
+## 1.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/inform/package.json
+++ b/packages/inform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-inform",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenFn inform adaptor",
   "type": "module",
   "exports": {

--- a/packages/inform/test/Adaptor.test.js
+++ b/packages/inform/test/Adaptor.test.js
@@ -21,6 +21,12 @@ const configuration = {
   access_token: 'someaccesstoken',
 };
 
+const jsonHeaders = {
+  headers: {
+    'content-type': 'application/json',
+  },
+};
+
 describe('getForms', () => {
   const result = [
     {
@@ -39,7 +45,7 @@ describe('getForms', () => {
         method: 'GET',
       })
 
-      .reply(200, result);
+      .reply(200, result, jsonHeaders);
 
     const state = {
       configuration,
@@ -62,7 +68,7 @@ describe('getForms', () => {
         },
       })
 
-      .reply(200, result);
+      .reply(200, result, jsonHeaders);
 
     const state = {
       configuration,
@@ -90,7 +96,7 @@ describe('getForm', () => {
         method: 'GET',
       })
 
-      .reply(200, result);
+      .reply(200, result, jsonHeaders);
 
     const state = {
       configuration,
@@ -111,7 +117,7 @@ describe('getForm', () => {
         method: 'GET',
       })
 
-      .reply(200, result);
+      .reply(200, result, jsonHeaders);
 
     const state = {
       configuration,
@@ -139,7 +145,7 @@ describe('getSubmissions', () => {
         method: 'GET',
       })
 
-      .reply(200, result);
+      .reply(200, result, jsonHeaders);
 
     const state = {
       configuration,
@@ -161,7 +167,7 @@ describe('getSubmissions', () => {
         },
       })
 
-      .reply(200, result);
+      .reply(200, result, jsonHeaders);
 
     const state = {
       configuration,
@@ -184,9 +190,13 @@ describe('getSubmission', () => {
         method: 'GET',
       })
 
-      .reply(200, {
-        _id: 7783155,
-      });
+      .reply(
+        200,
+        {
+          _id: 7783155,
+        },
+        jsonHeaders
+      );
 
     const state = {
       configuration,
@@ -205,10 +215,14 @@ describe('getAttachmentMetadata', () => {
         method: 'GET',
       })
 
-      .reply(200, {
-        id: 621985,
-        xform: 7205,
-      });
+      .reply(
+        200,
+        {
+          id: 621985,
+          xform: 7205,
+        },
+        jsonHeaders
+      );
 
     const state = {
       configuration,
@@ -231,11 +245,15 @@ describe('downloadAttachment', () => {
         },
       })
 
-      .reply(200, {
-        _readableState: {},
-        _events: {},
-        _eventsCount: 0,
-      });
+      .reply(
+        200,
+        {
+          _readableState: {},
+          _events: {},
+          _eventsCount: 0,
+        },
+        jsonHeaders
+      );
 
     const state = {
       configuration,

--- a/packages/inform/test/Adaptor.test.js
+++ b/packages/inform/test/Adaptor.test.js
@@ -31,16 +31,15 @@ describe('getForms', () => {
       public: true,
       formid: 3,
     },
-];
+  ];
   it('should get all forms', async () => {
-
     testServer
       .intercept({
         path: `/api/${configuration.apiVersion}/forms`,
         method: 'GET',
       })
 
-      .reply(200,  result);
+      .reply(200, result);
 
     const state = {
       configuration,
@@ -84,14 +83,14 @@ describe('getForm', () => {
     const result = {
       public: true,
       formid: 1234,
-    }
+    };
     testServer
       .intercept({
         path: `/api/${configuration.apiVersion}/forms/1234`,
         method: 'GET',
       })
 
-      .reply(200,result );
+      .reply(200, result);
 
     const state = {
       configuration,
@@ -105,14 +104,14 @@ describe('getForm', () => {
     const result = {
       name: 'data',
       type: 'survey',
-    }
+    };
     testServer
       .intercept({
         path: `/api/${configuration.apiVersion}/forms/1234/form.json`,
         method: 'GET',
       })
 
-      .reply(200,result);
+      .reply(200, result);
 
     const state = {
       configuration,
@@ -132,7 +131,7 @@ describe('getSubmissions', () => {
     {
       _id: 7783158,
     },
-  ]
+  ];
   it("should get a single form's submission", async () => {
     testServer
       .intercept({

--- a/packages/inform/test/http.test.js
+++ b/packages/inform/test/http.test.js
@@ -11,6 +11,12 @@ const configuration = {
   access_token: 'someaccesstoken',
 };
 
+const jsonHeaders = {
+  headers: {
+    'content-type': 'application/json',
+  },
+};
+
 describe('request', () => {
   it('should get forms with a query', async () => {
     testServer
@@ -24,10 +30,14 @@ describe('request', () => {
         },
       })
 
-      .reply(200, {
-        public: true,
-        formid: 2,
-      });
+      .reply(
+        200,
+        {
+          public: true,
+          formid: 2,
+        },
+        jsonHeaders
+      );
 
     const state = {
       configuration,
@@ -53,10 +63,14 @@ describe('get', () => {
         method: 'GET',
       })
 
-      .reply(200, {
-        public: true,
-        formid: 2,
-      });
+      .reply(
+        200,
+        {
+          public: true,
+          formid: 2,
+        },
+        jsonHeaders
+      );
 
     const state = {
       configuration,

--- a/packages/intuit/CHANGELOG.md
+++ b/packages/intuit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-intuit
 
+## 1.0.7 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.6 - 10 July 2025
 
 ### Patch Changes

--- a/packages/intuit/package.json
+++ b/packages/intuit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-intuit",
   "label": "Intuit",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "OpenFn intuit adaptor",
   "type": "module",
   "exports": {

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-khanacademy
 
+## 0.5.17 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.5.16 - 10 July 2025
 
 ### Patch Changes

--- a/packages/khanacademy/package.json
+++ b/packages/khanacademy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-khanacademy",
   "label": "Khan Academy",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "description": "A Khan Academy Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-kobotoolbox
 
+## 4.2.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 4.2.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-kobotoolbox",
   "label": "KoboToolbox",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A KoboToolbox Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/magpi/CHANGELOG.md
+++ b/packages/magpi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-magpi
 
+## 1.2.6 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.2.5 - 10 July 2025
 
 ### Patch Changes

--- a/packages/magpi/package.json
+++ b/packages/magpi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-magpi",
   "label": "Magpi",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A Magpi Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailchimp
 
+## 1.0.18 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.17 - 10 July 2025
 
 ### Patch Changes

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mailchimp",
   "label": "Mailchimp",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "An OpenFn adaptor for use with Mailchimp",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailgun
 
+## 0.5.16 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.5.15 - 10 July 2025
 
 ### Patch Changes

--- a/packages/mailgun/package.json
+++ b/packages/mailgun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mailgun",
   "label": "Mailgun",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "mailgun Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-maximo
 
+## 0.5.19 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.5.18 - 10 July 2025
 
 ### Patch Changes

--- a/packages/maximo/package.json
+++ b/packages/maximo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-maximo",
   "label": "Maximo",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "An IBM Maximo EAM Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-medicmobile
 
+## 0.5.17 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.5.16 - 10 July 2025
 
 ### Patch Changes

--- a/packages/medicmobile/package.json
+++ b/packages/medicmobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-medicmobile",
   "label": "Medic Mobile",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "description": "A Medic Mobile language pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -1,5 +1,12 @@
 v0.1.6
 
+## 0.6.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.6.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/mogli/package.json
+++ b/packages/mogli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mogli",
   "label": "Mogli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A Mogli SMS Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mojatax/CHANGELOG.md
+++ b/packages/mojatax/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mojatax
 
+## 1.0.12 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.11 - 10 July 2025
 
 ### Patch Changes

--- a/packages/mojatax/package.json
+++ b/packages/mojatax/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mojatax",
   "label": "MojaTax",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "OpenFn mojatax adaptor",
   "type": "module",
   "exports": {

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mongodb
 
+## 2.1.17 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.1.16 - 10 July 2025
 
 ### Patch Changes

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mongodb",
   "label": "MongoDB",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "description": "A language package for working with MongoDb",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mpesa/CHANGELOG.md
+++ b/packages/mpesa/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mpesa
 
+## 1.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/mpesa/package.json
+++ b/packages/mpesa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mpesa",
   "label": "Mpesa",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenFn mpesa adaptor",
   "type": "module",
   "exports": {

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msgraph
 
+## 0.8.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.8.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-msgraph",
   "label": "Microsoft Graph",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Microsoft Graph Language Pack for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mssql
 
+## 5.2.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 5.2.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mssql",
   "label": "MSSQL",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {

--- a/packages/msupply/CHANGELOG.md
+++ b/packages/msupply/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msupply
 
+## 1.0.5 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.4 - 10 July 2025
 
 ### Patch Changes

--- a/packages/msupply/package.json
+++ b/packages/msupply/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-msupply",
   "label": "mSupply",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenFn msupply adaptor",
   "type": "module",
   "exports": {

--- a/packages/mtn-momo/CHANGELOG.md
+++ b/packages/mtn-momo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mtn-momo
 
+## 1.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/mtn-momo/package.json
+++ b/packages/mtn-momo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mtn-momo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenFn mtn-momo adaptor",
   "type": "module",
   "exports": {

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mysql
 
+## 2.2.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.2.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mysql",
   "label": "MySQL",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A MySQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "main": "dist/index.cjs",

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-nexmo
 
+## 0.5.19 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.5.18 - 10 July 2025
 
 ### Patch Changes

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-nexmo",
   "label": "Nexmo",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "An Language Package for Nexmo",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ocl
 
+## 1.2.18 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.2.17 - 10 July 2025
 
 ### Patch Changes

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-ocl",
   "label": "OCL",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "An OCL language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-odk
 
+## 3.0.18 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 3.0.17 - 10 July 2025
 
 ### Patch Changes

--- a/packages/odk/package.json
+++ b/packages/odk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-odk",
   "label": "ODK",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "OpenFn odk adaptor",
   "type": "module",
   "exports": {

--- a/packages/odk/test/Adaptor.test.js
+++ b/packages/odk/test/Adaptor.test.js
@@ -479,7 +479,11 @@ describe('HTTP wrappers', () => {
         path: '/v1/projects',
         method: 'POST',
       })
-      .reply(403, 'Forbidden');
+      .reply(403, 'Forbidden', {
+        headers: {
+          'content-type': 'text',
+        },
+      });
 
     const state = {
       configuration,

--- a/packages/odoo/CHANGELOG.md
+++ b/packages/odoo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-odoo
 
+## 1.0.9 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.8 - 10 July 2025
 
 ### Patch Changes

--- a/packages/odoo/package.json
+++ b/packages/odoo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-odoo",
   "label": "Odoo",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "OpenFn odoo adaptor",
   "type": "module",
   "exports": {

--- a/packages/openboxes/CHANGELOG.md
+++ b/packages/openboxes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openboxes
 
+## 1.0.6 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.5 - 10 July 2025
 
 ### Patch Changes

--- a/packages/openboxes/package.json
+++ b/packages/openboxes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openboxes",
   "label": "OpenBoxes",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "OpenFn openboxes adaptor",
   "type": "module",
   "exports": {

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openfn
 
+## 3.0.2 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 3.0.1 - 10 July 2025
 
 ### Patch Changes

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openfn",
   "label": "OpenFn",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "An (experimental) adaptor for accessing the OpenFn web API",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openhim
 
+## 0.3.16 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.3.15 - 10 July 2025
 
 ### Patch Changes

--- a/packages/openhim/package.json
+++ b/packages/openhim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openhim",
   "label": "OpenHIM",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "openhim Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openimis
 
+## 2.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/openimis/package.json
+++ b/packages/openimis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openimis",
   "label": "OpenIMIS",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "An OpenIMIS adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openlmis
 
+## 1.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/openlmis/package.json
+++ b/packages/openlmis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openlmis",
   "label": "OpenLMIS",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenFn openlmis adaptor",
   "type": "module",
   "exports": {

--- a/packages/openlmis/test/Adaptor.test.js
+++ b/packages/openlmis/test/Adaptor.test.js
@@ -224,7 +224,11 @@ describe('HTTP wrappers', () => {
         path: '/api/programs',
         method: 'POST',
       })
-      .reply(400, 'Bad Request');
+      .reply(400, 'Bad Request', {
+        headers: {
+          'content-type': 'text',
+        },
+      });
 
     const state = {
       configuration,

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openmrs
 
+## 5.2.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 5.2.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openmrs",
   "label": "OpenMRS",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "OpenMRS Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openspp
 
+## 2.0.15 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.0.14 - 10 July 2025
 
 ### Patch Changes

--- a/packages/openspp/package.json
+++ b/packages/openspp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openspp",
   "label": "OpenSPP",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "An OpenFn adaptor for working with the OpenSPP json rpc",
   "type": "module",
   "exports": {

--- a/packages/pesapal/CHANGELOG.md
+++ b/packages/pesapal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-pesapal
 
+## 1.1.2 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.1.1 - 10 July 2025
 
 ### Patch Changes

--- a/packages/pesapal/package.json
+++ b/packages/pesapal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-pesapal",
   "label": "Pesapal",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "OpenFn pesapal adaptor",
   "type": "module",
   "exports": {

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-postgresql
 
+## 6.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 6.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-postgresql",
   "label": "PostgreSQL",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "A PostgreSQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-primero
 
+## 3.2.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 3.2.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-primero",
   "label": "Primero",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A UNICEF Primero language package for use with Open Function",
   "exports": {
     ".": {

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-progres
 
+## 2.0.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.0.0 - 10 July 2025
 
 ### Major Changes

--- a/packages/progres/package.json
+++ b/packages/progres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-progres",
   "label": "ProGres",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An OpenFn adaptor to work with UNHCR's ProGres case management system",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/progres/test/index.js
+++ b/packages/progres/test/index.js
@@ -40,7 +40,6 @@ describe('execute', () => {
 });
 
 describe('post', () => {
-
   it('calls the callback', async () => {
     let state = {
       configuration: {
@@ -56,17 +55,17 @@ describe('post', () => {
       })
       .reply(200, { foo: 'bar' });
 
-    await execute(
+    const result = await execute(
       postData({
         url: 'https://fake.server.com/api',
         headers: null,
         body: { a: 1 },
       })
-    )(state).then(state => {
-      let status = state.response.statusCode;
-      let responseBody = state.data;
-      expect(status).to.eq(200);
-      expect(JSON.parse(responseBody)).to.eql({ foo: 'bar' });
-    });
+    )(state);
+
+    const status = result.response.statusCode;
+    const responseBody = result.data;
+    expect(status).to.eq(200);
+    expect(responseBody).to.eql({ foo: 'bar' });
   });
 });

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-rapidpro
 
+## 2.0.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.0.0 - 10 July 2025
 
 ### Major Changes

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-rapidpro",
   "label": "RapidPro",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A RapidPro adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-redis
 
+## 1.3.6 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.3.5 - 10 July 2025
 
 ### Patch Changes

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-redis",
   "label": "Redis",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "OpenFn redis adaptor",
   "type": "module",
   "exports": {

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-resourcemap
 
+## 0.4.18 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.4.17 - 10 July 2025
 
 ### Patch Changes

--- a/packages/resourcemap/package.json
+++ b/packages/resourcemap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-resourcemap",
   "label": "Resourcemap",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Resourcemap Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-salesforce
 
+## 7.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 7.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-salesforce",
   "label": "Salesforce",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "OpenFn Salesforce adaptor",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-satusehat
 
+## 2.1.1 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.1.0 - 10 July 2025
 
 ### Minor Changes

--- a/packages/satusehat/package.json
+++ b/packages/satusehat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-satusehat",
   "label": "Satusehat",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "OpenFn Satusehat adaptor",
   "type": "module",
   "exports": {

--- a/packages/senaite/CHANGELOG.md
+++ b/packages/senaite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-senaite
 
+## 1.0.5 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.4 - 10 July 2025
 
 ### Patch Changes

--- a/packages/senaite/package.json
+++ b/packages/senaite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-senaite",
   "label": "Senaite",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenFn senaite adaptor",
   "type": "module",
   "exports": {

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-sftp
 
+## 2.0.16 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.0.15 - 10 July 2025
 
 ### Patch Changes

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-sftp",
   "label": "SFTP",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "An SFTP language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/surveycto/CHANGELOG.md
+++ b/packages/surveycto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-surveycto
 
+## 2.2.6 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 2.2.5 - 10 July 2025
 
 ### Patch Changes

--- a/packages/surveycto/package.json
+++ b/packages/surveycto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-surveycto",
   "label": "SurveyCTO",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "A SurveyCTO Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-telerivet
 
+## 0.3.16 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.3.15 - 10 July 2025
 
 ### Patch Changes

--- a/packages/telerivet/package.json
+++ b/packages/telerivet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-telerivet",
   "label": "Telerivet",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "telerivet Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/twilio/CHANGELOG.md
+++ b/packages/twilio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-twilio
 
+## 0.5.4 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.5.3 - 10 July 2025
 
 ### Patch Changes

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-twilio",
   "label": "Twilio",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "An Language Package for twilio",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/varo/CHANGELOG.md
+++ b/packages/varo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-varo
 
+## 1.1.3 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.1.2 - 10 July 2025
 
 ### Patch Changes

--- a/packages/varo/package.json
+++ b/packages/varo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-varo",
   "label": "Varo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "OpenFn varo adaptor",
   "type": "module",
   "exports": {

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-vtiger
 
+## 1.3.17 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.3.16 - 10 July 2025
 
 ### Patch Changes

--- a/packages/vtiger/package.json
+++ b/packages/vtiger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-vtiger",
   "label": "Vtiger",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "A Vtiger Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/whatsapp/CHANGELOG.md
+++ b/packages/whatsapp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-whatsapp
 
+## 1.0.2 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 1.0.1 - 10 July 2025
 
 ### Patch Changes

--- a/packages/whatsapp/package.json
+++ b/packages/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-whatsapp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenFn whatsapp adaptor",
   "type": "module",
   "exports": {

--- a/packages/wigal-sms/CHANGELOG.md
+++ b/packages/wigal-sms/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-wigal-sms
 
+## 0.1.10 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.1.9 - 10 July 2025
 
 ### Patch Changes

--- a/packages/wigal-sms/package.json
+++ b/packages/wigal-sms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-wigal-sms",
   "label": "Wigal SMS",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "OpenFn wigal-sms adaptor",
   "type": "module",
   "exports": {

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-zoho
 
+## 0.4.16 - 10 July 2025
+
+### Patch Changes
+
+- Updated dependencies \[cf9c09f]
+  - @openfn/language-common@3.0.1
+
 ## 0.4.15 - 10 July 2025
 
 ### Patch Changes

--- a/packages/zoho/package.json
+++ b/packages/zoho/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-zoho",
   "label": "Zoho",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "zoho Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,7 +588,7 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@openfn/language-fhir':
-        specifier: ^5.0.5
+        specifier: ^5.0.6
         version: link:../fhir
       '@types/fhir':
         specifier: ^0.0.41


### PR DESCRIPTION
## Summary

This PR fixes an issue where sometimes parsing an empty response body as JSON can lead to an exception.

This is particularly hurting is in OpenCRVS, where responses do not have a `content-length` header on the auth endpoint.  This tricks our adaptor into thinking there's no body, and so ignoring it completely (returning undefined).

This PR improves the heuristic for detecting an empty body - which it turns out is really hard if the server doesn't explicitly report the body length.

The fix is:
- If the server sends a `content-length`, great! Use that.
- If the server sends a `content-type`, it should really only be doing that if there's a body. So assume there is.

This is inspired by advice from unidici: https://github.com/nodejs/undici/pull/1516/files

So far as I can tell the actual fix is fine - the real problem is that so many unit tests break. Because we're now very reliant on headers and most of our mocks don't include headers.

I've managed to work out a fix in the mock client which will automatically set the content-type header where appropriate. This gets most tests passing again. A few other tests are fixed manually.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
