### PR TITLE
common: fix breaking set import in common

### DIFF
--- a/packages/common/src/http.js
+++ b/packages/common/src/http.js
@@ -1,7 +1,7 @@
-import pkg from 'lodash';
+import _ from 'lodash';
 import { request, expandReferences } from './util';
 
-const { set } = pkg;
+const { set } = _;
 /**
  * Helper functions provided by `http.options`.
  * @typedef OptionsHelpers


### PR DESCRIPTION
## Summary

Fix breaking import of `set` from lodash in common.

Fixes #

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
