### PR TITLE
chatgpt: add `deepResearch()` function and remove `reasoning_effort`

### DIFF
--- a/.changeset/weak-rings-laugh.md
+++ b/.changeset/weak-rings-laugh.md
@@ -3,3 +3,4 @@
 ---
 
 Add a `deepResearch()` function that calls to GPT's deep research models
+Remove defaulted `reasoning_effort` from `prompt()`

--- a/.changeset/weak-rings-laugh.md
+++ b/.changeset/weak-rings-laugh.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-chatgpt': major
+---
+
+Add a `deepResearch()` function that calls to GPT's deep research models

--- a/packages/chatgpt/ast.json
+++ b/packages/chatgpt/ast.json
@@ -52,6 +52,59 @@
         ]
       },
       "valid": false
+    },
+    {
+      "name": "deepResearch",
+      "params": [
+        "message",
+        "opts"
+      ],
+      "docs": {
+        "description": "Prompt GPT deep research interface",
+        "tags": [
+          {
+            "title": "example",
+            "description": "prompt(`Filter these emails and pick out the most urgent: ${JSON.stringify($.data)}`);"
+          },
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "The prompt",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "message"
+          },
+          {
+            "title": "param",
+            "description": "Model, Response Form and other parameters (https://platform.openai.com/docs/guides/deep-research)",
+            "type": {
+              "type": "NameExpression",
+              "name": "DeepResearchOptions"
+            },
+            "name": "options"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "operation"
+            }
+          }
+        ]
+      },
+      "valid": false
     }
   ],
   "exports": [],

--- a/packages/chatgpt/package.json
+++ b/packages/chatgpt/package.json
@@ -30,13 +30,13 @@
   ],
   "dependencies": {
     "@openfn/language-common": "workspace:*",
-    "openai": "^4.86.2"
+    "openai": "^4.104.0"
   },
   "devDependencies": {
     "assertion-error": "2.0.0",
     "chai": "4.3.6",
     "deep-eql": "4.1.1",
-    "mocha": "^10.7.3",
+    "mocha": "^10.8.2",
     "rimraf": "3.0.2",
     "undici": "^5.29.0"
   },

--- a/packages/chatgpt/src/Adaptor.js
+++ b/packages/chatgpt/src/Adaptor.js
@@ -13,6 +13,15 @@ import OpenAI from 'openai';
  * @property {string} reasoning_effort - Use `low`, `medium`, or `high` to constrain effort on reasoning for some models.
  */
 
+/**
+ * Options provided to Chat Responses Create (https://platform.openai.com/docs/guides/deep-research)
+ * @typedef {Object} DeepResearchOptions
+ * @public
+ * @property {string} model - Which mode to use, i.e., `o3-deep-research`.
+ * @property {string} tools - An array of tools to use for the search. Default [{"type": "web_search_preview"}] See (https://platform.openai.com/docs/guides/deep-research#tools)
+ * @property {number} max_tool_calls - The maximum number of tool calls to make. Default: 1
+ */
+
 let client;
 
 /**
@@ -84,6 +93,54 @@ export function prompt(message, opts) {
     };
 
     const msg = await client.chat.completions.create(payload);
+    return composeNextState(state, msg);
+  };
+}
+
+/**
+ * Prompt GPT deep research interface
+ * @example
+ * deepResearch(
+ *   `Verify if this healthcare facility is legitimate:
+ *    INPUT: ${JSON.stringify($.data)}
+ *
+ *   Return JSON only with:
+ *   - siteVerificationStatus: "Pre-Approved" or "Declined"
+ *   - orgType: "government", "private", etc.
+ *   - fundingStatus
+ *   - confidenceLevel (0–5)
+ *   - siteVerificationNotes`,
+ *   {
+ *     model: 'o3-deep-research',
+ *     max_tool_calls: 1
+ *   }
+ * )
+ * @public
+ * @function
+ * @param {string} message - The prompt
+ * @param {DeepResearchOptions} options - Model, tools and other parameters (https://platform.openai.com/docs/guides/deep-research)
+ * @returns {operation}
+ */
+export function deepResearch(message, opts) {
+  return async state => {
+    const [resolvedMessage, resolvedOpts] = expandReferences(
+      state,
+      message,
+      opts
+    );
+
+    const payload = {
+      model: 'o3-deep-research',
+      input: resolvedMessage,
+      tools: [{ type: 'web_search_preview' }, ...(resolvedOpts?.tools || [])],
+      max_tool_calls: resolvedOpts?.max_tool_calls || 1,
+      ...resolvedOpts,
+    };
+
+    console.log('Preparing deep search operation...');
+    const msg = await client.responses.create(payload);
+    console.log('√ Deep search operation completed');
+
     return composeNextState(state, msg);
   };
 }

--- a/packages/chatgpt/src/Adaptor.js
+++ b/packages/chatgpt/src/Adaptor.js
@@ -10,7 +10,6 @@ import OpenAI from 'openai';
  * @typedef {Object} PromptOptions
  * @public
  * @property {string} model - Which mode to use, i.e., `o3-mini-2025-01-31`.
- * @property {string} reasoning_effort - Use `low`, `medium`, or `high` to constrain effort on reasoning for some models.
  */
 
 /**
@@ -87,12 +86,12 @@ export function prompt(message, opts) {
 
     const payload = {
       model: 'o3-mini-2025-01-31',
-      reasoning_effort: 'low',
       messages: [{ role: 'user', content: resolvedMessage }],
       ...resolvedOpts,
     };
 
     const msg = await client.chat.completions.create(payload);
+    console.log('√ Prompt operation completed');
     return composeNextState(state, msg);
   };
 }

--- a/packages/chatgpt/test/Adaptor.test.js
+++ b/packages/chatgpt/test/Adaptor.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { prompt, setMockClient } from '../src/Adaptor.js';
+import { prompt, setMockClient, deepResearch } from '../src/Adaptor.js';
 import testData from "./fixtures/fixture.json" assert {type: 'json'};
 
 
@@ -34,5 +34,36 @@ describe('prompt', () => {
     const finalState = await prompt('Write a poem about surfing.')(state);
 
     expect(finalState.data).to.eql(testData.response);
+  });
+});
+
+describe('deep research', () => {
+  it('sends a deep research post request to OpenAI', async () => {
+    // Setup a mock endpoint
+
+    const mock = {
+ 
+        responses: {
+          create: ({ model, input , tools}) => {
+            expect(model).to.eql('o3-deep-research');
+            expect(input).to.eql('Give a list of all newly registered healthcare facilities in the last 30 days.');
+            expect(tools).to.eql([{ type: 'web_search_preview' }]);
+
+            return testData.deep_research_response
+          }
+        }
+    };
+
+    const state = {
+      configuration: {
+        apiKey: 'secret',
+      },
+    };
+
+    setMockClient(mock)
+
+    const finalState = await deepResearch('Give a list of all newly registered healthcare facilities in the last 30 days.')(state);
+
+    expect(finalState.data).to.eql(testData.deep_research_response);
   });
 });

--- a/packages/chatgpt/test/fixtures/fixture.json
+++ b/packages/chatgpt/test/fixtures/fixture.json
@@ -25,5 +25,40 @@
         "index": 0
       }
     ]
+  },
+  "deep_research_response": {
+    "id": "res_testid1",
+    "object": "response",
+    "created_at": 1753344791,
+    "status": "completed",
+    "max_tool_calls": 1,
+    "model": "o3-deep-research-2025-06-26",
+    "reasoning": {
+      "effort": "medium",
+      "summary": null
+    },
+    "safety_identifier": null,
+    "service_tier": "default",
+    "store": true,
+    "temperature": 1,
+    "text": {
+      "format": {
+        "type": "text"
+      }
+    },
+    "tool_choice": "auto",
+    "tools": [
+      {
+        "type": "web_search_preview",
+        "search_context_size": "medium",
+        "user_location": null
+      }
+    ],
+    "top_logprobs": 0,
+    "top_p": 1,
+    "truncation": "disabled",
+    "user": null,
+    "metadata": {},
+    "output_text": "\n\nThis is a deep research test!"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,8 +200,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       openai:
-        specifier: ^4.86.2
-        version: 4.86.2
+        specifier: ^4.104.0
+        version: 4.104.0
     devDependencies:
       assertion-error:
         specifier: 2.0.0
@@ -213,8 +213,8 @@ importers:
         specifier: 4.1.1
         version: 4.1.1
       mocha:
-        specifier: ^10.7.3
-        version: 10.7.3
+        specifier: ^10.8.2
+        version: 10.8.2
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
@@ -546,7 +546,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.11.11)(@types/node@18.17.5)(typescript@4.8.4)
+        version: 10.9.1(@swc/core@1.11.11)(@types/node@24.1.0)(typescript@4.8.4)
       typescript:
         specifier: 4.8.4
         version: 4.8.4
@@ -2312,7 +2312,7 @@ importers:
         version: 9.1.1
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.11.11)(@types/node@18.17.5)(typescript@4.8.4)
+        version: 10.9.1(@types/node@18.17.5)(typescript@4.8.4)
       tsup:
         specifier: 6.3.0
         version: 6.3.0(ts-node@10.9.1)(typescript@4.8.4)
@@ -2354,7 +2354,7 @@ importers:
         version: 9.2.16
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.11.11)(@types/node@18.17.5)(typescript@4.8.4)
+        version: 10.9.1(@types/node@18.17.5)(typescript@4.8.4)
       tsup:
         specifier: 6.3.0
         version: 6.3.0(ts-node@10.9.1)(typescript@4.8.4)
@@ -2405,7 +2405,7 @@ importers:
         version: 1.9.1
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.11.11)(@types/node@18.17.5)(typescript@4.8.4)
+        version: 10.9.1(@types/node@18.17.5)(typescript@4.8.4)
       tsup:
         specifier: 6.3.0
         version: 6.3.0(ts-node@10.9.1)(typescript@4.8.4)
@@ -2441,7 +2441,7 @@ importers:
         version: 4.17.21
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.11.11)(@types/node@18.17.5)(typescript@4.8.4)
+        version: 10.9.1(@types/node@18.17.5)(typescript@4.8.4)
       typescript:
         specifier: 4.8.4
         version: 4.8.4
@@ -2465,7 +2465,7 @@ importers:
         version: 8.0.0
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.11.11)(@types/node@18.17.5)(typescript@4.8.4)
+        version: 10.9.1(@types/node@18.17.5)(typescript@4.8.4)
       typedoc:
         specifier: ^0.23.26
         version: 0.23.26(typescript@4.8.4)
@@ -5598,6 +5598,13 @@ packages:
       form-data: 4.0.0
     dev: false
 
+  /@types/node-fetch@2.6.12:
+    resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
+    dependencies:
+      '@types/node': 18.19.120
+      form-data: 4.0.4
+    dev: false
+
   /@types/node@10.17.60:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
     dev: false
@@ -5608,6 +5615,17 @@ packages:
 
   /@types/node@18.17.5:
     resolution: {integrity: sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA==}
+
+  /@types/node@18.19.120:
+    resolution: {integrity: sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: false
+
+  /@types/node@24.1.0:
+    resolution: {integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==}
+    dependencies:
+      undici-types: 7.8.0
 
   /@types/node@8.10.66:
     resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
@@ -7220,6 +7238,13 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
+    dev: false
+
+  /brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: true
 
   /braces@1.8.5:
     resolution: {integrity: sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==}
@@ -7306,7 +7331,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001727
-      electron-to-chromium: 1.5.187
+      electron-to-chromium: 1.5.190
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
     dev: false
@@ -7414,6 +7439,14 @@ packages:
         optional: true
     dependencies:
       array-back: 6.2.2
+    dev: false
+
+  /call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
     dev: false
 
   /call-bind@1.0.2:
@@ -8337,6 +8370,19 @@ packages:
       ms: 2.1.3
       supports-color: 8.1.1
 
+  /debug@4.4.1(supports-color@8.1.1):
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+      supports-color: 8.1.1
+    dev: true
+
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
     engines: {node: '>=0.10.0'}
@@ -8671,6 +8717,15 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    dev: false
+
   /duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
     dependencies:
@@ -8720,8 +8775,8 @@ packages:
     resolution: {integrity: sha512-EML1wnwkY5MFh/xUnCvY8FrhUuKzdYhowuZExZOfwJo+Zu9OsNCI23Cgl5y7awy7HrUHSwB1Z8pZX5TI34lsUg==}
     dev: false
 
-  /electron-to-chromium@1.5.187:
-    resolution: {integrity: sha512-cl5Jc9I0KGUoOoSbxvTywTa40uspGJt/BDBoDLoxJRSBpWh4FFXBsjNRHfQrONsV/OoEjDfHUmZQa2d6Ze4YgA==}
+  /electron-to-chromium@1.5.190:
+    resolution: {integrity: sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==}
     dev: false
 
   /emittery@1.0.1:
@@ -8861,12 +8916,24 @@ packages:
     dependencies:
       get-intrinsic: 1.2.4
 
+  /es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
   /es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+    dev: false
+
+  /es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
     dev: false
 
   /es-set-tostringtag@2.0.1:
@@ -8877,6 +8944,16 @@ packages:
       has: 1.0.3
       has-tostringtag: 1.0.0
     dev: true
+
+  /es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+    dev: false
 
   /es-shim-unscopables@1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
@@ -9922,6 +9999,17 @@ packages:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
+  /form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+    dev: false
+
   /formatio@1.1.1:
     resolution: {integrity: sha512-cPh7is6k3d8tIUh+pnXXuAbD/uhSXGgqLPw0UrYpv5lfdJ+MMMSjx40JNpqP7Top9Nt25YomWEiRmkHbOvkCaA==}
     deprecated: This package is unmaintained. Use @sinonjs/formatio instead
@@ -10125,9 +10213,33 @@ packages:
       has-symbols: 1.0.3
       hasown: 2.0.2
 
+  /get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+    dev: false
+
   /get-port@3.2.0:
     resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
     engines: {node: '>=4'}
+    dev: false
+
+  /get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
     dev: false
 
   /get-stream@6.0.1:
@@ -10359,6 +10471,11 @@ packages:
     dependencies:
       get-intrinsic: 1.2.4
 
+  /gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     requiresBuild: true
@@ -10466,12 +10583,24 @@ packages:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
 
+  /has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
   /has-tostringtag@1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
     dev: true
+
+  /has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-symbols: 1.1.0
+    dev: false
 
   /has-value@0.3.1:
     resolution: {integrity: sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==}
@@ -11273,7 +11402,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.17.5
+      '@types/node': 24.1.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -12151,6 +12280,11 @@ packages:
       escape-string-regexp: 5.0.0
     dev: false
 
+  /math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
   /math-random@1.0.4:
     resolution: {integrity: sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==}
     requiresBuild: true
@@ -12556,7 +12690,7 @@ packages:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
     dev: true
 
   /minimatch@7.4.1:
@@ -12667,7 +12801,7 @@ packages:
       ansi-colors: 4.1.3
       browser-stdout: 1.3.1
       chokidar: 3.6.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@8.1.1)
       diff: 5.2.0
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
@@ -12935,6 +13069,18 @@ packages:
       whatwg-url: 5.0.0
     dev: false
 
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
   /node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
@@ -13135,8 +13281,8 @@ packages:
       is-wsl: 2.2.0
     dev: false
 
-  /openai@4.86.2:
-    resolution: {integrity: sha512-nvYeFjmjdSu6/msld+22JoUlCICNk/lUFpSMmc6KNhpeNLpqL70TqbD/8Vura/tFmYqHKW0trcjgPwUpKSPwaA==}
+  /openai@4.104.0:
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -13147,13 +13293,13 @@ packages:
       zod:
         optional: true
     dependencies:
-      '@types/node': 18.17.5
-      '@types/node-fetch': 2.6.10
+      '@types/node': 18.19.120
+      '@types/node-fetch': 2.6.12
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
-      node-fetch: 2.6.9
+      node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -13646,7 +13792,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      ts-node: 10.9.1(@swc/core@1.11.11)(@types/node@18.17.5)(typescript@4.8.4)
+      ts-node: 10.9.1(@types/node@18.17.5)(typescript@4.8.4)
       yaml: 1.10.2
     dev: false
 
@@ -15695,7 +15841,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: false
 
-  /ts-node@10.9.1(@swc/core@1.11.11)(@types/node@18.17.5)(typescript@4.8.4):
+  /ts-node@10.9.1(@swc/core@1.11.11)(@types/node@24.1.0)(typescript@4.8.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -15715,6 +15861,37 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
+      '@types/node': 24.1.0
+      acorn: 8.14.1
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.8.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /ts-node@10.9.1(@types/node@18.17.5)(typescript@4.8.4):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
       '@types/node': 18.17.5
       acorn: 8.14.1
       acorn-walk: 8.2.0
@@ -15725,6 +15902,7 @@ packages:
       typescript: 4.8.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /tsconfig-paths@3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
@@ -15991,6 +16169,13 @@ packages:
   /underscore@1.8.2:
     resolution: {integrity: sha512-CHzhycUy6eSLBV/Yksw4nSDIcsNAsdAExaSILTOSvZkfmymBxxrvnrUGoFJSYEUJvEe8C/p8a5Cs844mtwgNOw==}
     dev: false
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: false
+
+  /undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
   /undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}


### PR DESCRIPTION
## Summary

Add `deepResearch()` function for GPT deep research models
Remove `reasoning_effort` from `prompt()`. Fails with current models `4o`

Fixes #1298 

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
