### PR TITLE
OpenMRS: Add `put()` helper and fix a docs issue

### DIFF
--- a/.changeset/famous-crabs-fold.md
+++ b/.changeset/famous-crabs-fold.md
@@ -1,6 +1,0 @@
----
-'@openfn/language-openmrs': minor
----
-
-- Add `http.put()` helper function
-- Fix docs on `http.request()`

--- a/.changeset/famous-crabs-fold.md
+++ b/.changeset/famous-crabs-fold.md
@@ -1,0 +1,6 @@
+---
+'@openfn/language-openmrs': minor
+---
+
+- Add `http.put()` helper function
+- Fix docs on `http.request()`

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openmrs
 
+## 5.3.0 - 25 July 2025
+
+### Minor Changes
+
+- 5c12ab4: - Add `http.put()` helper function
+  - Fix docs on `http.request()`
+
 ## 5.2.2 - 14 July 2025
 
 ### Patch Changes

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openmrs",
   "label": "OpenMRS",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "description": "OpenFn adaptor for OpenMRS",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openmrs/src/http.js
+++ b/packages/openmrs/src/http.js
@@ -15,7 +15,7 @@ import * as util from './Utils';
  * @typedef {Object} HTTPRequestOptions
  * @property {object} query - An object of query parameters to be encoded into the URL
  * @property {object} headers - An object of all request headers
- * @property {object} body - The request body (as JSON)
+ * @property {object} data - The request body (as JSON)
  * @property {object|boolean} errors - Pass `false` to not throw on errors. Pass a map of errorCodes: error messages, ie, `{ 404: 'Resource not found' }`, or `false` to suppress errors for a specific code.
  * @property {string} [parseAs='json'] - The response format to parse (e.g., 'json', 'text', or 'stream')
  */
@@ -30,6 +30,11 @@ import * as util from './Utils';
  *       startIndex: 20
  *    },
  * });
+ * @example <caption>PUT request with a payload</caption>
+ * http.request("PUT",
+ *   "/ws/rest/v1/patient/d3f7e1a8-0114-4de6-914b-41a11fc8a1a8",
+ *   { data: $.resource },
+ * );
  * @function
  * @public
  * @param {string} method - HTTP method to use

--- a/packages/openmrs/src/http.js
+++ b/packages/openmrs/src/http.js
@@ -156,6 +156,57 @@ export function post(path, data, options = {}) {
 }
 
 /**
+ * Make a PUT request to an OpenMRS endpoint
+ * @public
+ * @function
+ * @example <caption>Put with a JSON payload</caption>
+ * http.put(
+ *  "/ws/rest/v1/patient",
+ *  {
+ *      "person": {
+ *      "gender":"M",
+ *      "age":47,
+ *      "birthdate":"1970-01-01T00:00:00.000+0100",
+ *      "names":[
+ *        {
+ *          "givenName":"Jon",
+ *          "familyName":"Snow"
+ *        }
+ *      ],
+ *    }
+ *    }
+ * )
+ * @param {string} path - path to resource
+ * @param {any} data - the payload
+ * @param {HTTPRequestOptions} [options={}] - An object containing query params and headers for the request
+ * @state {HttpState}
+ * @returns {operation}
+ */
+export function put(path, data, options = {}) {
+  return async state => {
+    const [resolvedPath, resolvedData, resolvedOptions] = expandReferences(
+      state,
+      path,
+      data,
+      options
+    );
+
+    const optionsObject = {
+      data: resolvedData,
+      ...resolvedOptions,
+    };
+    const response = await util.request(
+      state,
+      'PUT',
+      resolvedPath,
+      optionsObject
+    );
+
+    return util.prepareNextState(state, response);
+  };
+}
+
+/**
  * Make a DELETE request to an OpenMRS endpoint
  * @alias delete
  * @public

--- a/packages/openmrs/test/http.test.js
+++ b/packages/openmrs/test/http.test.js
@@ -172,6 +172,27 @@ describe('http.post', () => {
   });
 });
 
+describe('http.put', () => {
+  beforeEach(() => {
+    testServer
+      .intercept({
+        path: '/ws/rest/v1/patient',
+        method: 'PUT',
+        data: testData.newPatient,
+      })
+      .reply(200, { results: testData.patientResults }, { ...jsonHeaders });
+  });
+
+  it('should make http request with the PUT verb', async () => {
+    const response = await http.put(
+      '/ws/rest/v1/patient',
+      testData.newPatient
+    )(state);
+    expect(response.response.statusCode).to.eql(200);
+    expect(response.response.method).to.eql('PUT');
+  });
+});
+
 describe('http.delete', () => {
   beforeEach(() => {
     // Basic patient query interceptor

--- a/packages/openmrs/test/utils.test.js
+++ b/packages/openmrs/test/utils.test.js
@@ -506,7 +506,7 @@ describe('requestWithPagination', () => {
     console.warn = warn;
   });
 
-  it('should nod warn if the a custom max limit is hit', async () => {
+  it('should not warn if the a custom max limit is hit', async () => {
     const oldDb = db;
     const warn = console.warn;
 


### PR DESCRIPTION
## Summary

Add a `put() ` helper function and fix an issue in docs, which wrongly claimed that `options.body` should be used to upload data via `http.request`

Fixes #1302

Added a very basic test of the PUT functionality.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
