### PR TITLE
remove `http` exports from common

### DIFF
--- a/packages/asana/src/Adaptor.js
+++ b/packages/asana/src/Adaptor.js
@@ -375,7 +375,6 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,

--- a/packages/azure-storage/src/Adaptor.js
+++ b/packages/azure-storage/src/Adaptor.js
@@ -240,7 +240,6 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,

--- a/packages/bigquery/src/Adaptor.js
+++ b/packages/bigquery/src/Adaptor.js
@@ -125,7 +125,6 @@ export {
   each,
   field,
   fields,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -462,7 +462,6 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   map,
   merge,

--- a/packages/dhis2/src/Adaptor.js
+++ b/packages/dhis2/src/Adaptor.js
@@ -661,7 +661,6 @@ export {
   fn,
   fnIf,
   group,
-  http,
   lastReferenceValue,
   map,
   merge,

--- a/packages/gmail/src/Adaptor.js
+++ b/packages/gmail/src/Adaptor.js
@@ -239,7 +239,6 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,

--- a/packages/googledrive/src/Adaptor.js
+++ b/packages/googledrive/src/Adaptor.js
@@ -184,7 +184,6 @@ export {
   as,
   fn,
   fnIf,
-  http,
   util,
   each,
   field,

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -244,7 +244,6 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -791,10 +791,9 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   cursor,
   merge,
   sourceValue,
-  as
+  as,
 } from '@openfn/language-common';

--- a/packages/odoo/src/Adaptor.js
+++ b/packages/odoo/src/Adaptor.js
@@ -223,7 +223,6 @@ export {
   field,
   fields,
   fn,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,

--- a/packages/openimis/src/Adaptor.js
+++ b/packages/openimis/src/Adaptor.js
@@ -115,9 +115,8 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,
-  as
+  as,
 } from '@openfn/language-common';

--- a/packages/openspp/src/Adaptor.js
+++ b/packages/openspp/src/Adaptor.js
@@ -1035,7 +1035,6 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,

--- a/packages/postgresql/src/Adaptor.js
+++ b/packages/postgresql/src/Adaptor.js
@@ -765,10 +765,9 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   group,
   lastReferenceValue,
   merge,
   sourceValue,
-  as
+  as,
 } from '@openfn/language-common';

--- a/packages/primero/src/Adaptor.js
+++ b/packages/primero/src/Adaptor.js
@@ -913,9 +913,8 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,
-  as
+  as,
 } from '@openfn/language-common';

--- a/packages/satusehat/src/Adaptor.js
+++ b/packages/satusehat/src/Adaptor.js
@@ -211,7 +211,6 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   map,
   merge,

--- a/packages/sftp/src/Adaptor.js
+++ b/packages/sftp/src/Adaptor.js
@@ -273,7 +273,6 @@ export {
   each,
   field,
   fields,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,

--- a/packages/twilio/src/Adaptor.js
+++ b/packages/twilio/src/Adaptor.js
@@ -44,7 +44,7 @@ export function sendSMS(params) {
   return state => {
     const { accountSid, authToken } = state.configuration;
     const [resolvedParams] = expandReferences(state, params);
-    const {body, from, to} = resolvedParams;
+    const { body, from, to } = resolvedParams;
 
     const client = require('twilio')(accountSid, authToken);
 
@@ -74,7 +74,6 @@ export {
   alterState,
   fn,
   fnIf,
-  http,
   each,
   merge,
   dataPath,

--- a/packages/varo/src/Adaptor.js
+++ b/packages/varo/src/Adaptor.js
@@ -179,7 +179,6 @@ export {
   fields,
   fn,
   fnIf,
-  http,
   lastReferenceValue,
   merge,
   sourceValue,


### PR DESCRIPTION
## Summary

This PR removes `http` exports from `@openfn/language-common`

Fixes #1269


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA:  If this is a new adaptor, added the adaptor on marketing website ?
- [x] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
