### PR TITLE
 pdfShift: QA fixes

### DIFF
--- a/.changeset/seven-spoons-search.md
+++ b/.changeset/seven-spoons-search.md
@@ -1,0 +1,7 @@
+---
+'@openfn/language-pdfshift': patch
+---
+
+- Format response to `json` when `filename` option is passed.
+- Make `generatePDF()` function public
+

--- a/packages/pdfshift/ast.json
+++ b/packages/pdfshift/ast.json
@@ -1,6 +1,82 @@
 {
   "operations": [
     {
+      "name": "generatePDF",
+      "params": [
+        "htmlTemplateString",
+        "options"
+      ],
+      "docs": {
+        "description": "Generate a PDF from an HTML string.",
+        "tags": [
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "param",
+            "description": "A HTML string or url to convert to PDF",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "htmlTemplateString"
+          },
+          {
+            "title": "param",
+            "description": "Optional configuration for PDF generation",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "PDFBodyOptions"
+              }
+            },
+            "name": "options"
+          },
+          {
+            "title": "example",
+            "description": "generatePDF(\n`<html>\n  <body>\n    <h1>Sales Report</h1>\n    <p>Date: 2025-02-01</p>\n    <p>Total Sales: $42</p>\n  </body>\n</html>\n`);",
+            "caption": "Generate a PDF from a HTML string"
+          },
+          {
+            "title": "example",
+            "description": "generatePDF(\n`<html>\n  <body>\n    <h1>Sales Report</h1>\n    <p>Date: 2025-02-01</p>\n    <p>Total Sales: $42</p>\n  </body>\n</html>\n`, {\n  sandbox: true});",
+            "caption": "Generate a PDF with options"
+          },
+          {
+            "title": "example",
+            "description": "generatePDF('https://www.example.com/', {\n  sandbox: true,\n  encode: false,\n});",
+            "caption": "Generate a PDF from a url"
+          },
+          {
+            "title": "example",
+            "description": "generatePDF('https://www.example.com/', {\n sandbox: true,\n filename: 'example.pdf',\n});",
+            "caption": "Generate a PDF with a filename"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          },
+          {
+            "title": "state",
+            "description": "{HttpState}"
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "request",
       "params": [
         "method",
@@ -13,7 +89,7 @@
         "tags": [
           {
             "title": "example",
-            "description": "request(\n  'POST',\n  '/convert/pdf',\n   { source: $.html }\n);",
+            "description": "request(\n  'POST',\n  '/convert/pdf',\n   { source: $.html,\n     encode: true \n   },\n);",
             "caption": "Make a request to convert a HTML string to PDF"
           },
           {

--- a/packages/pdfshift/src/Adaptor.js
+++ b/packages/pdfshift/src/Adaptor.js
@@ -28,10 +28,14 @@ import * as util from './Utils';
  * @typedef {Object} PDFBodyOptions
  * @property {boolean} sandbox - Generates PDF documents in dev mode that doesn't count in the credits.
  * @property {boolean} encode - Return the generated PDF in Base64 encoded format, instead of raw. Defaults to `true`.
+ * @property {string} filename - Optional. Must be 7+ characters (letters, numbers, "-" or "_").
+ *   If set, the API returns a temporary S3 URL (file kept 2 days); otherwise, it returns a Base64 PDF.
  */
 
 /**
  * Generate a PDF from an HTML string.
+ * @function
+ * @public
  * @param {string} htmlTemplateString - A HTML string or url to convert to PDF
  * @param {PDFBodyOptions} [options] - Optional configuration for PDF generation
  * @example <caption>Generate a PDF from a HTML string</caption>
@@ -60,6 +64,11 @@ import * as util from './Utils';
  *   sandbox: true,
  *   encode: false,
  * });
+ * @example <caption>Generate a PDF with a filename</caption>
+ * generatePDF('https://www.example.com/', {
+ *  sandbox: true,
+ *  filename: 'example.pdf',
+ * });
  * @returns {Operation}
  * @state {HttpState}
  */
@@ -82,7 +91,7 @@ export function generatePDF(htmlTemplateString, options) {
           encode: true,
           ...resolvedOptions,
         },
-        parseAs: 'text',
+        parseAs: resolvedOptions?.filename ? 'json' : 'text',
       }
     );
 
@@ -95,7 +104,9 @@ export function generatePDF(htmlTemplateString, options) {
  * @typedef {Object} BodyOptions
  * @property {string} source - The HTML string or url to convert to PDF.
  * @property {boolean} sandbox - Generates PDF documents in dev mode that doesn't count in the credits.
- * @property {boolean} encode - Return the generated PDF in Base64 encoded format, instead of raw. Defaults to `true`
+ * @property {boolean} encode - Return the generated PDF in Base64 encoded format, instead of raw. Defaults to `true`.
+ * @property {string} filename - Optional. Must be 7+ characters (letters, numbers, "-" or "_").
+ *   If set, the API returns a temporary S3 URL (file kept 2 days); otherwise, it returns a Base64 PDF.
  */
 
 /**
@@ -104,7 +115,7 @@ export function generatePDF(htmlTemplateString, options) {
  * request(
  *   'POST',
  *   '/convert/pdf',
- *    { source: $.html }
+ *    { source: $.html },
  * );
  * @function
  * @public
@@ -125,8 +136,11 @@ export function request(method, path, body, options = {}) {
       resolvedMethod,
       resolvedPath,
       {
-        body: resolvedBody,
-        parseAs: 'text',
+        body: {
+          ...resolvedBody,
+          encode: resolvedoptions?.encode ?? true,
+        },
+        parseAs: resolvedoptions?.filename ? 'json' : 'text',
         ...resolvedoptions,
       }
     );

--- a/packages/pdfshift/test/Adaptor.test.js
+++ b/packages/pdfshift/test/Adaptor.test.js
@@ -132,4 +132,31 @@ describe('generatePDF', () => {
     expect(data).to.eql('JVBERi0xLjQKJeLjz9MKMSAwIG9');
     expect(data).to.includes('JVBERi0x');
   });
+  it('generates pdf as a hosted url', async () => {
+    const state = {
+      configuration,
+    };
+    testServer
+      .intercept({
+        path: '/v3/convert/pdf',
+        method: 'POST',
+        headers: {
+          'x-api-key': 'some-api-key',
+        },
+      })
+      .reply(200, {
+        success: true,
+        url: 'https://pdfshift.s3.amazonaws.com/d/2/2025-08/c304bea9a791446896d39e287234c345/example.pdf',
+        filesize: 50023,
+        duration: 2248,
+      });
+
+    const { data } = await generatePDF('https://www.example.com/', {
+      filename: 'example.pdf',
+    })(state);
+    expect(data.url).to.eql(
+      'https://pdfshift.s3.amazonaws.com/d/2/2025-08/c304bea9a791446896d39e287234c345/example.pdf'
+    );
+    expect(data.filesize).to.eql(50023);
+  });
 });


### PR DESCRIPTION
## Summary

Parse response when `filename` is provided.
Make `generatePDF()` function public.
Document `filename` behavior

Fixes #1338 

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
