### PR TITLE
`mssql` removed `rowCollectionOnRequestCompletion` from configuration

### DIFF
--- a/.changeset/kind-pets-film.md
+++ b/.changeset/kind-pets-film.md
@@ -1,9 +1,0 @@
----
-'@openfn/language-mssql': patch
----
-
-Optimize query handling by:
-
-- Revert to using `tedious.Request's callback` signature
-- Remove `rowCollectionOnRequestCompletion` option from configuration
-- Improve error messaging for `AggregateError` errors

--- a/.changeset/kind-pets-film.md
+++ b/.changeset/kind-pets-film.md
@@ -1,0 +1,9 @@
+---
+'@openfn/language-mssql': patch
+---
+
+Optimize query handling by:
+
+- Revert to using `tedious.Request's callback` signature
+- Remove `rowCollectionOnRequestCompletion` option from configuration
+- Improve error messaging for `AggregateError` errors

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @openfn/language-mssql
 
+## 6.0.1 - 26 August 2025
+
+### Patch Changes
+
+- d737f89: Optimize query handling by:
+
+  - Revert to using `tedious.Request's callback` signature
+  - Remove `rowCollectionOnRequestCompletion` option from configuration
+  - Improve error messaging for `AggregateError` errors
+
 ## 6.0.0 - 11 August 2025
 
 ### Major Changes

--- a/packages/mssql/configuration-schema.json
+++ b/packages/mssql/configuration-schema.json
@@ -55,13 +55,6 @@
         false
       ]
     },
-    "rowCollectionOnRequestCompletion": {
-      "type": "boolean",
-      "default": true,
-      "examples": [
-        false
-      ]
-    },
     "trustServerCertificate": {
       "type": "boolean",
       "default": true,

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mssql",
   "label": "MSSQL",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -273,7 +273,7 @@ export function findValue(filter) {
     try {
       const body = `select ${uuid} from ${relation} ${condition}`;
       console.log('Preparing to execute sql statement');
-
+      let returnValue = null;
       return new Promise((resolve, reject) => {
         console.log(`Executing query: ${body}`);
 
@@ -331,7 +331,7 @@ export function insert(table, record, options) {
         ', '
       )}) VALUES [--REDACTED--]];`;
 
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         const queryToLog = options && options.logValues ? query : safeQuery;
         console.log(`Executing insert via: ${queryToLog}`);
 
@@ -379,7 +379,7 @@ export function insertMany(table, records, options) {
         ', '
       )}) VALUES [--REDACTED--]];`;
 
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         const queryToLog = options && options.logValues ? query : safeQuery;
         console.log(`Executing insertMany via: ${queryToLog}`);
 
@@ -452,7 +452,7 @@ export function upsert(table, uuid, record, options) {
         WHEN NOT MATCHED THEN
           INSERT (${insertColumns}) VALUES [--REDACTED--];`;
 
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         const queryToLog = options && options.logValues ? query : safeQuery;
         console.log(`Executing upsert via: ${queryToLog}`);
 
@@ -493,7 +493,7 @@ export function upsertIf(logical, table, uuid, record, options) {
       const columns = Object.keys(recordData).sort();
       const [logicalData] = expandReferences(state, logical);
 
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         if (!logicalData) {
           console.log(`Skipping upsert for ${uuid}.`);
           resolve(state);
@@ -574,7 +574,7 @@ export function upsertMany(table, uuid, records, options) {
     try {
       const [recordData] = expandReferences(state, records);
 
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         if (!recordData || recordData.length === 0) {
           console.log('No records provided; skipping upsert.');
           resolve(state);
@@ -687,7 +687,7 @@ export function insertTable(tableName, columns, options) {
     try {
       const [data] = expandReferences(state, columns);
 
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         if (!data || data.length === 0) {
           console.log('No columns provided; skipping table creation.');
           resolve(state);
@@ -747,7 +747,7 @@ export function modifyTable(tableName, columns, options) {
     try {
       const [data] = expandReferences(state, columns);
 
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         if (!data || data.length === 0) {
           console.log('No columns provided; skipping table modification.');
           resolve(state);

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -161,8 +161,9 @@ function queryHandler(state, query, callback, options) {
 
     const request = new Request(query, (err, rowCount, rows) => {
       if (err) {
-        console.error(err);
+        err.errors.map(error => console.error('Error: ', error.message));
         reject(err);
+        return;
       } else {
         console.log(`Finished: ${rowCount} row(s).`);
         resolve(callback(state, rows));

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -160,13 +160,12 @@ function queryHandler(state, query, callback, options) {
       }
     }
 
-    const rows = [];
-    const request = new Request(query, err => {
+    const request = new Request(query, (err, rowCount, rows) => {
       if (err) {
         console.error(err);
         reject(err);
       } else {
-        console.log(`Finished: ${rows.length} row(s).`);
+        console.log(`Finished: ${rowCount} row(s).`);
         resolve(callback(state, rows));
       }
     });

--- a/packages/mssql/src/Adaptor.js
+++ b/packages/mssql/src/Adaptor.js
@@ -161,7 +161,11 @@ function queryHandler(state, query, callback, options) {
 
     const request = new Request(query, (err, rowCount, rows) => {
       if (err) {
-        err.errors.map(error => console.error('Error: ', error.message));
+        if (err.name === 'AggregateError' && err.errors) {
+          err.errors.map(error => console.error('Error: ', error.message));
+        } else {
+          console.error(err);
+        }
         reject(err);
         return;
       } else {

--- a/packages/mssql/test/integration.js
+++ b/packages/mssql/test/integration.js
@@ -11,7 +11,7 @@
 //            --name sqledge \
 //            -d mcr.microsoft.com/azure-sql-edge
 
-import { execute, sql, findValue } from '../src/Adaptor';
+import { execute, sql, findValue, insert, insertMany } from '../src/Adaptor';
 import { expect } from 'chai';
 
 describe('MSSQL Integration Tests', () => {
@@ -177,6 +177,21 @@ describe('MSSQL Integration Tests', () => {
       }
       throw error;
     }
+  });
+  it('should insert a record', async () => {
+    const result = await execute(
+      insert('test_users', { name: 'John Doe', email: 'john@example.com' })
+    )(state);
+    expect(result).to.equal(1);
+  });
+  it('should insert multiple records', async () => {
+    const result = await execute(
+      insertMany('test_users', [
+        { name: 'John Doe', email: 'john@example.com' },
+        { name: 'Jane Smith', email: 'jane@example.com' },
+      ])
+    )(state);
+    expect(result).to.equal(2);
   });
 
   after(async () => {


### PR DESCRIPTION
## Summary

Removed `rowCollectionOnRequestCompletion` option from configuration and and reverted `tedious.Request` to include `rows` in `callback`. Also improved `AggregateError` message

Fixes #1337, #1326

## Details

- Reverted how `tedious.Request` is used to rely on its built-in row collection callback.
- Remove `rowCollectionOnRequestCompletion` from `state.configuration` and configuration schema
- Enabled `config.options.rowCollectionOnRequestCompletion = true` to ensure all rows are returned directly in the request completion callback.
- Add integration test for `insert` and `insertMany`. This helped me confirm the `queryHandler` function is still working as expected
- Improve `AggregateError` error message
- Remove unused `reject` param

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA: If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
