### PR TITLE
adaptors: fix ast for pdfshift

### DIFF
--- a/packages/pdfshift/ast.json
+++ b/packages/pdfshift/ast.json
@@ -89,7 +89,7 @@
         "tags": [
           {
             "title": "example",
-            "description": "request(\n  'POST',\n  '/convert/pdf',\n   { source: $.html,\n     encode: true \n   },\n);",
+            "description": "request(\n  'POST',\n  '/convert/pdf',\n   { source: $.html },\n);",
             "caption": "Make a request to convert a HTML string to PDF"
           },
           {


### PR DESCRIPTION
## Summary

Fix the failing `ast.json` file during publish for `pdfshift`



## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
