### PR TITLE
kobotoolbox: Update `http.request` body description

### DIFF
--- a/.changeset/thick-carrots-care.md
+++ b/.changeset/thick-carrots-care.md
@@ -2,4 +2,4 @@
 '@openfn/language-kobotoolbox': patch
 ---
 
-Update `http.request` to use `data` instead of `body` in requests
+Update `http.request` option docs to use `data` instead of `body` in requests

--- a/.changeset/thick-carrots-care.md
+++ b/.changeset/thick-carrots-care.md
@@ -3,3 +3,36 @@
 ---
 
 Update `http.request` option docs to use `data` instead of `body` in requests
+
+
+### Migration Guide
+- The `http.request()` function now uses `data` in stead of `body` for the body data.
+
+#### Before 
+
+```
+http.request('PATCH', `assets/aDReHdA7UuNBYsiCXQBr43/data/bulk/`, {
+  body: {
+    submission_ids: ['aDReHdA7UuNBYsiCXQBr43'],
+    data: {
+      Transaction_status: 'success',
+    },
+  },
+});
+
+```
+
+#### Now
+
+```
+http.request('PATCH', `assets/aDReHdA7UuNBYsiCXQBr43/data/bulk/`, {
+  data: {
+    submission_ids: ['aDReHdA7UuNBYsiCXQBr43'],
+    data: {
+      Transaction_status: 'success',
+    },
+  },
+});
+
+```
+

--- a/.changeset/thick-carrots-care.md
+++ b/.changeset/thick-carrots-care.md
@@ -1,5 +1,5 @@
 ---
-'@openfn/language-kobotoolbox': patch
+'@openfn/language-kobotoolbox': major
 ---
 
 Update `http.request` option docs to use `data` instead of `body` in requests

--- a/.changeset/thick-carrots-care.md
+++ b/.changeset/thick-carrots-care.md
@@ -5,34 +5,3 @@
 Update `http.request` option docs to use `data` instead of `body` in requests
 
 
-### Migration Guide
-- The `http.request()` function now uses `data` in stead of `body` for the body data.
-
-#### Before 
-
-```
-http.request('PATCH', `assets/aDReHdA7UuNBYsiCXQBr43/data/bulk/`, {
-  body: {
-    submission_ids: ['aDReHdA7UuNBYsiCXQBr43'],
-    data: {
-      Transaction_status: 'success',
-    },
-  },
-});
-
-```
-
-#### Now
-
-```
-http.request('PATCH', `assets/aDReHdA7UuNBYsiCXQBr43/data/bulk/`, {
-  data: {
-    submission_ids: ['aDReHdA7UuNBYsiCXQBr43'],
-    data: {
-      Transaction_status: 'success',
-    },
-  },
-});
-
-```
-

--- a/.changeset/thick-carrots-care.md
+++ b/.changeset/thick-carrots-care.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-kobotoolbox': patch
+---
+
+Update `http.request` to use `data` instead of `body` in requests

--- a/.changeset/thick-carrots-care.md
+++ b/.changeset/thick-carrots-care.md
@@ -1,5 +1,5 @@
 ---
-'@openfn/language-kobotoolbox': major
+'@openfn/language-kobotoolbox': patch
 ---
 
 Update `http.request` option docs to use `data` instead of `body` in requests

--- a/packages/kobotoolbox/src/http.js
+++ b/packages/kobotoolbox/src/http.js
@@ -15,7 +15,7 @@ import * as util from './util';
  * @typedef {Object} HTTPRequestOptions
  * @property {object} query - An object of query parameters to be encoded into the URL
  * @property {object} headers - An object of all request headers
- * @property {object} body - The request body (as JSON)
+ * @property {object} data - The request body data (as JSON)
  * @property {number} maxRedirections - The maximum number of redirects to follow
  * @property {string} [parseAs='json'] - The response format to parse (e.g., 'json', 'text', or 'stream')
  */
@@ -24,7 +24,7 @@ import * as util from './util';
  * Make a HTTP request to any KoboToolbox endpoint
  * @example <caption>Bulk updating of submissions</caption>
  * http.request("PATCH", `assets/${$.form_uid}/data/bulk/`, {
- *   body: {
+ *   data: {
  *     submission_ids: [$.data.submission_id],
  *     data: {
  *       Transaction_status: "success",


### PR DESCRIPTION
## Summary

Update `http.request` option docs to use `data` instead of `body` in requests

Fixes #1310


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
