### PR TITLE
Add git hash hyperlinks in changelogs

### DIFF
--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- 05aae5f: Default `resource_subtype` to `default_task` in `searchTask()`
+- [05aae5f](https://github.com/OpenFn/adaptors/commit/05aae5f): Default `resource_subtype` to `default_task` in `searchTask()`
 
 ## 5.0.0 - 11 August 2025
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -45,49 +45,49 @@
 
 ### Minor Changes
 
-- 3fae9d2: Add `searchTask` function
+- [3fae9d2](https://github.com/OpenFn/adaptors/commit/3fae9d2): Add `searchTask` function
 
 ## 4.2.2 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 4.2.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 4.2.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 4.1.1 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 4.1.0 - 17 June 2025
 
 ### Minor Changes
 
-- d1edd7c: #### Add Auto Pagination to `getTasks` and `upsertTask` Functions
+- [d1edd7c](https://github.com/OpenFn/adaptors/commit/d1edd7c): #### Add Auto Pagination to `getTasks` and `upsertTask` Functions
 
   ##### `getTasks` Function:
 
@@ -117,55 +117,55 @@
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 4.0.11 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 4.0.10 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 4.0.9 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 4.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 4.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 4.0.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 4.0.5 - 28 October 2024
@@ -180,29 +180,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 4.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 4.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 4.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 4.0.0 - 01 August 2024
@@ -215,42 +215,42 @@
 
 ### Patch Changes
 
-- 510354a: Don't allow HTTP helpers to call out to different domains. This can
+- [510354a](https://github.com/OpenFn/adaptors/commit/510354a): Don't allow HTTP helpers to call out to different domains. This can
   cause a security violation where credentials are sent to external servers. Use
   generic HTTP helpers like `http.get` or `fetch` instead.
-- 510354a: Fix an issue where not passing a params argument would trigger an
+- [510354a](https://github.com/OpenFn/adaptors/commit/510354a): Fix an issue where not passing a params argument would trigger an
   exception
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 3.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 3.2.0 - 12 April 2024
 
 ### Minor Changes
 
-- bae5d3b6: Add the cursor() function from common. See the job writing guide for
+- [bae5d3b6](https://github.com/OpenFn/adaptors/commit/bae5d3b6): Add the cursor() function from common. See the job writing guide for
   more information.
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 3.1.0 - 03 April 2024
 
 ### Minor Changes
 
-- 673e41e8: - Add `createTaskStory()` function
+- [673e41e8](https://github.com/OpenFn/adaptors/commit/673e41e8): - Add `createTaskStory()` function
   - Replaced common `http` with a more efficient implementation from
     `common/util` http
 
@@ -266,7 +266,7 @@
 
 ### Major Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -278,62 +278,62 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 2.1.6 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 2.1.5 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 2.1.4 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 2.1.3 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 2.1.2 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 2.1.1 - 04 November 2022
 
 ### Patch Changes
 
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
 
 ## 2.1.0 - 21 October 2022
 
 ### Minor Changes
 
-- 5f40dcf: Migrated language-asana
+- [5f40dcf](https://github.com/OpenFn/adaptors/commit/5f40dcf): Migrated language-asana
 
 ### Patch Changes
 
-- e04aa28: Rename credential-schema to configuration-schema, update descriptions
+- [e04aa28](https://github.com/OpenFn/adaptors/commit/e04aa28): Rename credential-schema to configuration-schema, update descriptions

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,85 +39,85 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.0.15 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.0.14 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 2.0.13 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 2.0.12 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 2.0.11 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 2.0.10 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 2.0.9 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 2.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 2.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 2.0.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 2.0.5 - 28 October 2024
@@ -132,29 +132,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 2.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 2.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 2.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 2.0.0 - 01 August 2024
@@ -167,18 +167,18 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.0.2 - 08 May 2024
@@ -193,7 +193,7 @@
 
 ### Patch Changes
 
-- 6afba70: Add proper variable declaration (linting)
+- [6afba70](https://github.com/OpenFn/adaptors/commit/6afba70): Add proper variable declaration (linting)
 
 ## 1.0.0 - 11 December 2023
 

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -4,151 +4,151 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.3.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.3.16 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.3.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.3.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.3.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.3.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.3.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.3.10 - 10 March 2025
 
 ### Patch Changes
 
-- 8a8c28d: - cleanup examples wrapped with `execute()` function
+- [8a8c28d](https://github.com/OpenFn/adaptors/commit/8a8c28d): - cleanup examples wrapped with `execute()` function
   - Add example caption and add sample payload
 
 ## 0.3.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.3.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.3.7 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.3.6 - 18 October 2024
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.3.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.3.4 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.3.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.3.2 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.3.1 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 0.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.2.1 - 19 June 2023
@@ -163,7 +163,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -175,80 +175,80 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.1.9 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.1.8 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.1.7 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.1.6 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.1.5 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 0.1.4 - 04 November 2022
 
 ### Patch Changes
 
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
 
 ## 0.1.3 - 25 October 2022
 
 ### Patch Changes
 
-- 63080d0: Update common for build
+- [63080d0](https://github.com/OpenFn/adaptors/commit/63080d0): Update common for build
 
 ## 0.1.2 - 25 October 2022
 
 ### Patch Changes
 
-- 0d358b6: Add ast.json for beyonic
+- [0d358b6](https://github.com/OpenFn/adaptors/commit/0d358b6): Add ast.json for beyonic
 
 ## 0.1.1 - 25 October 2022
 
 ### Patch Changes
 
-- 06ff25f: Update superagent to v8
+- [06ff25f](https://github.com/OpenFn/adaptors/commit/06ff25f): Update superagent to v8
 
 ## 0.1.0 - 21 October 2022
 
 ### Minor Changes
 
-- 28ceb1f: Moving language-beyonic to adaptors/packages/beyonic
+- [28ceb1f](https://github.com/OpenFn/adaptors/commit/28ceb1f): Moving language-beyonic to adaptors/packages/beyonic
 
 ### Patch Changes
 
-- e04aa28: Rename credential-schema to configuration-schema, update descriptions
+- [e04aa28](https://github.com/OpenFn/adaptors/commit/e04aa28): Rename credential-schema to configuration-schema, update descriptions

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,85 +39,85 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 3.0.16 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 3.0.15 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 3.0.14 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 3.0.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 3.0.12 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 3.0.11 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 3.0.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 3.0.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 3.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 3.0.7 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 3.0.6 - 28 October 2024
@@ -132,35 +132,35 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 3.0.4 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 3.0.3 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 3.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 3.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 3.0.0 - 01 August 2024
@@ -173,33 +173,33 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 2.1.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 2.1.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 2.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 3d9d564c: Add `fn` and `fnIf` operation
+- [3d9d564c](https://github.com/OpenFn/adaptors/commit/3d9d564c): Add `fn` and `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 2.0.10 - 11 June 2024
@@ -213,14 +213,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 2.0.8 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 2.0.7 - 08 May 2024
@@ -241,60 +241,60 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 2.0.4 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 2.0.3 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 2.0.2 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 2.0.1 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 2.0.0 - 14 July 2023
 
 ### Major Changes
 
-- 0b6f20b: use parseCsv from common
+- [0b6f20b](https://github.com/OpenFn/adaptors/commit/0b6f20b): use parseCsv from common
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 1.2.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 1.2.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 1.2.1 - 19 June 2023
@@ -309,7 +309,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -321,50 +321,50 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.1.5 - 20 April 2023
 
 ### Patch Changes
 
-- 5895eb9: update dependencies
+- [5895eb9](https://github.com/OpenFn/adaptors/commit/5895eb9): update dependencies
 
 ## 1.1.4 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 1.1.3 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 1.1.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 1.1.1 - 15 December 2022
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
-- 57f3513: Fix exports in index.js
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [57f3513](https://github.com/OpenFn/adaptors/commit/57f3513): Fix exports in index.js
 
 ## 1.1.0 - 11 November 2022
 
 ### Minor Changes
 
-- e4c6114: bigquery migration and build
+- [e4c6114](https://github.com/OpenFn/adaptors/commit/e4c6114): bigquery migration and build
 
 ### Patch Changes
 
-- Updated dependencies \[f2a91a4]
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -4,95 +4,95 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.4.18 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.4.17 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.4.16 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.4.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.4.14 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.4.13 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.4.12 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.4.11 - 10 March 2025
 
 ### Patch Changes
 
-- 8a8c28d: - cleanup examples wrapped with `execute()` function
+- [8a8c28d](https://github.com/OpenFn/adaptors/commit/8a8c28d): - cleanup examples wrapped with `execute()` function
   - Add example caption and add sample payload
 
 ## 0.4.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.4.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.4.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.4.7 - 28 October 2024
@@ -107,45 +107,45 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.4.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.4.4 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.4.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.4.2 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.4.1 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 0.4.0 - 13 June 2024
@@ -156,11 +156,11 @@ Republish to npmjs.com. No changes.
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.2.2
@@ -181,7 +181,7 @@ Republish to npmjs.com. No changes.
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -193,41 +193,41 @@ Republish to npmjs.com. No changes.
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.1.4
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.1.3
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.1.2
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.1.1
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.1.0
 
 ### Minor Changes
 
-- 792d495: Migrate CartoDB
+- [792d495](https://github.com/OpenFn/adaptors/commit/792d495): Migrate CartoDB
 
 ### Patch Changes
 
-- e4ebcb6: Fix Large gzip Denial of Service in superagent
+- [e4ebcb6](https://github.com/OpenFn/adaptors/commit/e4ebcb6): Fix Large gzip Denial of Service in superagent

--- a/packages/chatgpt/CHANGELOG.md
+++ b/packages/chatgpt/CHANGELOG.md
@@ -4,82 +4,82 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 2.0.0 - 24 July 2025
 
 ### Major Changes
 
-- 87c7586: Add a `deepResearch()` function that calls to GPT's deep research
+- [87c7586](https://github.com/OpenFn/adaptors/commit/87c7586): Add a `deepResearch()` function that calls to GPT's deep research
   models Remove defaulted `reasoning_effort` from `prompt()`
 
 ## 1.0.10 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.9 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.8 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.7 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.6 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.5 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.4 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.3 - 20 March 2025
 
 ### Patch Changes
 
-- 36a849c: Update example in docs to be more relevant
+- [36a849c](https://github.com/OpenFn/adaptors/commit/36a849c): Update example in docs to be more relevant
 
 ## 1.0.2 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.1 - 07 March 2025

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -4,91 +4,91 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.13 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.12 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.11 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.10 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.9 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 1.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 1.0.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 1.0.5 - 28 October 2024
@@ -103,29 +103,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 1.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 1.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 1.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.0.0 - 29 July 2024

--- a/packages/claude/CHANGELOG.md
+++ b/packages/claude/CHANGELOG.md
@@ -4,75 +4,75 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 1.0.11 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.10 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.9 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.8 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.7 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.6 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.5 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.4 - 20 March 2025
 
 ### Patch Changes
 
-- 36a849c: Update example in docs to be more relevant
+- [36a849c](https://github.com/OpenFn/adaptors/commit/36a849c): Update example in docs to be more relevant
 
 ## 1.0.3 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.2 - 07 March 2025

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -4,91 +4,91 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 0.7.12 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.7.11 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.7.10 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.7.9 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.7.8 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.7.7 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.7.6 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.7.5 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.7.4 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.7.3 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.7.2 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.7.1 - 16 December 2024
@@ -101,7 +101,7 @@
 
 ### Minor Changes
 
-- c95ccba: BREAKING: Pass state into the keygen function on `set()`. This allows
+- [c95ccba](https://github.com/OpenFn/adaptors/commit/c95ccba): BREAKING: Pass state into the keygen function on `set()`. This allows
   state to be used to calculate keys.
 
   When calling `collections.set(collection, keygen, values)`, the keygen
@@ -110,7 +110,7 @@
 
 ### Patch Changes
 
-- cdb01db: Better error handling if the keygen function is invalid
+- [cdb01db](https://github.com/OpenFn/adaptors/commit/cdb01db): Better error handling if the keygen function is invalid
 
 ## 0.6.2 - 07 December 2024
 
@@ -122,7 +122,7 @@
 
 ### Patch Changes
 
-- 12d634c: Fix an issue where reference values for setting a single item were
+- [12d634c](https://github.com/OpenFn/adaptors/commit/12d634c): Fix an issue where reference values for setting a single item were
   not resolved, eg:
 
   ```js
@@ -137,10 +137,10 @@
 
 ### Patch Changes
 
-- 39fb894: Allow a single key to be set to an array value
-- ad9fca2: Throw if insufficient arguments passed to set()
-- 29a6ce0: Throw a nice error if the collection does not exist
-- 26aa57c: Fix an issue where requesting a single key that does not exist throws
+- [39fb894](https://github.com/OpenFn/adaptors/commit/39fb894): Allow a single key to be set to an array value
+- [ad9fca2](https://github.com/OpenFn/adaptors/commit/ad9fca2): Throw if insufficient arguments passed to set()
+- [29a6ce0](https://github.com/OpenFn/adaptors/commit/29a6ce0): Throw a nice error if the collection does not exist
+- [26aa57c](https://github.com/OpenFn/adaptors/commit/26aa57c): Fix an issue where requesting a single key that does not exist throws
   an error, as in:
 
   ```
@@ -166,7 +166,7 @@
 
 ### Minor Changes
 
-- b73b063: - Added pagination support
+- [b73b063](https://github.com/OpenFn/adaptors/commit/b73b063): - Added pagination support
   - Removed `updated_*` time filters
 
 ## 0.4.0 - 01 November 2024
@@ -179,17 +179,17 @@
 
 ### Minor Changes
 
-- 1e472ed: Update new GET request structure Fix streaming API
+- [1e472ed](https://github.com/OpenFn/adaptors/commit/1e472ed): Update new GET request structure Fix streaming API
 
 ### Patch Changes
 
-- 32e5a03: Fix an issue where the query object isn't getting sent to the server
+- [32e5a03](https://github.com/OpenFn/adaptors/commit/32e5a03): Fix an issue where the query object isn't getting sent to the server
 
 ## 0.2.0 - 30 October 2024
 
 ### Minor Changes
 
-- f4deb81: Updates to latest spec
+- [f4deb81](https://github.com/OpenFn/adaptors/commit/f4deb81): Updates to latest spec
 
 ## 0.1.0 - 23 October 2024
 

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 4.0.0 - 11 August 2025
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -45,75 +45,75 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 3.3.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 3.3.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
-- 8d78db4: Export `map()` function from common
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
+- [8d78db4](https://github.com/OpenFn/adaptors/commit/8d78db4): Export `map()` function from common
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 3.2.14 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 3.2.13 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 3.2.12 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 3.2.11 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 3.2.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 3.2.9 - 16 January 2025
 
 ### Patch Changes
 
-- 3b166c9: Update commcare request docs to read query parameters instead of
+- [3b166c9](https://github.com/OpenFn/adaptors/commit/3b166c9): Update commcare request docs to read query parameters instead of
   options, and fix the empty body response received when specific requests are
   made.
 
@@ -121,31 +121,31 @@
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 3.2.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 3.2.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 3.2.5 - 04 November 2024
 
 ### Patch Changes
 
-- 2fc7d82: Update example docs and configuration
+- [2fc7d82](https://github.com/OpenFn/adaptors/commit/2fc7d82): Update example docs and configuration
 
 ## 3.2.4 - 28 October 2024
 
@@ -159,42 +159,42 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 3.2.2 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 3.2.1 - 03 October 2024
 
 ### Patch Changes
 
-- 8d85bb4: Implement resolved body and resolved params in bulk
+- [8d85bb4](https://github.com/OpenFn/adaptors/commit/8d85bb4): Implement resolved body and resolved params in bulk
 
 ## 3.2.0 - 02 October 2024
 
 ### Minor Changes
 
-- c800948: Implement a generic request funciton for generic HTTP calls
-- cff886e: Implement bulk function for lookup-table and case-data bulk uploads
+- [c800948](https://github.com/OpenFn/adaptors/commit/c800948): Implement a generic request funciton for generic HTTP calls
+- [cff886e](https://github.com/OpenFn/adaptors/commit/cff886e): Implement bulk function for lookup-table and case-data bulk uploads
 
 ## 3.1.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 3.1.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 3.1.0 - 07 August 2024
@@ -206,7 +206,7 @@
 
 ### Patch Changes
 
-- 90d74c7: Revise documentation
+- [90d74c7](https://github.com/OpenFn/adaptors/commit/90d74c7): Revise documentation
 
 ## 3.0.0 - 01 August 2024
 
@@ -218,47 +218,47 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 2.3.1 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 2.3.0 - 24 July 2024
 
 ### Minor Changes
 
-- ac4b4a0: `get()` will now automatically paginate responses (unless an offset
+- [ac4b4a0](https://github.com/OpenFn/adaptors/commit/ac4b4a0): `get()` will now automatically paginate responses (unless an offset
   is passed)
 
 ## 2.2.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 2.2.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 2.1.0 - 11 June 2024
 
 ### Minor Changes
 
-- 0719de00: Implement better error handling and make post a public function
+- [0719de00](https://github.com/OpenFn/adaptors/commit/0719de00): Implement better error handling and make post a public function
 
 ### Patch Changes
 
@@ -286,14 +286,14 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 1.6.14 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 1.6.13 - 08 May 2024
@@ -314,14 +314,14 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 1.6.10 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
   - @openfn/language-http@5.0.4
 
@@ -329,7 +329,7 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
   - @openfn/language-http@5.0.3
 
@@ -337,7 +337,7 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
   - @openfn/language-http@5.0.2
 
@@ -345,19 +345,19 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- 52c02c8: update xlsx package
+- [52c02c8](https://github.com/OpenFn/adaptors/commit/52c02c8): update xlsx package
 
 ## 1.6.6 - 21 July 2023
 
 ### Patch Changes
 
-- 8205673: update superagent
+- [8205673](https://github.com/OpenFn/adaptors/commit/8205673): update superagent
 
 ## 1.6.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
   - @openfn/language-http@5.0.1
 
@@ -365,8 +365,8 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- Updated dependencies \[0b6f20b]
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [0b6f20b](https://github.com/OpenFn/adaptors/commit/0b6f20b)
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-http@5.0.0
   - @openfn/language-common@1.10.1
 
@@ -374,7 +374,7 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
   - @openfn/language-http@4.3.3
 
@@ -382,7 +382,7 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
   - @openfn/language-http@4.3.2
 
@@ -399,7 +399,7 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -411,7 +411,7 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
   - @openfn/language-http@4.3.0
 
@@ -419,13 +419,13 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- e0406fa: update dependencies
+- [e0406fa](https://github.com/OpenFn/adaptors/commit/e0406fa): update dependencies
 
 ## 1.5.5 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
   - @openfn/language-http@4.2.8
 
@@ -433,9 +433,9 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
-- Updated dependencies \[14f481e]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
+- Updated dependencies [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e)
   - @openfn/language-common@1.7.6
   - @openfn/language-http@4.2.7
 
@@ -443,25 +443,25 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Patch Changes
 
-- f2aed32: add examples
-- Updated dependencies \[f2aed32]
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
+- Updated dependencies [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32)
   - @openfn/language-http@4.2.5
 
 ## 1.5.2 - 15 December 2022
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
-- 57f3513: Fix exports in index.js
-- Updated dependencies \[6d8de03]
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [57f3513](https://github.com/OpenFn/adaptors/commit/57f3513): Fix exports in index.js
+- Updated dependencies [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03)
   - @openfn/language-http@4.2.4
 
 ## 1.5.1 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
   - @openfn/language-http@4.2.3
 
@@ -469,18 +469,18 @@ Rebase the commcare adaptor on the new HTTP helpers.
 
 ### Minor Changes
 
-- 5c050ed: Migrate CommCare
+- [5c050ed](https://github.com/OpenFn/adaptors/commit/5c050ed): Migrate CommCare
 
 ### Patch Changes
 
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- 94076b9: update dependency xlsx to ^0.18.0
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[9a2755e]
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [94076b9](https://github.com/OpenFn/adaptors/commit/94076b9): update dependency xlsx to ^0.18.0
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [9a2755e](https://github.com/OpenFn/adaptors/commit/9a2755e)
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-http@4.2.2
   - @openfn/language-common@1.7.4

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Patch Changes
 
-- 9b5a4f8: More robust handling of empty response bodies in http helpers
+- [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8): More robust handling of empty response bodies in http helpers
 
 ### Patch Changes
 
-- cf9c09f: Fix an issue where JSON responses without a content-type header could
+- [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f): Fix an issue where JSON responses without a content-type header could
   return undefined
 
 ## 3.0.0 - 10 July 2025
@@ -21,12 +21,12 @@ convenience function.
 
 ### Major Changes
 
-- 3fce58f: - Re-write `map()` to work more like JavaScript's `Array.map()`.
+- [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f): - Re-write `map()` to work more like JavaScript's `Array.map()`.
 
 ### Minor Changes
 
-- f26bd2b: Export for lodash
-- 19f2d7e: Implement `as()` function for saving the result of an operation to a
+- [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b): Export for lodash
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Implement `as()` function for saving the result of an operation to a
   custom key in state instead of overwriting state.data.
 
 ### Migration Guide
@@ -55,69 +55,69 @@ each(
 
 ### Minor Changes
 
-- 28c2e8b: - Updated internal `logResponse` API
+- [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b): - Updated internal `logResponse` API
 - Update request to response to include `query` parameters
 
 ## 2.4.0 - 22 April 2025
 
 ### Minor Changes
 
-- 13bf08f: Add `log()` and `debug()` functions
+- [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f): Add `log()` and `debug()` functions
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
 
 ## 2.3.3 - 16 April 2025
 
 ### Patch Changes
 
-- b089c56: Implement support for `parseAs:'base64'` for binary data.
+- [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56): Implement support for `parseAs:'base64'` for binary data.
 
 ## 2.3.2 - 11 April 2025
 
 ### Patch Changes
 
-- d7105c0: Improved handling of response bodies with no content
+- [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0): Improved handling of response bodies with no content
 
 ## 2.3.1 - 14 March 2025
 
 ### Patch Changes
 
-- 23ccb01: Allow the errorMap passed into the request helper to be false, which
+- [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01): Allow the errorMap passed into the request helper to be false, which
   suppresses all errors
 
 ## 2.3.0 - 16 January 2025
 
 ### Minor Changes
 
-- b3d7f59: Common util functions `encode` and `decode` can now take a JavaScript
+- [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59): Common util functions `encode` and `decode` can now take a JavaScript
   object and stringify
-- 41e8cc3: Added an 'assert' function that throws an error when an expression or
+- [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3): Added an 'assert' function that throws an error when an expression or
   function resolves to false
 
 ### Patch Changes
 
-- 2d709ff: Ensure that RegExp objects can be safely passed as references
+- [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff): Ensure that RegExp objects can be safely passed as references
 
 ## 2.2.1 - 16 January 2025
 
 ### Patch Changes
 
-- 6dffdbd: Fixed an issue in the HTTP helpers where responses without a body can
+- [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd): Fixed an issue in the HTTP helpers where responses without a body can
   cause an error to be thrown.
 
 ## 2.2.0 - 09 January 2025
 
 ### Minor Changes
 
-- a47d8d5: `decode`, `encode` and `uuid` are now correctly documented as being
+- [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5): `decode`, `encode` and `uuid` are now correctly documented as being
   in the `util` namespace
 
 ### Patch Changes
 
-- 9240428: security: Update dependencies
+- [9240428](https://github.com/OpenFn/adaptors/commit/9240428): security: Update dependencies
 
 ## 2.1.1 - 28 October 2024
 
@@ -129,25 +129,25 @@ each(
 
 ### Minor Changes
 
-- 03a1a74: Add `encode`, `decode` and `uuid` helpers
+- [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74): Add `encode`, `decode` and `uuid` helpers
 
 ## 2.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- 33973a2: Fix a critical security issue in jsonpath-plus
+- [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2): Fix a critical security issue in jsonpath-plus
 
 ## 2.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- 77a690f: improve cursor setup message
+- [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f): improve cursor setup message
 
 ## 2.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
 
 ## 2.0.0 - 01 August 2024
 
@@ -182,20 +182,20 @@ content type to JSON.
 
 ### Patch Changes
 
-- 4c08444: document `date-fns` functions
+- [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444): document `date-fns` functions
 
 ## 1.15.0 - 19 June 2024
 
 ### Minor Changes
 
-- 5fb82f07: - Add `group()` operation
+- [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07): - Add `group()` operation
   - Initialize `state.references` in `composeNextState()`
 
 ## 1.14.0 - 13 June 2024
 
 ### Minor Changes
 
-- 106ecf6d: Add `fnIf` operation
+- [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d): Add `fnIf` operation
 
 ## 1.13.5 - 11 June 2024
 
@@ -208,13 +208,13 @@ content type to JSON.
 
 ### Patch Changes
 
-- 12f02ed5: http helpers: Ensure redirects append base url
+- [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5): http helpers: Ensure redirects append base url
 
 ## 1.13.3 - 08 May 2024
 
 ### Patch Changes
 
-- 88f99a8f: cursor: support format option
+- [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f): cursor: support format option
 
 ## 1.13.2 - 08 May 2024
 
@@ -232,13 +232,13 @@ content type to JSON.
 
 ### Minor Changes
 
-- 1ad86651: Added cursor() helper
+- [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651): Added cursor() helper
 
 ## 1.12.0 - 24 January 2024
 
 ### Minor Changes
 
-- 7f52699: New HTTP helper functions have been added to common in
+- [7f52699](https://github.com/OpenFn/adaptors/commit/7f52699): New HTTP helper functions have been added to common in
   `src/util/http.js`
 
   These are based on the `undici` library. They are functions, not operations,
@@ -284,45 +284,45 @@ content type to JSON.
 
 ### Patch Changes
 
-- c19efbe: don't attempt to expand references for a buffer
+- [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe): don't attempt to expand references for a buffer
 
 ## 1.11.0 - 08 September 2023
 
 ### Minor Changes
 
-- 85c35b8: Add validate function to validate data against a JSON schema
+- [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8): Add validate function to validate data against a JSON schema
 
 ## 1.10.3 - 14 August 2023
 
 ### Patch Changes
 
-- df09270: Fix streaming interface to parseCSV
+- [df09270](https://github.com/OpenFn/adaptors/commit/df09270): Fix streaming interface to parseCSV
 
 ## 1.10.2 - 14 July 2023
 
 ### Patch Changes
 
-- 26a303e: add expandReferences for csvData and parsingOptions
+- [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e): add expandReferences for csvData and parsingOptions
 
 ## 1.10.1 - 14 July 2023
 
 ### Patch Changes
 
-- 8c32eb3: - update parseCsv to await callback
+- [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3): - update parseCsv to await callback
   - Added documentation for splitKeys
 
 ## 1.10.0 - 30 June 2023
 
 ### Minor Changes
 
-- aad9549: Ensure that standard OAuth2 credentials with snake-cased
+- [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549): Ensure that standard OAuth2 credentials with snake-cased
   "access\_token" keys can be used for OAuth2-reliant adaptors
 
 ## 1.9.0 - 23 June 2023
 
 ### Minor Changes
 
-- 111807f: Add support for `parseCsv` in common
+- [111807f](https://github.com/OpenFn/adaptors/commit/111807f): Add support for `parseCsv` in common
 
 ## 1.8.1 - 19 June 2023
 
@@ -334,7 +334,7 @@ content type to JSON.
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -348,28 +348,28 @@ content type to JSON.
 
 ### Patch Changes
 
-- 929bca6: Export metadata helper function
+- [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6): Export metadata helper function
 
 ## 1.7.6 - 30 March 2023
 
 ### Patch Changes
 
-- 2b4c61a: mark execute private and ast build
+- [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a): mark execute private and ast build
 
 ## 1.7.5 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
 
 ## 1.7.4 - 04 November 2022
 
 ### Patch Changes
 
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- b5eb665: Adjusted docs for common and built to markdown
-- # ecf5d30: remove sinon since it was not being used
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665): Adjusted docs for common and built to markdown
+- # [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
 
 Bumped all package versions to their latest.
 

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,49 +39,49 @@
 
 ### Patch Changes
 
-- aeb09c4: Fix an issue in metadata generation
+- [aeb09c4](https://github.com/OpenFn/adaptors/commit/aeb09c4): Fix an issue in metadata generation
 
 ## 7.1.2 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 7.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 7.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 7.0.2 - 01 July 2025
 
 ### Patch Changes
 
-- aa2f46b: - Adjust logging in create to not include item details.
+- [aa2f46b](https://github.com/OpenFn/adaptors/commit/aa2f46b): - Adjust logging in create to not include item details.
   - Fix issues in docs.
 
 ## 7.0.1 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 7.0.0 - 04 June 2025
@@ -111,12 +111,12 @@ other adaptors).
 
 ### Minor Changes
 
-- dfe53ef: - Implement a new `tracker` namespace for `tracker.import()` and
+- [dfe53ef](https://github.com/OpenFn/adaptors/commit/dfe53ef): - Implement a new `tracker` namespace for `tracker.import()` and
   `tracker.export()` functions.
 
   - Throw an error when `create('tracker')` is called.
 
-- 5b73844: - Add importStrategy to query params for `create` and `update`
+- [5b73844](https://github.com/OpenFn/adaptors/commit/5b73844): - Add importStrategy to query params for `create` and `update`
 
 ### Migration Guide
 
@@ -172,29 +172,29 @@ fn((state) => {
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 6.3.3 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 6.3.2 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 6.3.1 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 6.3.0 - 30 January 2025
@@ -208,47 +208,47 @@ fn((state) => {
 
 ### Minor Changes
 
-- 0156632: Add `asBase64` option in dhis2 `get()` function
+- [0156632](https://github.com/OpenFn/adaptors/commit/0156632): Add `asBase64` option in dhis2 `get()` function
 
 ## 6.1.0 - 16 January 2025
 
 ### Minor Changes
 
-- c19d561: Added support for personal access tokens in dhis2
+- [c19d561](https://github.com/OpenFn/adaptors/commit/c19d561): Added support for personal access tokens in dhis2
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 6.0.3 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 6.0.2 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 6.0.1 - 04 December 2024
 
 ### Patch Changes
 
-- ab94b7c: Fix links in docs examples
+- [ab94b7c](https://github.com/OpenFn/adaptors/commit/ab94b7c): Fix links in docs examples
 
 ## 6.0.0 - 28 November 2024
 
 ### Major Changes
 
-- b44a3b1: Migrates the adaptor to the new Tracker API (v36+) for
+- [b44a3b1](https://github.com/OpenFn/adaptors/commit/b44a3b1): Migrates the adaptor to the new Tracker API (v36+) for
   `trackedEntities`, `enrollments`, `events` and `relationships`. Note that
   `trackedEntities` is no longer used.
 
@@ -307,20 +307,20 @@ fn((state) => {
 
 ### Minor Changes
 
-- d30f39f: Added new post() operation
+- [d30f39f](https://github.com/OpenFn/adaptors/commit/d30f39f): Added new post() operation
 
 ## 5.0.8 - 26 November 2024
 
 ### Patch Changes
 
-- 94be282: Fix an issue where the path argument of update does not accept a
+- [94be282](https://github.com/OpenFn/adaptors/commit/94be282): Fix an issue where the path argument of update does not accept a
   function value
 
 ## 5.0.7 - 08 November 2024
 
 ### Patch Changes
 
-- 6cb5377: Removed support for DHIS2 v42
+- [6cb5377](https://github.com/OpenFn/adaptors/commit/6cb5377): Removed support for DHIS2 v42
 
 ## 5.0.6 - 28 October 2024
 
@@ -334,35 +334,35 @@ fn((state) => {
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 5.0.4 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 5.0.3 - 09 October 2024
 
 ### Patch Changes
 
-- 3fd13c2: Update axios to 1.7.7
+- [3fd13c2](https://github.com/OpenFn/adaptors/commit/3fd13c2): Update axios to 1.7.7
 
 ## 5.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 5.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 5.0.0 - 01 August 2024
@@ -375,29 +375,29 @@ fn((state) => {
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 4.2.0 - 19 June 2024
 
 ### Minor Changes
 
-- 5fb82f07: Export `group` operation from common
+- [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07): Export `group` operation from common
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 4.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 4.0.5 - 14 May 2024
@@ -418,7 +418,7 @@ fn((state) => {
 
 ### Patch Changes
 
-- 222184d: remove Class Log and replaced
+- [222184d](https://github.com/OpenFn/adaptors/commit/222184d): remove Class Log and replaced
 
   - `Log.success` with `console.log`
   - `Log.warn` with `console.warn`
@@ -428,7 +428,7 @@ fn((state) => {
 
 ### Patch Changes
 
-- 1bd612e: improve error logs response
+- [1bd612e](https://github.com/OpenFn/adaptors/commit/1bd612e): improve error logs response
 
 ## 4.0.1 - 19 June 2023
 
@@ -442,7 +442,7 @@ fn((state) => {
 
 ### Major Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -454,35 +454,35 @@ fn((state) => {
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 3.2.12 - 31 May 2023
 
 ### Patch Changes
 
-- 57742d1: improve logs output
+- [57742d1](https://github.com/OpenFn/adaptors/commit/57742d1): improve logs output
 
 ## 3.2.11 - 31 March 2023
 
 ### Patch Changes
 
-- 705caab: Remove tools as devdependencies
+- [705caab](https://github.com/OpenFn/adaptors/commit/705caab): Remove tools as devdependencies
 
 ## 3.2.10 - 31 March 2023
 
 ### Patch Changes
 
-- 929bca6: Use metadata helper function from common
-- Updated dependencies \[929bca6]
+- [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6): Use metadata helper function from common
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 3.2.9 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 3.2.8 - 24 March 2023
@@ -495,46 +495,46 @@ fn((state) => {
 
 ### Patch Changes
 
-- c09b821: Add @magic annotations
+- [c09b821](https://github.com/OpenFn/adaptors/commit/c09b821): Add @magic annotations
 
 ## 3.2.6 - 16 February 2023
 
 ### Patch Changes
 
-- df6098d: replace sample state with configuration
+- [df6098d](https://github.com/OpenFn/adaptors/commit/df6098d): replace sample state with configuration
 
 ## 3.2.5 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 3.2.4 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 3.2.3 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 3.2.2 - 04 November 2022
 
 ### Patch Changes
 
-- 9a2755e: Update dependency on language-common
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [9a2755e](https://github.com/OpenFn/adaptors/commit/9a2755e): Update dependency on language-common
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
   - @openfn/buildtools@1.0.2
 
@@ -542,22 +542,22 @@ fn((state) => {
 
 ### Patch Changes
 
-- e04aa28: Rename credential-schema to configuration-schema, update descriptions
+- [e04aa28](https://github.com/OpenFn/adaptors/commit/e04aa28): Rename credential-schema to configuration-schema, update descriptions
 
 ## 3.2.0 - 19 October 2022
 
 ### Minor Changes
 
-- f670bf8: Added credential schema to enable new ui
+- [f670bf8](https://github.com/OpenFn/adaptors/commit/f670bf8): Added credential schema to enable new ui
 
 ## 3.1.0 - 18 October 2022
 
 ### Minor Changes
 
-- 8d6e8ce: Migrate dhis2 into repo
+- [8d6e8ce](https://github.com/OpenFn/adaptors/commit/8d6e8ce): Migrate dhis2 into repo
 
 ### Patch Changes
 
-- Updated dependencies \[4671e89]
-- Updated dependencies \[8d6e8ce]
+- Updated dependencies [4671e89](https://github.com/OpenFn/adaptors/commit/4671e89)
+- Updated dependencies [8d6e8ce](https://github.com/OpenFn/adaptors/commit/8d6e8ce)
   - @openfn/buildtools@1.0.1

--- a/packages/divoc/CHANGELOG.md
+++ b/packages/divoc/CHANGELOG.md
@@ -4,62 +4,62 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 0.1.7 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.1.6 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.1.5 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.1.4 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.1.3 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.1.2 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.1.1 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.1.0 - 24 March 2025

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -4,88 +4,88 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.5.19 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.5.18 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.5.17 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.5.16 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.5.15 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.5.14 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.5.13 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.5.12 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.5.11 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.5.10 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.5.9 - 28 October 2024
@@ -100,68 +100,68 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.5.7 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.5.6 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 0.5.5 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.5.4 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.5.3 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.5.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 0.5.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 0.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.4.14 - 11 June 2024
@@ -175,14 +175,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 0.4.12 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 0.4.11 - 08 May 2024
@@ -203,58 +203,58 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 0.4.8 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 0.4.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 0.4.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 0.4.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 0.4.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 0.4.3 - 30 June 2023
 
 ### Patch Changes
 
-- aad9549: Ensure that standard OAuth2 credentials with snake-cased
+- [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549): Ensure that standard OAuth2 credentials with snake-cased
   "access\_token" keys can be used for OAuth2-reliant adaptors
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 0.4.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 0.4.1 - 19 June 2023
@@ -269,7 +269,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -281,48 +281,48 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.3.5 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 0.3.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.3.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.3.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.3.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.3.0 - 25 November 2022
 
 ### Minor Changes
 
-- b032b9c: Migrate Dynamics
+- [b032b9c](https://github.com/OpenFn/adaptors/commit/b032b9c): Migrate Dynamics
 
 ### Patch Changes
 
-- e81561f: Updated ast and package.json
+- [e81561f](https://github.com/OpenFn/adaptors/commit/e81561f): Updated ast and package.json

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -4,88 +4,88 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.4.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.4.16 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.4.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.4.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.4.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.4.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.4.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.4.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.4.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.4.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.4.7 - 28 October 2024
@@ -100,68 +100,68 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.4.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.4.4 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 0.4.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.4.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.4.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.4.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.3.3 - 17 May 2024
 
 ### Patch Changes
 
-- d5a326f5: Add example `access_token` in the `configuration-schema`
+- [d5a326f5](https://github.com/OpenFn/adaptors/commit/d5a326f5): Add example `access_token` in the `configuration-schema`
 
 ## 0.3.2 - 30 June 2023
 
 ### Patch Changes
 
-- aad9549: Ensure that standard OAuth2 credentials with snake-cased
+- [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549): Ensure that standard OAuth2 credentials with snake-cased
   "access\_token" keys can be used for OAuth2-reliant adaptors
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 0.3.1 - 19 June 2023
@@ -176,7 +176,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -188,31 +188,31 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.2.3 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.2.2 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.2.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.2.0 - 25 November 2022
 
 ### Minor Changes
 
-- f7669d2: migrate facebook
+- [f7669d2](https://github.com/OpenFn/adaptors/commit/f7669d2): migrate facebook

--- a/packages/fhir-4/CHANGELOG.md
+++ b/packages/fhir-4/CHANGELOG.md
@@ -4,57 +4,57 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.1.8 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.1.7 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.1.6 - 20 June 2025
 
 ### Patch Changes
 
-- 28c2e8b: Remove query option from `logResponse` function
-- Updated dependencies \[28c2e8b]
+- [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b): Remove query option from `logResponse` function
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.1.5 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.1.4 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.1.3 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.1.2 - 21 March 2025

--- a/packages/fhir-fr/CHANGELOG.md
+++ b/packages/fhir-fr/CHANGELOG.md
@@ -4,85 +4,85 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.14 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.13 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.12 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.11 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.10 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.9 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.8 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 1.0.6 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 1.0.5 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 1.0.4 - 01 December 2024

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
   - @openfn/language-fhir@5.0.7
 
@@ -12,7 +12,7 @@
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
   - @openfn/language-fhir@5.0.6
 
@@ -20,11 +20,11 @@
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
   - @openfn/language-fhir@5.0.5
 
@@ -32,15 +32,15 @@
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.1.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
   - @openfn/language-fhir@5.0.4
 
@@ -48,45 +48,45 @@
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.1.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.1.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.1.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.1.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.1.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.1.7 - 03 November 2024
@@ -112,20 +112,20 @@
 
 ### Patch Changes
 
-- 47bf58f: Adjust build process to fix docs
+- [47bf58f](https://github.com/OpenFn/adaptors/commit/47bf58f): Adjust build process to fix docs
 
 ## 0.1.3 - 18 October 2024
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.1.2 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.1.1 - 09 October 2024

--- a/packages/fhir/CHANGELOG.md
+++ b/packages/fhir/CHANGELOG.md
@@ -4,35 +4,35 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 5.0.6 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 5.0.5 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 5.0.4 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 5.0.3 - 28 October 2024
@@ -47,16 +47,16 @@
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 5.0.1 - 01 August 2024
 
 ### Patch Changes
 
-- 940996b: Use common helper code to handle invalid absolute URLs
-- Updated dependencies \[4fe527c]
+- [940996b](https://github.com/OpenFn/adaptors/commit/940996b): Use common helper code to handle invalid absolute URLs
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 5.0.0 - 19 July 2024
@@ -142,7 +142,7 @@
 
 ### Major Changes
 
-- a42ffeb9: - All HTTP methods now write `{ data, response }` to state, where
+- [a42ffeb9](https://github.com/OpenFn/adaptors/commit/a42ffeb9): - All HTTP methods now write `{ data, response }` to state, where
   data is the response body and response is the raw response
   - All HTTP methods now support a `throwOnError` param, which defaults to true.
     If false, the adaptor will not throw if the HTTP status is an error code
@@ -154,18 +154,18 @@
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 3.1.2 - 17 May 2024
 
 ### Patch Changes
 
-- 2b283549: - Update `create()` example
+- [2b283549](https://github.com/OpenFn/adaptors/commit/2b283549): - Update `create()` example
   - Update required properties in configuration schema
 
 ## 3.1.1 - 08 May 2024
@@ -180,7 +180,7 @@
 
 ### Minor Changes
 
-- d94e9ee: Migrate from axios to using `fetch` from `undici` and add uniti tests
+- [d94e9ee](https://github.com/OpenFn/adaptors/commit/d94e9ee): Migrate from axios to using `fetch` from `undici` and add uniti tests
 
 ## 3.0.1 - 19 June 2023
 
@@ -194,7 +194,7 @@
 
 ### Major Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -206,14 +206,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 2.0.0 - 06 June 2023
 
 ### Major Changes
 
-- d4b4094: - Update configuration schema,
+- [d4b4094](https://github.com/OpenFn/adaptors/commit/d4b4094): - Update configuration schema,
   - Add `get()` function
   - Fix `create()` axios config
   - Remove unused code
@@ -224,50 +224,50 @@
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 1.1.4 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 1.1.3 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 1.1.2 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 1.1.1 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 1.1.0 - 04 November 2022
 
 ### Minor Changes
 
-- fee607e: Migrate FHIR, update package export
+- [fee607e](https://github.com/OpenFn/adaptors/commit/fee607e): Migrate FHIR, update package export
 
 ### Patch Changes
 
-- cb5d0ed: Updated to @openfn/simple-ast v0.4.1
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [cb5d0ed](https://github.com/OpenFn/adaptors/commit/cb5d0ed): Updated to @openfn/simple-ast v0.4.1
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4

--- a/packages/ghana-bdr/CHANGELOG.md
+++ b/packages/ghana-bdr/CHANGELOG.md
@@ -4,82 +4,82 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.1.10 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.1.9 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.1.8 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.1.7 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.1.6 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.1.5 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.1.4 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.1.3 - 31 January 2025
 
 ### Patch Changes
 
-- 7c677a5: Update mock and examples for bdr, add auth to test
+- [7c677a5](https://github.com/OpenFn/adaptors/commit/7c677a5): Update mock and examples for bdr, add auth to test
 
 ## 0.1.2 - 29 January 2025
 
 ### Patch Changes
 
-- 5e3b3cf: Updates to the mock endpoint, these are still moving targets
+- [5e3b3cf](https://github.com/OpenFn/adaptors/commit/5e3b3cf): Updates to the mock endpoint, these are still moving targets
 
 ## 0.1.1 - 28 January 2025
 
 ### Patch Changes
 
-- 8fb854a: Swapped inline example for BDR and NIA
+- [8fb854a](https://github.com/OpenFn/adaptors/commit/8fb854a): Swapped inline example for BDR and NIA
 
 ## 0.1.0 - 28 January 2025
 

--- a/packages/ghana-nia/CHANGELOG.md
+++ b/packages/ghana-nia/CHANGELOG.md
@@ -4,82 +4,82 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.1.10 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.1.9 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.1.8 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.1.7 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.1.6 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.1.5 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.1.4 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.1.3 - 31 January 2025
 
 ### Patch Changes
 
-- 7c677a5: Update mock and nia, add auth to test
+- [7c677a5](https://github.com/OpenFn/adaptors/commit/7c677a5): Update mock and nia, add auth to test
 
 ## 0.1.2 - 29 January 2025
 
 ### Patch Changes
 
-- 5e3b3cf: Updates to the mock endpoint, these are still moving targets
+- [5e3b3cf](https://github.com/OpenFn/adaptors/commit/5e3b3cf): Updates to the mock endpoint, these are still moving targets
 
 ## 0.1.1 - 28 January 2025
 
 ### Patch Changes
 
-- 8fb854a: Swapped inline example for BDR and NIA
+- [8fb854a](https://github.com/OpenFn/adaptors/commit/8fb854a): Swapped inline example for BDR and NIA
 
 ## 0.1.0 - 28 January 2025
 

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,102 +39,102 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.3.4 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.3.3 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.3.2 - 03 July 2025
 
 ### Patch Changes
 
-- ead4e42: Added support for sending emails with or without attachments in the
+- [ead4e42](https://github.com/OpenFn/adaptors/commit/ead4e42): Added support for sending emails with or without attachments in the
   `sendMessage` function
 
 ## 1.3.1 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.3.0 - 30 May 2025
 
 ### Minor Changes
 
-- 1205796: Enhance `sendMessage()` to accept an array of configuration objects,
+- [1205796](https://github.com/OpenFn/adaptors/commit/1205796): Enhance `sendMessage()` to accept an array of configuration objects,
   allowing multiple messages to be send in a single command.
 
 ## 1.2.0 - 22 April 2025
 
 ### Minor Changes
 
-- 7d6d513: Added support for sending messages. Upgraded zip library to support
+- [7d6d513](https://github.com/OpenFn/adaptors/commit/7d6d513): Added support for sending messages. Upgraded zip library to support
   creating archives as well as reading archives.
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.1.4 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.1.3 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.1.2 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.1.1 - 05 February 2025
 
 ### Patch Changes
 
-- 658971a: Fixed bug which prevented multiple content of the same "type" and now
+- [658971a](https://github.com/OpenFn/adaptors/commit/658971a): Fixed bug which prevented multiple content of the same "type" and now
   correctly works to prevent multiple of the same "name".
 
 ## 1.1.0 - 23 January 2025
 
 ### Minor Changes
 
-- 8203e90: Added options.maxResults field to limit excessive data transfer.
+- [8203e90](https://github.com/OpenFn/adaptors/commit/8203e90): Added options.maxResults field to limit excessive data transfer.
 
 ## 1.0.1 - 18 January 2025
 
 ### Patch Changes
 
-- 01b4aa9: This patch includes breaking changes to the API - but since the
+- [01b4aa9](https://github.com/OpenFn/adaptors/commit/01b4aa9): This patch includes breaking changes to the API - but since the
   adpator has only been released a couple of days we don't anticipate this
   affecting any users.
 

--- a/packages/godata/CHANGELOG.md
+++ b/packages/godata/CHANGELOG.md
@@ -4,25 +4,25 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 3.5.6 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 3.5.5 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 3.5.4 - 28 October 2024
@@ -37,39 +37,39 @@
 
 ### Patch Changes
 
-- 3fd13c2: Update axios to 1.7.7
+- [3fd13c2](https://github.com/OpenFn/adaptors/commit/3fd13c2): Update axios to 1.7.7
 
 ## 3.5.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 3.5.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 3.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 3d9d564c: Add `fn` and `fnIf` operation
+- [3d9d564c](https://github.com/OpenFn/adaptors/commit/3d9d564c): Add `fn` and `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 3.4.0 - 14 December 2023
 
 ### Minor Changes
 
-- df4cfca: Switch from `'writeOnly: true'` to `'format: email'` in the godata
+- [df4cfca](https://github.com/OpenFn/adaptors/commit/df4cfca): Switch from `'writeOnly: true'` to `'format: email'` in the godata
   configuration schema.
 
 ## 3.3.1 - 19 June 2023
@@ -84,7 +84,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -96,43 +96,43 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 3.2.4 - 30 March 2023
 
 ### Patch Changes
 
-- ef828e7: update old urls in readme
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [ef828e7](https://github.com/OpenFn/adaptors/commit/ef828e7): update old urls in readme
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 3.2.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 3.2.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 3.2.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 3.2.0 - 25 November 2022
 
 ### Minor Changes
 
-- 8e7a79e: Migrate Godata
+- [8e7a79e](https://github.com/OpenFn/adaptors/commit/8e7a79e): Migrate Godata
 
 ### Patch Changes
 
-- cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
-- e81561f: Updated ast and package.json
+- [cbb8968](https://github.com/OpenFn/adaptors/commit/cbb8968): Fix axios Inefficient Regular Expression Complexity vulnerability
+- [e81561f](https://github.com/OpenFn/adaptors/commit/e81561f): Updated ast and package.json

--- a/packages/googledrive/CHANGELOG.md
+++ b/packages/googledrive/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,47 +39,47 @@
 
 ### Minor Changes
 
-- bfcfab9: - Update `get()` to fetch file using fileId or fileName
+- [bfcfab9](https://github.com/OpenFn/adaptors/commit/bfcfab9): - Update `get()` to fetch file using fileId or fileName
   - Export `dateFns`,`as`, `chunk`, `arrayToString` and `parseCsv` from `common`
 
 ## 1.0.5 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.4 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.3 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.2 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.1 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.0 - 17 April 2025

--- a/packages/googlehealthcare/CHANGELOG.md
+++ b/packages/googlehealthcare/CHANGELOG.md
@@ -4,28 +4,28 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.1.5 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.1.4 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.1.3 - 28 October 2024
@@ -40,26 +40,26 @@
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.1.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.0.1 - 08 May 2024
@@ -74,7 +74,7 @@
 
 ### Major Changes
 
-- 7df7e20: remove `projectId`, `dataSetId`, `cloudRegion`, and `fhirStoreId` out
+- [7df7e20](https://github.com/OpenFn/adaptors/commit/7df7e20): remove `projectId`, `dataSetId`, `cloudRegion`, and `fhirStoreId` out
   of configuration
 
   The new implementation of `createFhirResource(fhirStore, resource, callback)`
@@ -87,11 +87,11 @@
 
 ### Minor Changes
 
-- 861d774: add createFhirResource function
+- [861d774](https://github.com/OpenFn/adaptors/commit/861d774): add createFhirResource function
 
 ### Patch Changes
 
-- aad9549: Ensure that standard OAuth2 credentials with snake-cased
+- [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549): Ensure that standard OAuth2 credentials with snake-cased
   "access\_token" keys can be used for OAuth2-reliant adaptors
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,61 +39,61 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 3.0.16 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 3.0.15 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 3.0.14 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 3.0.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 3.0.12 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 3.0.11 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 3.0.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 3.0.9 - 27 January 2025
@@ -107,24 +107,24 @@
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 3.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 3.0.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 3.0.5 - 28 October 2024
@@ -139,29 +139,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 3.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 3.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 3.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 3.0.0 - 01 August 2024
@@ -174,52 +174,52 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 2.5.1 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 2.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 2.4.0 - 12 April 2024
 
 ### Minor Changes
 
-- bae5d3b6: Add the cursor() function from common. See the job writing guide for
+- [bae5d3b6](https://github.com/OpenFn/adaptors/commit/bae5d3b6): Add the cursor() function from common. See the job writing guide for
   more information.
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 2.3.1 - 08 April 2024
 
 ### Patch Changes
 
-- 4594a324: add callback jsdocs
+- [4594a324](https://github.com/OpenFn/adaptors/commit/4594a324): add callback jsdocs
 
 ## 2.3.0 - 03 April 2024
 
 ### Minor Changes
 
-- 8405fc9a: - Add `getValues()` function
+- [8405fc9a](https://github.com/OpenFn/adaptors/commit/8405fc9a): - Add `getValues()` function
   - Improve connection handling
   - Improve error logs
 
@@ -227,9 +227,9 @@
 
 ### Patch Changes
 
-- aad9549: Ensure that standard OAuth2 credentials with snake-cased
+- [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549): Ensure that standard OAuth2 credentials with snake-cased
   "access\_token" keys can be used for OAuth2-reliant adaptors
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 2.2.1 - 19 June 2023
@@ -244,7 +244,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -256,59 +256,59 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 2.1.6 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 2.1.5 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 2.1.4 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 2.1.3 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 2.1.2 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 2.1.1 - 04 November 2022
 
 ### Patch Changes
 
-- 9a2755e: Update dependency on language-common
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [9a2755e](https://github.com/OpenFn/adaptors/commit/9a2755e): Update dependency on language-common
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
 
 ## 2.1.0 - 25 October 2022
 
 ### Minor Changes
 
-- 9e7d458: Migrate googlesheets
+- [9e7d458](https://github.com/OpenFn/adaptors/commit/9e7d458): Migrate googlesheets

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -4,85 +4,85 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.3.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.3.16 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.3.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.3.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.3.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.3.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.3.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.3.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.3.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.3.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.3.7 - 28 October 2024
@@ -97,60 +97,60 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.3.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.3.4 - 09 October 2024
 
 ### Patch Changes
 
-- e53b30f: Update hive-driver dependency
+- [e53b30f](https://github.com/OpenFn/adaptors/commit/e53b30f): Update hive-driver dependency
 
 ## 0.3.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.3.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.3.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.2.1 - 24 April 2024
 
 ### Patch Changes
 
-- 02ab7a89: - Change `host` format from `uri` to `string` in
+- [02ab7a89](https://github.com/OpenFn/adaptors/commit/02ab7a89): - Change `host` format from `uri` to `string` in
   `configuration-schema.json`
   - Update required list to include `database`
 
@@ -158,4 +158,4 @@
 
 ### Minor Changes
 
-- a380347: Add query function
+- [a380347](https://github.com/OpenFn/adaptors/commit/a380347): Add query function

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -4,99 +4,99 @@
 
 ### Minor Changes
 
-- c381879: Add support for `tls` object options in state.configuration
+- [c381879](https://github.com/OpenFn/adaptors/commit/c381879): Add support for `tls` object options in state.configuration
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 7.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 7.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
-- 8d78db4: Export `map()` function from common
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
+- [8d78db4](https://github.com/OpenFn/adaptors/commit/8d78db4): Export `map()` function from common
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 7.0.7 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 7.0.6 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- 99e4b48: Fix parseAs option in all operations
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): Fix parseAs option in all operations
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 7.0.5 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 7.0.4 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 7.0.3 - 04 April 2025
 
 ### Patch Changes
 
-- 2073994: - Add a `POST` example to the `request()` function
+- [2073994](https://github.com/OpenFn/adaptors/commit/2073994): - Add a `POST` example to the `request()` function
 
 ## 7.0.2 - 20 March 2025
 
 ### Patch Changes
 
-- 7174293: improve function examples
+- [7174293](https://github.com/OpenFn/adaptors/commit/7174293): improve function examples
 
 ## 7.0.1 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 7.0.0 - 05 March 2025
 
 ### Major Changes
 
-- 8b28b87: - Remove all callback functions
-- 57a2a63: - Add `contentType` option to requests. This defaults to `json`
-- ba84591: - Add a `data` argument to `put()`, `patch()` and `post()`
+- [8b28b87](https://github.com/OpenFn/adaptors/commit/8b28b87): - Remove all callback functions
+- [57a2a63](https://github.com/OpenFn/adaptors/commit/57a2a63): - Add `contentType` option to requests. This defaults to `json`
+- [ba84591](https://github.com/OpenFn/adaptors/commit/ba84591): - Add a `data` argument to `put()`, `patch()` and `post()`
 - Remove the deprecated `json` property on `RequestOptions`
 
 ### Patch Changes
 
-- b1ce36f: - Remove duplicated body response from `http`.
+- [b1ce36f](https://github.com/OpenFn/adaptors/commit/b1ce36f): - Remove duplicated body response from `http`.
 
 ### Migration Guide
 
@@ -162,26 +162,26 @@ post('/patient', $.patient).then(next => {
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 6.5.3 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 6.5.2 - 09 January 2025
 
 ### Patch Changes
 
-- 4b9a5b9: - Fix typo in util functions examples
+- [4b9a5b9](https://github.com/OpenFn/adaptors/commit/4b9a5b9): - Fix typo in util functions examples
   - Remove export for `addAuth()` helper
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 6.5.1 - 28 October 2024
@@ -196,25 +196,25 @@ post('/patient', $.patient).then(next => {
 
 ### Minor Changes
 
-- b433d7f: Add `util.encode`, `util.decode` and `util.uuid` helpers
+- [b433d7f](https://github.com/OpenFn/adaptors/commit/b433d7f): Add `util.encode`, `util.decode` and `util.uuid` helpers
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 6.4.6 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 6.4.5 - 09 October 2024
 
 ### Patch Changes
 
-- e01d7b3: - Fix an issue where an error is thrown if `state.configuration` is
+- [e01d7b3](https://github.com/OpenFn/adaptors/commit/e01d7b3): - Fix an issue where an error is thrown if `state.configuration` is
   `null`
   - better error when `baseUrl` is not set and the passed url is a relative url.
   - better error when `baseUrl` is not set and no url is provided.
@@ -223,53 +223,53 @@ post('/patient', $.patient).then(next => {
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 6.4.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 6.4.2 - 01 August 2024
 
 ### Patch Changes
 
-- c803bab: In all functions, if baseUrl if set, path MUST be relative.
-- Updated dependencies \[4fe527c]
+- [c803bab](https://github.com/OpenFn/adaptors/commit/c803bab): In all functions, if baseUrl if set, path MUST be relative.
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 6.4.1 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 6.4.0 - 19 June 2024
 
 ### Minor Changes
 
-- 5fb82f07: Export `group` operation from common
+- [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07): Export `group` operation from common
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 6.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 6.2.3 - 11 June 2024
@@ -304,13 +304,13 @@ post('/patient', $.patient).then(next => {
 
 ### Minor Changes
 
-- cfe1ccb: Add callback support for parseXML
+- [cfe1ccb](https://github.com/OpenFn/adaptors/commit/cfe1ccb): Add callback support for parseXML
 
 ## 6.0.0 - 24 January 2024
 
 ### Major Changes
 
-- f741086: The axios library has been removed and the operation API simplified.
+- [f741086](https://github.com/OpenFn/adaptors/commit/f741086): The axios library has been removed and the operation API simplified.
 
 ### New features
 
@@ -347,73 +347,73 @@ post('/patient', $.patient).then(next => {
 
 ### Patch Changes
 
-- Updated dependencies \[7f52699]
+- Updated dependencies [7f52699](https://github.com/OpenFn/adaptors/commit/7f52699)
   - @openfn/language-common@1.12.0
 
 ## 5.1.1 - 11 December 2023
 
 ### Patch Changes
 
-- a8d655e: Update `parseXML` to use `expandReferences`
+- [a8d655e](https://github.com/OpenFn/adaptors/commit/a8d655e): Update `parseXML` to use `expandReferences`
 
 ## 5.1.0 - 16 November 2023
 
 ### Minor Changes
 
-- 8e2b79c: Clean up `state.response.request` by returning only
+- [8e2b79c](https://github.com/OpenFn/adaptors/commit/8e2b79c): Clean up `state.response.request` by returning only
   `{ method, path, host, protocol, _headers }`
 
 ## 5.0.4 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 5.0.3 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 5.0.2 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 5.0.1 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 5.0.0 - 14 July 2023
 
 ### Major Changes
 
-- 0b6f20b: use parseCsv from common
+- [0b6f20b](https://github.com/OpenFn/adaptors/commit/0b6f20b): use parseCsv from common
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 4.3.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 4.3.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 4.3.1 - 19 June 2023
@@ -428,7 +428,7 @@ post('/patient', $.patient).then(next => {
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -440,84 +440,84 @@ post('/patient', $.patient).then(next => {
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 4.2.8 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 4.2.7 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 4.2.6 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 4.2.5 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 4.2.4 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 4.2.3 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 4.2.2 - 04 November 2022
 
 ### Patch Changes
 
-- 9a2755e: Update dependency on language-common
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [9a2755e](https://github.com/OpenFn/adaptors/commit/9a2755e): Update dependency on language-common
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
 
 ## 4.2.1 - 21 October 2022
 
 ### Patch Changes
 
-- e04aa28: Rename credential-schema to configuration-schema, update descriptions
+- [e04aa28](https://github.com/OpenFn/adaptors/commit/e04aa28): Rename credential-schema to configuration-schema, update descriptions
 
 ## 4.2.0 - 19 October 2022
 
 ### Minor Changes
 
-- f670bf8: Added credential schema to enable new ui
+- [f670bf8](https://github.com/OpenFn/adaptors/commit/f670bf8): Added credential schema to enable new ui
 
 ## 4.1.0 - 18 October 2022
 
 ### Minor Changes
 
-- 8e1b86d: update http to new format
+- [8e1b86d](https://github.com/OpenFn/adaptors/commit/8e1b86d): update http to new format
 
 ## 4.0.1 - 13 October 2022
 
 ### Patch Changes
 
-- 4671e89: Migrate language-http
+- [4671e89](https://github.com/OpenFn/adaptors/commit/4671e89): Migrate language-http

--- a/packages/hubtel/CHANGELOG.md
+++ b/packages/hubtel/CHANGELOG.md
@@ -4,76 +4,76 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 1.0.9 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.8 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.7 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.6 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.5 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.4 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.3 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.2 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.1 - 30 January 2025
 
 ### Patch Changes
 
-- f762c5a: Fix schema and docs
+- [f762c5a](https://github.com/OpenFn/adaptors/commit/f762c5a): Fix schema and docs
 
 ## 1.0.0 - 22 January 2025
 

--- a/packages/inform/CHANGELOG.md
+++ b/packages/inform/CHANGELOG.md
@@ -4,50 +4,50 @@
 
 ### Patch Changes
 
-- b2aec70: - Removed `common` exports in http
+- [b2aec70](https://github.com/OpenFn/adaptors/commit/b2aec70): - Removed `common` exports in http
 
 ## 1.1.2 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.2 - 20 June 2025
 
 ### Patch Changes
 
-- 28c2e8b: Remove query option from `logResponse` function
-- Updated dependencies \[28c2e8b]
+- [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b): Remove query option from `logResponse` function
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.1 - 28 May 2025
 
 ### Patch Changes
 
-- 62ec0a4: - Update square logo
+- [62ec0a4](https://github.com/OpenFn/adaptors/commit/62ec0a4): - Update square logo
   - Add semi-colon after each example.
   - Add options description to downloadAttachment function
   - Remove sensitive data in examples

--- a/packages/intuit/CHANGELOG.md
+++ b/packages/intuit/CHANGELOG.md
@@ -4,69 +4,69 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 1.0.8 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.7 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.6 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.5 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.4 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.3 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.2 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.1 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.0 - 30 January 2025

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -4,148 +4,148 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.5.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.5.16 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.5.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.5.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.5.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.5.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.5.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.5.10 - 10 March 2025
 
 ### Patch Changes
 
-- 8a8c28d: - cleanup examples wrapped with `execute()` function
+- [8a8c28d](https://github.com/OpenFn/adaptors/commit/8a8c28d): - cleanup examples wrapped with `execute()` function
   - Add example caption and add sample payload
 
 ## 0.5.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.5.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.5.7 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.5.6 - 18 October 2024
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.5.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.5.4 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 0.5.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.5.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.5.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.4.1 - 19 June 2023
@@ -160,7 +160,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -172,37 +172,37 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.3.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.3.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.3.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.3.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.3.0 - 25 November 2022
 
 ### Minor Changes
 
-- 9137655: migrate khanacademy
+- [9137655](https://github.com/OpenFn/adaptors/commit/9137655): migrate khanacademy

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -4,50 +4,50 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 4.2.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 4.2.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 4.1.1 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 4.1.0 - 06 June 2025
 
 ### Minor Changes
 
-- 2123876: Add support for `sort` and `start` option in `getSubmissions`
+- [2123876](https://github.com/OpenFn/adaptors/commit/2123876): Add support for `sort` and `start` option in `getSubmissions`
   function
 
 ## 4.0.0 - 30 May 2025
 
 ### Major Changes
 
-- fe5b899: Add automatic pagination to `getSubmissions()`.
+- [fe5b899](https://github.com/OpenFn/adaptors/commit/fe5b899): Add automatic pagination to `getSubmissions()`.
 
   `getSubmissions()` will now download all submissions, up to the requested
   limit, over multiple requests. Note that by default, a maximum of 30,000 items
@@ -96,52 +96,52 @@
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 3.0.4 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 3.0.3 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 3.0.2 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 3.0.1 - 16 February 2025
 
 ### Patch Changes
 
-- a8b91d2: Fix results handling for getSubmissions
+- [a8b91d2](https://github.com/OpenFn/adaptors/commit/a8b91d2): Fix results handling for getSubmissions
 
 ## 3.0.0 - 13 February 2025
 
 ### Major Changes
 
-- b01d4f0: Update all functions in the main API (remove callbacks and clean up
+- [b01d4f0](https://github.com/OpenFn/adaptors/commit/b01d4f0): Update all functions in the main API (remove callbacks and clean up
   signatures, see the Migration Guide)
-- 882ce29: Rewrite onto common http helpers (using undici)
+- [882ce29](https://github.com/OpenFn/adaptors/commit/882ce29): Rewrite onto common http helpers (using undici)
 
 ### Minor Changes
 
-- 6d536b2: Renaming `baseURL` to `baseUrl` to match all other adaptors, and
+- [6d536b2](https://github.com/OpenFn/adaptors/commit/6d536b2): Renaming `baseURL` to `baseUrl` to match all other adaptors, and
   logging a warning if `baseURL` is used
-- 311d3b2: Add http namespace with `get()`, `post()`, `put()`
+- [311d3b2](https://github.com/OpenFn/adaptors/commit/311d3b2): Add http namespace with `get()`, `post()`, `put()`
 
 ## Migration guide
 
@@ -163,56 +163,56 @@
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
 
 ## 2.4.1 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 2.4.0 - 19 June 2024
 
 ### Minor Changes
 
-- 5fb82f07: Export `group` operation from common
+- [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07): Export `group` operation from common
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 2.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 2.2.0 - 12 April 2024
 
 ### Minor Changes
 
-- bae5d3b6: Add the cursor() function from common. See the job writing guide for
+- [bae5d3b6](https://github.com/OpenFn/adaptors/commit/bae5d3b6): Add the cursor() function from common. See the job writing guide for
   more information.
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 2.1.0 - 13 September 2023
 
 ### Minor Changes
 
-- c85abf3: Removed the API version enum values in the credential configuration
+- [c85abf3](https://github.com/OpenFn/adaptors/commit/c85abf3): Removed the API version enum values in the credential configuration
   json schema and added a placeholder
 
 ## 2.0.1 - 19 June 2023
@@ -227,7 +227,7 @@
 
 ### Major Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -239,65 +239,65 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.3.3 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 1.3.2 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 1.3.1 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 1.3.0 - 13 January 2023
 
 ### Minor Changes
 
-- e48c30c: add getDeploymentInfo function
+- [e48c30c](https://github.com/OpenFn/adaptors/commit/e48c30c): add getDeploymentInfo function
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 1.2.0 - 18 November 2022
 
 ### Minor Changes
 
-- 7b5ca3e: add fn and fix adaptors export
+- [7b5ca3e](https://github.com/OpenFn/adaptors/commit/7b5ca3e): add fn and fix adaptors export
 
 ### Patch Changes
 
-- 4067c28: build ast file
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [4067c28](https://github.com/OpenFn/adaptors/commit/4067c28): build ast file
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 1.1.0 - 04 November 2022
 
 ### Minor Changes
 
-- 7fc47d8: Migrate kobotoolbox
+- [7fc47d8](https://github.com/OpenFn/adaptors/commit/7fc47d8): Migrate kobotoolbox
 
 ### Patch Changes
 
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4

--- a/packages/magpi/CHANGELOG.md
+++ b/packages/magpi/CHANGELOG.md
@@ -4,18 +4,18 @@
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.2.5 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.2.4 - 28 October 2024
@@ -30,39 +30,39 @@
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 1.2.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.2.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.2.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.1.2 - 24 January 2024
 
 ### Patch Changes
 
-- 6afba70: Fix variable reference in submitRecord
+- [6afba70](https://github.com/OpenFn/adaptors/commit/6afba70): Fix variable reference in submitRecord
 
 ## 1.1.1 - 19 June 2023
 
@@ -76,7 +76,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -88,47 +88,47 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.0.5 - 20 April 2023
 
 ### Patch Changes
 
-- 86fb813: dependencies update
+- [86fb813](https://github.com/OpenFn/adaptors/commit/86fb813): dependencies update
 
 ## 1.0.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 1.0.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 1.0.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 1.0.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 1.0.0 - 25 November 2022
 
 ### Major Changes
 
-- e6c2b4a: Update xml2js parser
+- [e6c2b4a](https://github.com/OpenFn/adaptors/commit/e6c2b4a): Update xml2js parser
 
 ### Minor Changes
 
-- df5dd2e: migrate magpi
+- [df5dd2e](https://github.com/OpenFn/adaptors/commit/df5dd2e): migrate magpi

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -4,85 +4,85 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.18 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.16 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.14 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.13 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.12 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.11 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 1.0.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 1.0.9 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 1.0.8 - 28 October 2024
@@ -97,58 +97,58 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 1.0.6 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 1.0.5 - 09 October 2024
 
 ### Patch Changes
 
-- 3fd13c2: Update axios to 1.7.7
+- [3fd13c2](https://github.com/OpenFn/adaptors/commit/3fd13c2): Update axios to 1.7.7
 
 ## 1.0.4 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 1.0.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.0.2 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.0.1 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.0.0 - 25 June 2024
 
 ### Major Changes
 
-- 60dec15: This update contains changes to the HTTP helpers (`get`, `post` etc):
+- [60dec15](https://github.com/OpenFn/adaptors/commit/60dec15): This update contains changes to the HTTP helpers (`get`, `post` etc):
 
   - Properly handle 204 responses (ie, success with no body)
   - On error, throw the mailchimp JSON body, which is full of useful info
@@ -164,11 +164,11 @@
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.7.4 - 08 May 2024
@@ -183,27 +183,27 @@
 
 ### Patch Changes
 
-- 6afba70: Fix updateMember()
+- [6afba70](https://github.com/OpenFn/adaptors/commit/6afba70): Fix updateMember()
 
 ## 0.7.2 - 16 December 2023
 
 ### Patch Changes
 
-- 1131c34: Remove regex pattern for validation and changed minLength to 1
+- [1131c34](https://github.com/OpenFn/adaptors/commit/1131c34): Remove regex pattern for validation and changed minLength to 1
 
 ## 0.7.1 - 13 September 2023
 
 ### Patch Changes
 
-- 1f856c4: Update configuration schema
-- 48394f5: - fix ast docs warnings
+- [1f856c4](https://github.com/OpenFn/adaptors/commit/1f856c4): Update configuration schema
+- [48394f5](https://github.com/OpenFn/adaptors/commit/48394f5): - fix ast docs warnings
   - add status code log on request
 
 ## 0.7.0 - 24 August 2023
 
 ### Minor Changes
 
-- 58fcea9: - Add chunk from common
+- [58fcea9](https://github.com/OpenFn/adaptors/commit/58fcea9): - Add chunk from common
   - Improve error logs
   - Return `state` in request finalState
 
@@ -211,13 +211,13 @@
 
 ### Minor Changes
 
-- 1582873: Add request, get and post functions
+- [1582873](https://github.com/OpenFn/adaptors/commit/1582873): Add request, get and post functions
 
 ## 0.5.0 - 01 August 2023
 
 ### Minor Changes
 
-- 8e39ee1: Add new functions
+- [8e39ee1](https://github.com/OpenFn/adaptors/commit/8e39ee1): Add new functions
 
   - addMember()
   - listMembers()
@@ -239,7 +239,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -251,49 +251,49 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.3.5 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.3.4 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.3.3 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.3.2 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.3.1 - 25 November 2022
 
 ### Patch Changes
 
-- cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
-- e81561f: Updated ast and package.json
+- [cbb8968](https://github.com/OpenFn/adaptors/commit/cbb8968): Fix axios Inefficient Regular Expression Complexity vulnerability
+- [e81561f](https://github.com/OpenFn/adaptors/commit/e81561f): Updated ast and package.json
 
 ## 0.3.0 - 18 November 2022
 
 ### Minor Changes
 
-- 88fa3b5: migrate mailchimp
+- [88fa3b5](https://github.com/OpenFn/adaptors/commit/88fa3b5): migrate mailchimp
 
 ### Patch Changes
 
-- Updated dependencies \[f2a91a4]
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -4,88 +4,88 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.5.16 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.5.15 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.5.14 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.5.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.5.12 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.5.11 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.5.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.5.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.5.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.5.7 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.5.6 - 28 October 2024
@@ -100,73 +100,73 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.5.4 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.5.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.5.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.5.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.4.5 - 24 April 2024
 
 ### Patch Changes
 
-- 02ab7a89: Change `host` format from `hostname` to `string` in
+- [02ab7a89](https://github.com/OpenFn/adaptors/commit/02ab7a89): Change `host` format from `hostname` to `string` in
   `configuration-schema.json`
 
 ## 0.4.4 - 19 March 2024
 
 ### Patch Changes
 
-- e7ff766: Update configuration-schema
+- [e7ff766](https://github.com/OpenFn/adaptors/commit/e7ff766): Update configuration-schema
 
 ## 0.4.3 - 11 August 2023
 
 ### Patch Changes
 
-- f86576d: Security update to mailgun.js
+- [f86576d](https://github.com/OpenFn/adaptors/commit/f86576d): Security update to mailgun.js
 
 ## 0.4.2 - 03 August 2023
 
 ### Patch Changes
 
-- 4620079: Bump opinionator version
+- [4620079](https://github.com/OpenFn/adaptors/commit/4620079): Bump opinionator version
 
 ## 0.4.1 - 19 June 2023
 
@@ -180,7 +180,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -192,37 +192,37 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.3.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.3.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.3.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.3.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.3.0 - 25 November 2022
 
 ### Minor Changes
 
-- 9ded25e: Migrate Mailgun
+- [9ded25e](https://github.com/OpenFn/adaptors/commit/9ded25e): Migrate Mailgun

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -4,93 +4,93 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.5.19 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.5.18 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.5.17 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.5.16 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.5.15 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.5.14 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.5.13 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.5.12 - 10 March 2025
 
 ### Patch Changes
 
-- 8a8c28d: - cleanup examples wrapped with `execute()` function
+- [8a8c28d](https://github.com/OpenFn/adaptors/commit/8a8c28d): - cleanup examples wrapped with `execute()` function
   - Add example caption and add sample payload
 
 ## 0.5.11 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.5.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.5.9 - 09 January 2025
 
 ### Patch Changes
 
-- cb9b3c5: Security update
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- [cb9b3c5](https://github.com/OpenFn/adaptors/commit/cb9b3c5): Security update
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.5.8 - 28 October 2024
@@ -105,62 +105,62 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.5.6 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.5.5 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 0.5.4 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.5.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.5.2 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.5.1 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 0.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.4.1 - 19 June 2023
@@ -175,7 +175,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -187,43 +187,43 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.3.5 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.3.4 - 17 March 2023
 
 ### Patch Changes
 
-- aed7e0b: fix required field in configuration schema
+- [aed7e0b](https://github.com/OpenFn/adaptors/commit/aed7e0b): fix required field in configuration schema
 
 ## 0.3.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.3.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.3.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.3.0 - 25 November 2022
 
 ### Minor Changes
 
-- 4d4be56: migrate maximo
+- [4d4be56](https://github.com/OpenFn/adaptors/commit/4d4be56): migrate maximo

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -4,88 +4,88 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.5.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.5.16 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.5.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.5.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.5.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.5.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.5.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.5.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.5.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.5.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.5.7 - 28 October 2024
@@ -100,60 +100,60 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.5.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.5.4 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 0.5.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.5.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.5.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.4.2 - 03 August 2023
 
 ### Patch Changes
 
-- 421fad3: Bump query-string
+- [421fad3](https://github.com/OpenFn/adaptors/commit/421fad3): Bump query-string
 
 ## 0.4.1 - 19 June 2023
 
@@ -167,7 +167,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -179,36 +179,36 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.3.3 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.3.2 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.3.1 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.3.0 - 18 November 2022
 
 ### Minor Changes
 
-- 2cd3236: migrate medicmobile
+- [2cd3236](https://github.com/OpenFn/adaptors/commit/2cd3236): migrate medicmobile
 
 ### Patch Changes
 
-- Updated dependencies \[f2a91a4]
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -4,89 +4,89 @@ v0.1.6
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.6.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.6.0 - 10 July 2025
 
 ### Minor Changes
 
-- a4f3740: Removed map() function, exported from common
+- [a4f3740](https://github.com/OpenFn/adaptors/commit/a4f3740): Removed map() function, exported from common
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.5.16 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.5.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.5.14 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.5.13 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.5.12 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.5.11 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.5.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.5.9 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.5.8 - 28 October 2024
@@ -101,62 +101,62 @@ v0.1.6
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.5.6 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.5.5 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 0.5.4 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.5.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.5.2 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.5.1 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 0.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 3d9d564c: Add `fn` and `fnIf` operation
+- [3d9d564c](https://github.com/OpenFn/adaptors/commit/3d9d564c): Add `fn` and `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.4.1 - 19 June 2023
@@ -171,7 +171,7 @@ v0.1.6
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -183,38 +183,38 @@ v0.1.6
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.3.4 - 20 April 2023
 
 ### Patch Changes
 
-- 7cc8efc: remove FakeAdaptor references
+- [7cc8efc](https://github.com/OpenFn/adaptors/commit/7cc8efc): remove FakeAdaptor references
 
 ## 0.3.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.3.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.3.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.3.0 - 25 November 2022
 
 ### Minor Changes
 
-- # c6056e8: migrate mogli
+- # [c6056e8](https://github.com/OpenFn/adaptors/commit/c6056e8): migrate mogli
 
 * State gets cleaned up after the operations are finished. This means that the
   final state is serializable.

--- a/packages/mojatax/CHANGELOG.md
+++ b/packages/mojatax/CHANGELOG.md
@@ -4,87 +4,87 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.12 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.11 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.10 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.9 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.8 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.7 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.6 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.5 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 1.0.4 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 1.0.3 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 1.0.2 - 28 October 2024
@@ -99,7 +99,7 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 1.0.0 - 16 October 2024

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -10,88 +10,88 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.1.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.1.16 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 2.1.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 2.1.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 2.1.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 2.1.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 2.1.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 2.1.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 2.1.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 2.1.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 2.1.7 - 28 October 2024
@@ -106,70 +106,70 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 2.1.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 2.1.4 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 2.1.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 2.1.2 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 2.1.1 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 2.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 2.0.2 - 24 April 2024
 
 ### Patch Changes
 
-- 38b3e8e0: Change `clusterHostname` format from `hostname` to `string` in
+- [38b3e8e0](https://github.com/OpenFn/adaptors/commit/38b3e8e0): Change `clusterHostname` format from `hostname` to `string` in
   `configuration-schema.json`
 
 ## 2.0.1 - 24 January 2024
 
 ### Patch Changes
 
-- 6afba70: Fix findDocuments
+- [6afba70](https://github.com/OpenFn/adaptors/commit/6afba70): Fix findDocuments
 
 ## 2.0.0 - 22 August 2023
 
@@ -192,7 +192,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -204,17 +204,17 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.0.6 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 1.0.5 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples

--- a/packages/mpesa/CHANGELOG.md
+++ b/packages/mpesa/CHANGELOG.md
@@ -4,67 +4,67 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 1.1.2 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.4 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.3 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- d1f7851: Fixed the title for the consumer\_secret on the configuration schema
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- [d1f7851](https://github.com/OpenFn/adaptors/commit/d1f7851): Fixed the title for the consumer\_secret on the configuration schema
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.2 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.1 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.0 - 02 April 2025

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -4,89 +4,89 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.8.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.8.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.7.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.7.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.7.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.7.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.7.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.7.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.7.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.7.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.7.7 - 28 October 2024
@@ -101,69 +101,69 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.7.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.7.4 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.7.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.7.2 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.7.1 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 0.7.0 - 12 July 2024
 
 ### Minor Changes
 
-- 1d2a641: Normalize configuration keys for oauth. `access_token` and
+- [1d2a641](https://github.com/OpenFn/adaptors/commit/1d2a641): Normalize configuration keys for oauth. `access_token` and
   `accessToken` are now both supported (`access_token` is preferred)
 
 ## 0.6.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 0.6.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.5.5 - 11 June 2024
@@ -177,14 +177,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 0.5.3 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 0.5.2 - 08 May 2024
@@ -206,63 +206,63 @@
 
 ### Minor Changes
 
-- bae5d3b6: Add the cursor() function from common. See the job writing guide for
+- [bae5d3b6](https://github.com/OpenFn/adaptors/commit/bae5d3b6): Add the cursor() function from common. See the job writing guide for
   more information.
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 0.4.0 - 20 September 2023
 
 ### Minor Changes
 
-- 4cd6587: Add `uploadFile` and `sheetToBuffer` function
+- [4cd6587](https://github.com/OpenFn/adaptors/commit/4cd6587): Add `uploadFile` and `sheetToBuffer` function
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 0.3.5 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 0.3.4 - 18 August 2023
 
 ### Patch Changes
 
-- 1c183e9: Fix getFile unit tests
+- [1c183e9](https://github.com/OpenFn/adaptors/commit/1c183e9): Fix getFile unit tests
 
 ## 0.3.3 - 14 August 2023
 
 ### Patch Changes
 
-- b90e8a2: Add support for stream
-- Updated dependencies \[df09270]
+- [b90e8a2](https://github.com/OpenFn/adaptors/commit/b90e8a2): Add support for stream
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 0.3.2 - 28 July 2023
 
 ### Patch Changes
 
-- 9cc4952: fix url in request util
+- [9cc4952](https://github.com/OpenFn/adaptors/commit/9cc4952): fix url in request util
 
 ## 0.3.1 - 27 July 2023
 
 ### Patch Changes
 
-- f45f477: Clean-up state before throwing an error
+- [f45f477](https://github.com/OpenFn/adaptors/commit/f45f477): Clean-up state before throwing an error
 
 ## 0.3.0 - 26 July 2023
 
 ### Minor Changes
 
-- 9366e53: - Switch from `nodejs` default `fetch` to `undici` `fetch`
+- [9366e53](https://github.com/OpenFn/adaptors/commit/9366e53): - Switch from `nodejs` default `fetch` to `undici` `fetch`
   - Added the following `sharepoint` functions
     - `getDrive()`
     - `getFolder()`
@@ -272,29 +272,29 @@
 
 ### Minor Changes
 
-- d33c0ee: export parseCsv from common
+- [d33c0ee](https://github.com/OpenFn/adaptors/commit/d33c0ee): export parseCsv from common
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 0.1.1 - 30 June 2023
 
 ### Patch Changes
 
-- aad9549: Ensure that standard OAuth2 credentials with snake-cased
+- [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549): Ensure that standard OAuth2 credentials with snake-cased
   "access\_token" keys can be used for OAuth2-reliant adaptors
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 0.1.0 - 23 June 2023
 
 ### Minor Changes
 
-- 93d82a8: Add msgraph adaptor with get() and create() functions
+- [93d82a8](https://github.com/OpenFn/adaptors/commit/93d82a8): Add msgraph adaptor with get() and create() functions
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- d737f89: Optimize query handling by:
+- [d737f89](https://github.com/OpenFn/adaptors/commit/d737f89): Optimize query handling by:
 
   - Revert to using `tedious.Request's callback` signature
   - Remove `rowCollectionOnRequestCompletion` option from configuration
@@ -14,7 +14,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -49,104 +49,104 @@
 
 ### Patch Changes
 
-- 5e97559: Fix `findValue` and `queryHandler` to return rows
+- [5e97559](https://github.com/OpenFn/adaptors/commit/5e97559): Fix `findValue` and `queryHandler` to return rows
 
 ## 5.2.2 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 5.2.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 5.2.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 5.1.0 - 20 June 2025
 
 ### Minor Changes
 
-- 49cd197: - Automatically excape incoming query parameters to protect against
+- [49cd197](https://github.com/OpenFn/adaptors/commit/49cd197): - Automatically excape incoming query parameters to protect against
   SQL attacks
   - Add `escape()` util function
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 5.0.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 5.0.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 5.0.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 5.0.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 5.0.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 5.0.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 5.0.8 - 09 January 2025
 
 ### Patch Changes
 
-- de03bea: Update tedious to 1.18.0. This should have no impact on the adaptor,
+- [de03bea](https://github.com/OpenFn/adaptors/commit/de03bea): Update tedious to 1.18.0. This should have no impact on the adaptor,
   but note this version will only run in node versions 18.x and 20+ (this should
   be fully compatible with all `@openfn/cli` and `@openfn/ws-worker` releases)
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 5.0.7 - 28 October 2024
@@ -161,47 +161,47 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 5.0.6 - 18 October 2024
 
 ### Patch Changes
 
-- d8d84d3: improve logging error message
+- [d8d84d3](https://github.com/OpenFn/adaptors/commit/d8d84d3): improve logging error message
 
 ## 5.0.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 5.0.4 - 26 September 2024
 
 ### Patch Changes
 
-- d3ac969: use reject instead of throw
+- [d3ac969](https://github.com/OpenFn/adaptors/commit/d3ac969): use reject instead of throw
 
 ## 5.0.3 - 26 September 2024
 
 ### Patch Changes
 
-- 6d38a48: Removed process.exit(1) to prevent workflow crashes on errors
+- [6d38a48](https://github.com/OpenFn/adaptors/commit/6d38a48): Removed process.exit(1) to prevent workflow crashes on errors
 
 ## 5.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 5.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 5.0.0 - 01 August 2024
@@ -214,39 +214,39 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 4.3.3 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 4.3.2 - 05 July 2024
 
 ### Patch Changes
 
-- bb5436c: Add title and description for `port` configuration
+- [bb5436c](https://github.com/OpenFn/adaptors/commit/bb5436c): Add title and description for `port` configuration
 
 ## 4.3.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 4.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 4.2.4 - 11 June 2024
@@ -260,14 +260,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 4.2.2 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 4.2.1 - 08 May 2024
@@ -281,7 +281,7 @@
 
 ### Minor Changes
 
-- 2964fc8d: - Add `cursor()` function
+- [2964fc8d](https://github.com/OpenFn/adaptors/commit/2964fc8d): - Add `cursor()` function
   - Update `configuration-schema.json`
 
 ## 4.1.10 - 12 April 2024
@@ -295,56 +295,56 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 4.1.8 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 4.1.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 4.1.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 4.1.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 4.1.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 4.1.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 4.1.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 4.1.1 - 19 June 2023
@@ -359,7 +359,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -371,92 +371,92 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 4.0.8 - 31 May 2023
 
 ### Patch Changes
 
-- 57742d1: remove request dependency
+- [57742d1](https://github.com/OpenFn/adaptors/commit/57742d1): remove request dependency
 
 ## 4.0.7 - 20 April 2023
 
 ### Patch Changes
 
-- 04ed74f: update dependencies
+- [04ed74f](https://github.com/OpenFn/adaptors/commit/04ed74f): update dependencies
 
 ## 4.0.6 - 06 April 2023
 
 ### Patch Changes
 
-- 43c3669: patch versions
+- [43c3669](https://github.com/OpenFn/adaptors/commit/43c3669): patch versions
 
 ## 4.0.5 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 4.0.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 4.0.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 4.0.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 4.0.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 4.0.0 - 18 November 2022
 
 ### Major Changes
 
-- 3878624: Modify composeNextState function, to flattern all rows into an array
+- [3878624](https://github.com/OpenFn/adaptors/commit/3878624): Modify composeNextState function, to flattern all rows into an array
   of rows with their corresponding column names
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 3.1.1 - 04 November 2022
 
 ### Patch Changes
 
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
 
 ## 3.1.0 - 21 October 2022
 
 ### Minor Changes
 
-- c9b7ed7: Add language-mssql in monorepo
+- [c9b7ed7](https://github.com/OpenFn/adaptors/commit/c9b7ed7): Add language-mssql in monorepo
 
 ### Patch Changes
 
-- e04aa28: Rename credential-schema to configuration-schema, update descriptions
+- [e04aa28](https://github.com/OpenFn/adaptors/commit/e04aa28): Rename credential-schema to configuration-schema, update descriptions

--- a/packages/msupply/CHANGELOG.md
+++ b/packages/msupply/CHANGELOG.md
@@ -4,49 +4,49 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.5 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.4 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.3 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.2 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.1 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.0 - 11 April 2025

--- a/packages/mtn-momo/CHANGELOG.md
+++ b/packages/mtn-momo/CHANGELOG.md
@@ -4,36 +4,36 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.1 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.0 - 12 May 2025

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- 62d0fd3: - Removed `query(options) ⇒ Operation` function
+- [62d0fd3](https://github.com/OpenFn/adaptors/commit/62d0fd3): - Removed `query(options) ⇒ Operation` function
 
   - Removed `sqlString(queryString) ⇒ Operation` function
   - Remove `http` function from `common` exports
@@ -33,72 +33,72 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.2.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.2.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 2.1.5 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 2.1.4 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 2.1.3 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 2.1.2 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 2.1.1 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 2.1.0 - 10 March 2025
 
 ### Minor Changes
 
-- e87110f: - add `cursor` and `dateFns` from `@openfn/language-common`
+- [e87110f](https://github.com/OpenFn/adaptors/commit/e87110f): - add `cursor` and `dateFns` from `@openfn/language-common`
   - cleanup examples wrapped with `execute()` function
   - Add example caption and add sample payload
   - remove unused import of url
@@ -107,24 +107,24 @@
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 2.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 2.0.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 2.0.5 - 28 October 2024
@@ -139,29 +139,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 2.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 2.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 2.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 2.0.0 - 01 August 2024
@@ -174,34 +174,34 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.5.2 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.5.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 1.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.4.15 - 11 June 2024
@@ -215,14 +215,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 1.4.13 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 1.4.12 - 08 May 2024
@@ -236,7 +236,7 @@
 
 ### Patch Changes
 
-- e9d0dac9: - Change `host` format from `uri` to `string` in
+- [e9d0dac9](https://github.com/OpenFn/adaptors/commit/e9d0dac9): - Change `host` format from `uri` to `string` in
   `configuration-schema.json`
   - Update required list to include `user` and `password`
 
@@ -251,56 +251,56 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 1.4.8 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 1.4.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 1.4.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 1.4.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 1.4.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 1.4.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 1.4.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 1.4.1 - 19 June 2023
@@ -315,7 +315,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -327,45 +327,45 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.3.5 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 1.3.4 - 30 March 2023
 
 ### Patch Changes
 
-- ef828e7: update old urls in readme
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [ef828e7](https://github.com/OpenFn/adaptors/commit/ef828e7): update old urls in readme
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 1.3.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 1.3.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 1.3.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 1.3.0 - 25 November 2022
 
 ### Minor Changes
 
-- 9d674c5: Migrate MySQL
+- [9d674c5](https://github.com/OpenFn/adaptors/commit/9d674c5): Migrate MySQL

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -4,91 +4,91 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 0.5.20 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.5.19 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.5.18 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.5.17 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.5.16 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.5.15 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.5.14 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.5.13 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.5.12 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.5.11 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.5.10 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.5.9 - 28 October 2024
@@ -103,68 +103,68 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.5.7 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.5.6 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 0.5.5 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.5.4 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.5.3 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.5.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 0.5.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 0.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.4.9 - 11 June 2024
@@ -178,14 +178,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 0.4.7 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 0.4.6 - 08 May 2024
@@ -206,35 +206,35 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 0.4.3 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 0.4.2 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 0.4.1 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 0.4.0 - 03 August 2023
 
 ### Minor Changes
 
-- 8591b67: - update nexmo to \`v2.9.1\`\`
+- [8591b67](https://github.com/OpenFn/adaptors/commit/8591b67): - update nexmo to \`v2.9.1\`\`
   - expandReferences on sendSMS
 
 ## 0.3.1 - 19 June 2023
@@ -249,7 +249,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -261,31 +261,31 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.2.3 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.2.2 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.2.1 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.2.0 - 25 November 2022
 
 ### Minor Changes
 
-- f0f2495: migrate nexmo
+- [f0f2495](https://github.com/OpenFn/adaptors/commit/f0f2495): migrate nexmo

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -4,85 +4,85 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.2.18 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.2.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.2.16 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.2.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.2.14 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.2.13 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.2.12 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.2.11 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 1.2.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 1.2.9 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 1.2.8 - 28 October 2024
@@ -97,62 +97,62 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 1.2.6 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 1.2.5 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 1.2.4 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.2.3 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.2.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.2.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 1.2.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.1.13 - 11 June 2024
@@ -166,14 +166,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 1.1.11 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 1.1.10 - 08 May 2024
@@ -195,69 +195,69 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 1.1.7 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 1.1.6 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 1.1.5 - 31 August 2023
 
 ### Patch Changes
 
-- 67a09fb: Add `fn` in OCL adaptor
+- [67a09fb](https://github.com/OpenFn/adaptors/commit/67a09fb): Add `fn` in OCL adaptor
 
 ## 1.1.4 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 1.1.3 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 1.1.2 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 1.1.1 - 30 June 2023
 
 ### Patch Changes
 
-- 3f3c0c5: update tests
-- Updated dependencies \[aad9549]
+- [3f3c0c5](https://github.com/OpenFn/adaptors/commit/3f3c0c5): update tests
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 1.1.0 - 26 June 2023
 
 ### Minor Changes
 
-- 29e335d: remove body in get request
+- [29e335d](https://github.com/OpenFn/adaptors/commit/29e335d): remove body in get request
 
 ## 1.0.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 1.0.1 - 19 June 2023
@@ -272,7 +272,7 @@
 
 ### Major Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -284,70 +284,70 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.3.0 - 15 June 2023
 
 ### Minor Changes
 
-- 63232eb: Add `get()` and `getMappings()` function
+- [63232eb](https://github.com/OpenFn/adaptors/commit/63232eb): Add `get()` and `getMappings()` function
 
 ## 0.2.6 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 0.2.5 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.2.4 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.2.3 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.2.2 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.2.1 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 0.2.0 - 04 November 2022
 
 ### Minor Changes
 
-- 5a06d7f: Migrate OCL, update package export
+- [5a06d7f](https://github.com/OpenFn/adaptors/commit/5a06d7f): Migrate OCL, update package export
 
 ### Patch Changes
 
-- cb5d0ed: Updated to @openfn/simple-ast v0.4.1
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [cb5d0ed](https://github.com/OpenFn/adaptors/commit/cb5d0ed): Updated to @openfn/simple-ast v0.4.1
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -4,94 +4,94 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 3.0.18 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 3.0.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 3.0.16 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 3.0.15 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 3.0.14 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 3.0.13 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 3.0.12 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 3.0.11 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 3.0.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 3.0.9 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 3.0.8 - 04 January 2025
 
 ### Patch Changes
 
-- 6c9affd: Fix typo in error message
+- [6c9affd](https://github.com/OpenFn/adaptors/commit/6c9affd): Fix typo in error message
 
 ## 3.0.7 - 28 October 2024
 
@@ -105,52 +105,52 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 3.0.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 3.0.4 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 3.0.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 3.0.2 - 01 August 2024
 
 ### Patch Changes
 
-- f51c5d0: Enforce that absolute urls must not be passed to HTTP functions
-- Updated dependencies \[4fe527c]
+- [f51c5d0](https://github.com/OpenFn/adaptors/commit/f51c5d0): Enforce that absolute urls must not be passed to HTTP functions
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 3.0.1 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 3.0.0 - 02 July 2024
 
 ### Major Changes
 
-- 0b81f06: - `getSubmissions()` now returns submission data (not metadata)
+- [0b81f06](https://github.com/OpenFn/adaptors/commit/0b81f06): - `getSubmissions()` now returns submission data (not metadata)
   - `getSubmissions()` arguments can be references (functions)
   - `getSubmissions()` supports query parameters
   - HTTP helper APIs have been slightly streamlined and fixed
@@ -161,7 +161,7 @@
 
 ### Major Changes
 
-- 9234f83: - configuration-schema: rename `username` to `email`
+- [9234f83](https://github.com/OpenFn/adaptors/commit/9234f83): - configuration-schema: rename `username` to `email`
   - Improve logging when authentication fails
   - Improve error reporting when requests fail
 
@@ -169,18 +169,18 @@
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 1.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.0.1 - 11 June 2024

--- a/packages/odoo/CHANGELOG.md
+++ b/packages/odoo/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 2.1.0 - 14 August 2025
 
 ### Minor Changes
 
-- 282f9f3: Add `search()` and `searchReadRecord()` functions.
+- [282f9f3](https://github.com/OpenFn/adaptors/commit/282f9f3): Add `search()` and `searchReadRecord()` functions.
   - `search()` Only returns the record IDs.
   - `searchReadRecord()` returns the records with the specified criteria or the
     full record if none is given.
@@ -19,7 +19,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -54,70 +54,70 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.9 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.8 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.7 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.6 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.5 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.4 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.3 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.2 - 12 March 2025
 
 ### Patch Changes
 
-- cde1ead: Add a `downloadNewRecord: true` option to `create` to enable
+- [cde1ead](https://github.com/OpenFn/adaptors/commit/cde1ead): Add a `downloadNewRecord: true` option to `create` to enable
   downloading of the whole record in the response.
 
   ```js
@@ -132,10 +132,10 @@
 
 ### Patch Changes
 
-- 2f58a71: Default `create()` options to `{}` to ensure that the options
+- [2f58a71](https://github.com/OpenFn/adaptors/commit/2f58a71): Default `create()` options to `{}` to ensure that the options
   argument is optional.
-- e26fbd5: Simplified logging across the adaptor without displaying user data
-- 2db9f8d: Update the third argument in `read()` examples and documentation to
+- [e26fbd5](https://github.com/OpenFn/adaptors/commit/e26fbd5): Simplified logging across the adaptor without displaying user data
+- [2db9f8d](https://github.com/OpenFn/adaptors/commit/2db9f8d): Update the third argument in `read()` examples and documentation to
   explicitly indicate that it accepts an array of strings.
 
 ## 1.0.0 - 18 February 2025

--- a/packages/openboxes/CHANGELOG.md
+++ b/packages/openboxes/CHANGELOG.md
@@ -4,56 +4,56 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.6 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.5 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.4 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.3 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.2 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.1 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.0 - 24 March 2025

--- a/packages/opencrvs/CHANGELOG.md
+++ b/packages/opencrvs/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 1.0.2 - 04 August 2025
 
 ### Patch Changes
 
-- b36f6d8: Remove `format:'uri'` from domain config
+- [b36f6d8](https://github.com/OpenFn/adaptors/commit/b36f6d8): Remove `format:'uri'` from domain config
 
 ## 1.0.1 - 21 July 2025
 
 ### Patch Changes
 
-- ad57dbf: Update `queryEvents()` examples
+- [ad57dbf](https://github.com/OpenFn/adaptors/commit/ad57dbf): Update `queryEvents()` examples
 
 ## 1.0.0
 

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -4,32 +4,32 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 3.0.2 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 3.0.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 3.0.0 - 02 July 2025
 
 ### Major Changes
 
-- 6bf20c4: ## Major Changes
+- [6bf20c4](https://github.com/OpenFn/adaptors/commit/6bf20c4): ## Major Changes
 
   - Add support for v2 API
   - Add `post()` and `get()` functions
@@ -44,60 +44,60 @@
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 2.0.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 2.0.12 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 2.0.11 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 2.0.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 2.0.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 2.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 2.0.7 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 2.0.6 - 28 October 2024
@@ -112,35 +112,35 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 2.0.4 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 2.0.3 - 09 October 2024
 
 ### Patch Changes
 
-- 3fd13c2: Update axios to 1.7.7
+- [3fd13c2](https://github.com/OpenFn/adaptors/commit/3fd13c2): Update axios to 1.7.7
 
 ## 2.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 2.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 2.0.0 - 01 August 2024
@@ -153,33 +153,33 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.4.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.4.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 1.4.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.3.14 - 11 June 2024
@@ -193,14 +193,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 1.3.12 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 1.3.11 - 08 May 2024
@@ -221,56 +221,56 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 1.3.8 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 1.3.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 1.3.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 1.3.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 1.3.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 1.3.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 1.3.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 1.3.1 - 19 June 2023
@@ -285,7 +285,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -297,50 +297,50 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.2.6 - 10 June 2023
 
 ### Patch Changes
 
-- 779596f: Use native fetch (undici) in template and add icons in openfn
+- [779596f](https://github.com/OpenFn/adaptors/commit/779596f): Use native fetch (undici) in template and add icons in openfn
 
 ## 1.2.5 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 1.2.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 1.2.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 1.2.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 1.2.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 1.2.0 - 25 November 2022
 
 ### Minor Changes
 
-- be9d3c6: Migrate OpenFn
+- [be9d3c6](https://github.com/OpenFn/adaptors/commit/be9d3c6): Migrate OpenFn

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -4,152 +4,152 @@
 
 ### Major Changes
 
-- abfce90: Change `registerClient()` to `createClient()`. Remove
+- [abfce90](https://github.com/OpenFn/adaptors/commit/abfce90): Change `registerClient()` to `createClient()`. Remove
   `updateClient()`
 
 ## 1.0.0 - 14 July 2025
 
 ### Major Changes
 
-- 08b6f7b: - Implement `http` namespace with `GET`, `POST`, `PUT`, and `DELETE`
+- [08b6f7b](https://github.com/OpenFn/adaptors/commit/08b6f7b): - Implement `http` namespace with `GET`, `POST`, `PUT`, and `DELETE`
   - Add `client, tasks, transactions, and channels` functions
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.3.16 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.3.15 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.3.14 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.3.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.3.12 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.3.11 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.3.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.3.9 - 10 March 2025
 
 ### Patch Changes
 
-- 8a8c28d: - cleanup examples wrapped with `execute()` function
+- [8a8c28d](https://github.com/OpenFn/adaptors/commit/8a8c28d): - cleanup examples wrapped with `execute()` function
   - Add example caption and add sample payload
 
 ## 0.3.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.3.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.3.6 - 09 January 2025
 
 ### Patch Changes
 
-- cb9b3c5: Security update
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- [cb9b3c5](https://github.com/OpenFn/adaptors/commit/cb9b3c5): Security update
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.3.5 - 18 October 2024
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.3.4 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.3.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.3.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.3.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.2.1 - 19 June 2023
@@ -164,7 +164,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -176,42 +176,42 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.1.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.1.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.1.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.1.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.1.0 - 25 November 2022
 
 ### Minor Changes
 
-- 1fd9b3b: Migrate OpenHIM
+- [1fd9b3b](https://github.com/OpenFn/adaptors/commit/1fd9b3b): Migrate OpenHIM
 
 ### Patch Changes
 
-- e4ebcb6: Fix Large gzip Denial of Service in superagent
-- e81561f: Updated ast and package.json
+- [e4ebcb6](https://github.com/OpenFn/adaptors/commit/e4ebcb6): Fix Large gzip Denial of Service in superagent
+- [e81561f](https://github.com/OpenFn/adaptors/commit/e81561f): Updated ast and package.json

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,96 +39,96 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 2.0.14 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 2.0.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 2.0.12 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 2.0.11 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 2.0.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 2.0.9 - 10 March 2025
 
 ### Patch Changes
 
-- 8a8c28d: - cleanup examples wrapped with `execute()` function
+- [8a8c28d](https://github.com/OpenFn/adaptors/commit/8a8c28d): - cleanup examples wrapped with `execute()` function
   - Add example caption and add sample payload
 
 ## 2.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 2.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 2.0.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 2.0.5 - 28 October 2024
@@ -143,29 +143,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 2.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 2.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 2.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 2.0.0 - 01 August 2024
@@ -178,33 +178,33 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.1.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.1.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 1.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.0.3 - 11 June 2024
@@ -218,14 +218,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 1.0.1 - 17 May 2024
 
 ### Patch Changes
 
-- 6c588212: Fix configuration-schema and add baseUrl in required
+- [6c588212](https://github.com/OpenFn/adaptors/commit/6c588212): Fix configuration-schema and add baseUrl in required
 
 ## 1.0.0 - 09 May 2024
 

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -4,91 +4,91 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.14 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.0.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 1.0.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 1.0.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 1.0.7 - 28 October 2024
@@ -103,45 +103,45 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 1.0.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 1.0.4 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 1.0.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.0.2 - 01 August 2024
 
 ### Patch Changes
 
-- 940996b: Use common helper code to handle invalid absolute URLs
-- Updated dependencies \[4fe527c]
+- [940996b](https://github.com/OpenFn/adaptors/commit/940996b): Use common helper code to handle invalid absolute URLs
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.0.1 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.0.0 - 18 July 2024

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -4,76 +4,76 @@
 
 ### Minor Changes
 
-- 5c12ab4: - Add `http.put()` helper function
+- [5c12ab4](https://github.com/OpenFn/adaptors/commit/5c12ab4): - Add `http.put()` helper function
   - Fix docs on `http.request()`
 
 ## 5.2.2 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 5.2.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 5.2.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common
-- 8d78db4: Export `map()` function from common
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common
+- [8d78db4](https://github.com/OpenFn/adaptors/commit/8d78db4): Export `map()` function from common
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 5.1.0
 
 ### Minor Changes
 
-- 3a97556: Add support for `language` option
+- [3a97556](https://github.com/OpenFn/adaptors/commit/3a97556): Add support for `language` option
 
 ## 5.0.4 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 5.0.3 - 14 June 2025
 
 ### Patch Changes
 
-- be854ec: Fix an issue where upsert will wrongly trigger creation of an
+- [be854ec](https://github.com/OpenFn/adaptors/commit/be854ec): Fix an issue where upsert will wrongly trigger creation of an
   existing item
-- 59251d5: Fix an issue where upsert will create to the wrong URL if there is no
+- [59251d5](https://github.com/OpenFn/adaptors/commit/59251d5): Fix an issue where upsert will create to the wrong URL if there is no
   UUID in the path
 
 ## 5.0.2 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 5.0.1 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 5.0.0 - 11 April 2025
@@ -97,7 +97,7 @@ cleaner API and automatic pagination on `get()`.
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ### Migration Guide
@@ -139,19 +139,19 @@ fn(state => {
 
 ### Minor Changes
 
-- 23ccb01: Allow errors to be passed to the http helpers. This overrides the
+- [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01): Allow errors to be passed to the http helpers. This overrides the
   behaviour to throw if an error code is returned
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 4.3.0 - 28 January 2025
 
 ### Minor Changes
 
-- 909d81f: Added `http.post()`, `http.delete()` and `http.get()`.
+- [909d81f](https://github.com/OpenFn/adaptors/commit/909d81f): Added `http.post()`, `http.delete()` and `http.get()`.
 
   removed the undocumented callback in `http.request()`.
 
@@ -159,7 +159,7 @@ fn(state => {
 
 ### Minor Changes
 
-- 5d6839e: Implement namespaced http.request() function. The function makes a
+- [5d6839e](https://github.com/OpenFn/adaptors/commit/5d6839e): Implement namespaced http.request() function. The function makes a
   call against the `instanceUrl` and the path provided, while allowing
   manipulation to the API call as needed.
 
@@ -167,24 +167,24 @@ fn(state => {
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 4.1.5 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 4.1.4 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 4.1.3 - 28 October 2024
@@ -199,33 +199,33 @@ fn(state => {
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 4.1.1 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 4.1.0 - 09 October 2024
 
 ### Minor Changes
 
-- 1227829: Add `fhir.get()` function
+- [1227829](https://github.com/OpenFn/adaptors/commit/1227829): Add `fhir.get()` function
 
 ## 4.0.2 - 03 October 2024
 
 ### Patch Changes
 
-- b1c48c7: improve upsert operation
+- [b1c48c7](https://github.com/OpenFn/adaptors/commit/b1c48c7): improve upsert operation
 
 ## 4.0.1 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 4.0.0 - 12 September 2024
@@ -237,7 +237,7 @@ fn(state => {
 
 ### Minor Changes
 
-- c8dbd21: Add cursor and dateFns helper functions
+- [c8dbd21](https://github.com/OpenFn/adaptors/commit/c8dbd21): Add cursor and dateFns helper functions
 
 ### Migration Guide
 
@@ -260,42 +260,42 @@ create('patient', $.patient);
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 3.1.3 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 3.1.2 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 3.1.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 3.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 3.0.6 - 11 June 2024
@@ -309,14 +309,14 @@ create('patient', $.patient);
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 3.0.4 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 3.0.3 - 08 May 2024
@@ -337,14 +337,14 @@ create('patient', $.patient);
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 3.0.0 - 03 April 2024
 
 ### Major Changes
 
-- cadff13b: - Remove superagent dependency.
+- [cadff13b](https://github.com/OpenFn/adaptors/commit/cadff13b): - Remove superagent dependency.
   - Rebase on new common http request helper.
   - Remove login function as no longer needed.
   - Update log output
@@ -353,49 +353,49 @@ create('patient', $.patient);
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 2.0.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 2.0.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 2.0.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 2.0.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 2.0.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 2.0.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 2.0.1 - 19 June 2023
@@ -410,7 +410,7 @@ create('patient', $.patient);
 
 ### Major Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -422,21 +422,21 @@ create('patient', $.patient);
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.1.1 - 15 June 2023
 
 ### Patch Changes
 
-- 2390129: - replace throw new Error with console.log
+- [2390129](https://github.com/OpenFn/adaptors/commit/2390129): - replace throw new Error with console.log
   - improve Log function
 
 ## 1.1.0 - 10 June 2023
 
 ### Minor Changes
 
-- d124f67: - Add create, update and upsert function
+- [d124f67](https://github.com/OpenFn/adaptors/commit/d124f67): - Add create, update and upsert function
   - Add callback support and improve examples for
     - get()
     - post()
@@ -452,14 +452,14 @@ create('patient', $.patient);
 
 ### Patch Changes
 
-- 97cc7ce: - Fix checking for empty response
+- [97cc7ce](https://github.com/OpenFn/adaptors/commit/97cc7ce): - Fix checking for empty response
   - Style logs output
 
 ## 1.0.0 - 30 May 2023
 
 ### Major Changes
 
-- b6478c0: - Removed `request` in favour of `superagent`
+- [b6478c0](https://github.com/OpenFn/adaptors/commit/b6478c0): - Removed `request` in favour of `superagent`
   - Improve error handling
   - Moved `login` to execute function
   - Added
@@ -475,37 +475,37 @@ create('patient', $.patient);
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 0.10.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.10.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.10.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.10.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.10.0 - 25 November 2022
 
 ### Minor Changes
 
-- 6786949: Migrate OpenMRS
+- [6786949](https://github.com/OpenFn/adaptors/commit/6786949): Migrate OpenMRS

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,85 +39,85 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.0.15 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.0.14 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 2.0.13 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 2.0.12 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 2.0.11 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 2.0.10 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 2.0.9 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 2.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 2.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 2.0.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 2.0.5 - 28 October 2024
@@ -132,29 +132,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 2.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 2.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 2.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 2.0.0 - 01 August 2024
@@ -167,18 +167,18 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.2.1 - 08 May 2024
@@ -193,7 +193,7 @@
 
 ### Changes
 
-- 05defd2: add new functions, correcting docstring and add more examples
+- [05defd2](https://github.com/OpenFn/adaptors/commit/05defd2): add new functions, correcting docstring and add more examples
   - correcting docstring input parameters type
   - changing getServicePoint() from get by name into get by unique id
   - add more examples in docstring
@@ -205,7 +205,7 @@
 
 ### Patch Changes
 
-- 48b4e97: update `spp date time now string` format
+- [48b4e97](https://github.com/OpenFn/adaptors/commit/48b4e97): update `spp date time now string` format
 
 ## 1.1.0 - 17 November 2023
 

--- a/packages/pdfshift/CHANGELOG.md
+++ b/packages/pdfshift/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- 7c606ef: - Format response to `json` when `filename` option is passed.
+- [7c606ef](https://github.com/OpenFn/adaptors/commit/7c606ef): - Format response to `json` when `filename` option is passed.
   - Make `generatePDF()` function public
 
 ## 1.0.0 - 14 August 2025

--- a/packages/pesapal/CHANGELOG.md
+++ b/packages/pesapal/CHANGELOG.md
@@ -4,65 +4,65 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 1.1.3 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.1.2 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- f182cfc: Add required fields in configuration-schema
+- [f182cfc](https://github.com/OpenFn/adaptors/commit/f182cfc): Add required fields in configuration-schema
 
 ## 1.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.3 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.2 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.1 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.0 - 10 April 2025

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 7.0.0 - 11 August 2025
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -45,89 +45,89 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 6.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 6.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 6.0.13 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 6.0.12 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 6.0.11 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 6.0.10 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 6.0.9 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 6.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 6.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 6.0.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 6.0.5 - 28 October 2024
@@ -142,29 +142,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 6.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 6.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 6.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 6.0.0 - 01 August 2024
@@ -177,42 +177,42 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 5.0.1 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 5.0.0 - 19 June 2024
 
 ### Major Changes
 
-- 6a4081b8: - Update all operations to use util `expandReferences`
+- [6a4081b8](https://github.com/OpenFn/adaptors/commit/6a4081b8): - Update all operations to use util `expandReferences`
   - Add `findValue` result to state
 
 ### Minor Changes
 
-- 5fb82f07: Export `group` operation from common
+- [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07): Export `group` operation from common
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 4.2.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 4.1.15 - 11 June 2024
@@ -226,14 +226,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 4.1.13 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 4.1.12 - 08 May 2024
@@ -247,7 +247,7 @@
 
 ### Patch Changes
 
-- 02ab7a89: - Change `host` format from `uri or ipv4` to `string` in
+- [02ab7a89](https://github.com/OpenFn/adaptors/commit/02ab7a89): - Change `host` format from `uri or ipv4` to `string` in
   `configuration-schema.json`
   - Update required list to include `user`, `password` and `database`
 
@@ -262,56 +262,56 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 4.1.8 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 4.1.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 4.1.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 4.1.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 4.1.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 4.1.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 4.1.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 4.1.1 - 19 June 2023
@@ -326,7 +326,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -338,69 +338,69 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 4.0.0 - 20 April 2023
 
 ### Major Changes
 
-- ecd0b53: add optional callback in sql and update response structure
+- [ecd0b53](https://github.com/OpenFn/adaptors/commit/ecd0b53): add optional callback in sql and update response structure
 
 ## 3.4.6 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 3.4.5 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 3.4.4 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 3.4.3 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 3.4.2 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 3.4.1 - 04 November 2022
 
 ### Patch Changes
 
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
 
 ## 3.4.0 - 21 October 2022
 
 ### Minor Changes
 
-- 44ae341: Migrate postgresql
+- [44ae341](https://github.com/OpenFn/adaptors/commit/44ae341): Migrate postgresql
 
 ### Patch Changes
 
-- e04aa28: Rename credential-schema to configuration-schema, update descriptions
+- [e04aa28](https://github.com/OpenFn/adaptors/commit/e04aa28): Rename credential-schema to configuration-schema, update descriptions

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,67 +39,67 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 3.2.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 3.2.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 3.1.4 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 3.1.3 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 3.1.2 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 3.1.1 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 3.1.0 - 31 March 2025
 
 ### Minor Changes
 
-- 7fecd5b: - Added a new http namespace, containing HTTP helpers for `get()`,
+- [7fecd5b](https://github.com/OpenFn/adaptors/commit/7fecd5b): - Added a new http namespace, containing HTTP helpers for `get()`,
   `post()` and `patch()`.
 
   - These functions will allow the users to make any requests with the `POST`,
@@ -118,31 +118,31 @@
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 3.0.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 3.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 3.0.7 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 3.0.6 - 28 October 2024
@@ -157,35 +157,35 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 3.0.4 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 3.0.3 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 3.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 3.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 3.0.0 - 01 August 2024
@@ -198,40 +198,40 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 2.12.3 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 2.12.2 - 18 July 2024
 
 ### Patch Changes
 
-- 3ad9122: - Improve `getCases()` withReferrals docs
+- [3ad9122](https://github.com/OpenFn/adaptors/commit/3ad9122): - Improve `getCases()` withReferrals docs
   - Add logs when fetching case referrals
 
 ## 2.12.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 2.12.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 2.11.14 - 11 June 2024
@@ -245,14 +245,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 2.11.12 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 2.11.11 - 08 May 2024
@@ -273,56 +273,56 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 2.11.8 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 2.11.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 2.11.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 2.11.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 2.11.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 2.11.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 2.11.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 2.11.1 - 19 June 2023
@@ -337,7 +337,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -349,63 +349,63 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 2.10.6 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 2.10.5 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 2.10.4 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 2.10.3 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
-- 059c956: added examples in docstring
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [059c956](https://github.com/OpenFn/adaptors/commit/059c956): added examples in docstring
 
 ## 2.10.2 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 2.10.1 - 04 November 2022
 
 ### Patch Changes
 
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
 
 ## 2.10.0 - 25 October 2022
 
 ### Minor Changes
 
-- 33742bf: Modify `composeNextState` so that `getCases` can pass it a third
+- [33742bf](https://github.com/OpenFn/adaptors/commit/33742bf): Modify `composeNextState` so that `getCases` can pass it a third
   argument: the metadata from Primero's response.
 
   `getCases` will now not only return an array of `cases` in `state.data`, but
@@ -413,28 +413,28 @@
 
 ### Patch Changes
 
-- 2014694: remove travis url in readme
-- bb764db: Conditionally check for 'withReferrals' in case no options are
+- [2014694](https://github.com/OpenFn/adaptors/commit/2014694): remove travis url in readme
+- [bb764db](https://github.com/OpenFn/adaptors/commit/bb764db): Conditionally check for 'withReferrals' in case no options are
   provided"
 
 ## 2.9.2 - 21 October 2022
 
 ### Patch Changes
 
-- e04aa28: Rename credential-schema to configuration-schema, update descriptions
+- [e04aa28](https://github.com/OpenFn/adaptors/commit/e04aa28): Rename credential-schema to configuration-schema, update descriptions
 
 ## 2.9.1 - 19 October 2022
 
 ### Patch Changes
 
-- d4ac748: Skipped failing test until we have a new strat (it's working)
+- [d4ac748](https://github.com/OpenFn/adaptors/commit/d4ac748): Skipped failing test until we have a new strat (it's working)
 
 ## 2.9.0 - 19 October 2022
 
 ### Minor Changes
 
-- b37a4ad: add language primero into monorepo
+- [b37a4ad](https://github.com/OpenFn/adaptors/commit/b37a4ad): add language primero into monorepo
 
 ### Patch Changes
 
-- adb97a0: Fixed issue where upsertCase always took state.data for main params
+- [adb97a0](https://github.com/OpenFn/adaptors/commit/adb97a0): Fixed issue where upsertCase always took state.data for main params

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -4,31 +4,31 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.0.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.0.0 - 10 July 2025
 
 ### Major Changes
 
-- 87b4f2e: - Migrate from `common.http` to `common.request`.
+- [87b4f2e](https://github.com/OpenFn/adaptors/commit/87b4f2e): - Migrate from `common.http` to `common.request`.
   - Remove `axios` and `nock` from progres.
   - Remove exportation of `http` from `common`, and the exportation of `axios`.
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.4.6 - 15 October 2024
@@ -41,47 +41,47 @@
 
 ### Patch Changes
 
-- 3fd13c2: Update axios to 1.7.7
+- [3fd13c2](https://github.com/OpenFn/adaptors/commit/3fd13c2): Update axios to 1.7.7
 
 ## 1.4.4 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.4.3 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.4.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.4.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 1.4.0 - 13 June 2024
 
 ### Minor Changes
 
-- 3d9d564c: Add `fn` and `fnIf` operation
+- [3d9d564c](https://github.com/OpenFn/adaptors/commit/3d9d564c): Add `fn` and `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.3.14 - 11 June 2024
@@ -95,14 +95,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 1.3.12 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 1.3.11 - 08 May 2024
@@ -123,56 +123,56 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 1.3.8 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 1.3.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 1.3.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 1.3.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 1.3.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 1.3.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 1.3.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 1.3.1 - 19 June 2023
@@ -187,7 +187,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -199,50 +199,50 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.2.5 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 1.2.4 - 30 March 2023
 
 ### Patch Changes
 
-- ef828e7: update old urls in readme
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [ef828e7](https://github.com/OpenFn/adaptors/commit/ef828e7): update old urls in readme
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 1.2.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 1.2.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 1.2.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 1.2.0 - 18 November 2022
 
 ### Minor Changes
 
-- 039ca0b: Migrate Progres
+- [039ca0b](https://github.com/OpenFn/adaptors/commit/039ca0b): Migrate Progres
 
 ### Patch Changes
 
-- Updated dependencies \[f2a91a4]
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -4,34 +4,34 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.0.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.0.0 - 10 July 2025
 
 ### Major Changes
 
-- bc409de: - Update `rapidPro` to not use deprecated `common-http`.
+- [bc409de](https://github.com/OpenFn/adaptors/commit/bc409de): - Update `rapidPro` to not use deprecated `common-http`.
   - Remove support and export of `axios`
   - Remove export of `http` namespace from `common`
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.1.5 - 15 October 2024
@@ -44,40 +44,40 @@
 
 ### Patch Changes
 
-- 3fd13c2: Update axios to 1.7.7
+- [3fd13c2](https://github.com/OpenFn/adaptors/commit/3fd13c2): Update axios to 1.7.7
 
 ## 1.1.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.1.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.1.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 1.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.0.14 - 11 June 2024
@@ -91,14 +91,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 1.0.12 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 1.0.11 - 08 May 2024
@@ -119,56 +119,56 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 1.0.8 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 1.0.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 1.0.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 1.0.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 1.0.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 1.0.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 1.0.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 1.0.1 - 19 June 2023
@@ -183,7 +183,7 @@
 
 ### Major Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -195,56 +195,56 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.5.6 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 0.5.5 - 30 March 2023
 
 ### Patch Changes
 
-- ef828e7: update old urls in readme
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [ef828e7](https://github.com/OpenFn/adaptors/commit/ef828e7): update old urls in readme
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.5.4 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.5.3 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.5.2 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.5.1 - 25 November 2022
 
 ### Patch Changes
 
-- cbb8968: Fix axios Inefficient Regular Expression Complexity vulnerability
+- [cbb8968](https://github.com/OpenFn/adaptors/commit/cbb8968): Fix axios Inefficient Regular Expression Complexity vulnerability
 
 ## 0.5.0 - 18 November 2022
 
 ### Minor Changes
 
-- 11f83ff: Migrate RapidPro
+- [11f83ff](https://github.com/OpenFn/adaptors/commit/11f83ff): Migrate RapidPro
 
 ### Patch Changes
 
-- Updated dependencies \[f2a91a4]
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -4,103 +4,103 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 1.3.7 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.3.6 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.3.5 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.3.4 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.3.3 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.3.2 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.3.1 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.3.0 - 20 March 2025
 
 ### Minor Changes
 
-- f713bc5: add mSet() function on redis adaptor
+- [f713bc5](https://github.com/OpenFn/adaptors/commit/f713bc5): add mSet() function on redis adaptor
 
 ### Patch Changes
 
-- f713bc5: use `util.throwError` for throwing errors
+- [f713bc5](https://github.com/OpenFn/adaptors/commit/f713bc5): use `util.throwError` for throwing errors
 
 ## 1.2.8 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.2.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 1.2.6 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 1.2.5 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 1.2.4 - 28 October 2024
@@ -115,28 +115,28 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 1.2.2 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 1.2.1 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 1.2.0 - 28 August 2024
 
 ### Minor Changes
 
-- c1e3221: - Add `mGet()` function
+- [c1e3221](https://github.com/OpenFn/adaptors/commit/c1e3221): - Add `mGet()` function
   - Remove console.log in `hget()`
   - Add logging to `scan()`
 
@@ -144,15 +144,15 @@
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.1.1 - 15 August 2024
 
 ### Patch Changes
 
-- 2b8ec34: - Update host type configuration-schema
+- [2b8ec34](https://github.com/OpenFn/adaptors/commit/2b8ec34): - Update host type configuration-schema
 
 ## 1.1.0 - 09 August 2024
 

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -4,95 +4,95 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.4.18 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.4.17 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.4.16 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.4.15 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.4.14 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.4.13 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.4.12 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.4.11 - 10 March 2025
 
 ### Patch Changes
 
-- 8a8c28d: - cleanup examples wrapped with `execute()` function
+- [8a8c28d](https://github.com/OpenFn/adaptors/commit/8a8c28d): - cleanup examples wrapped with `execute()` function
   - Add example caption and add sample payload
 
 ## 0.4.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.4.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.4.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.4.7 - 28 October 2024
@@ -107,60 +107,60 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.4.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.4.4 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 0.4.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.4.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.4.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.4.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.3.2 - 24 January 2024
 
 ### Patch Changes
 
-- 6afba70: Fix submitSite
+- [6afba70](https://github.com/OpenFn/adaptors/commit/6afba70): Fix submitSite
 
 ## 0.3.1 - 19 June 2023
 
@@ -174,7 +174,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -186,31 +186,31 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.2.3 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.2.2 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.2.1 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.2.0 - 25 November 2022
 
 ### Minor Changes
 
-- 664dc7f: migrate resourcemap
+- [664dc7f](https://github.com/OpenFn/adaptors/commit/664dc7f): migrate resourcemap

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 7.2.0 - 04 August 2025
 
 ### Minor Changes
 
-- dc89780: ## Added Salesforce Bulk API 2.0 Operations
+- [dc89780](https://github.com/OpenFn/adaptors/commit/dc89780): ## Added Salesforce Bulk API 2.0 Operations
 
   - Added `bulk2.query()` - Execute SOQL queries using Bulk API 2.0
   - Added `bulk2.insert()` - Bulk insert records
@@ -24,47 +24,47 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 7.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 7.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
-- 8d78db4: Export `map()` function from common
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
+- [8d78db4](https://github.com/OpenFn/adaptors/commit/8d78db4): Export `map()` function from common
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 7.0.1 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 7.0.0 - 01 May 2025
 
 ### Major Changes
 
-- 8dd65a1: - Modernize `query()` implementation using jsforce v3
+- [8dd65a1](https://github.com/OpenFn/adaptors/commit/8dd65a1): - Modernize `query()` implementation using jsforce v3
 
   - Remove `autoFetch` option from `query()` function
   - Add `limit` option to `query()` function
@@ -73,7 +73,7 @@
     - Query metadata (`done`, `totalSize`, `nextRecordsUrl`) moved to
       `state.response`
 
-- 3686988: remove map() function
+- [3686988](https://github.com/OpenFn/adaptors/commit/3686988): remove map() function
 
 ### Migration Guide
 
@@ -113,33 +113,33 @@ query('select name from account', { limit: Infinity });
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 6.0.2 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 6.0.1 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 6.0.0 - 02 April 2025
 
 ### Major Changes
 
-- 8ce97838: Add `http` function in salesforce (#1070)
-- 1fbfdc18: Update salesforce to use `connection` client (#1063)
-- 38de07ed: update jsforce to v3 (#1060)
+- [8ce97838](https://github.com/OpenFn/adaptors/commit/8ce97838): Add `http` function in salesforce (#1070)
+- [1fbfdc18](https://github.com/OpenFn/adaptors/commit/1fbfdc18): Update salesforce to use `connection` client (#1063)
+- [38de07ed](https://github.com/OpenFn/adaptors/commit/38de07ed): update jsforce to v3 (#1060)
 
 ### Migration Guide
 
@@ -176,23 +176,23 @@ http.post('Contact', { Name: 'test' });
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 5.0.4 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 5.0.3 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 5.0.2 - 14 January 2025
@@ -255,7 +255,7 @@ changes to be compatible - see the Migration Guide.
 
 ### Major Changes
 
-- 59721be: New API design for salesforce, including use of `composeNextState`
+- [59721be](https://github.com/OpenFn/adaptors/commit/59721be): New API design for salesforce, including use of `composeNextState`
   and removing old code.
 - Remove `axios` dependency
 - Remove old/unused functions. `relationship`, `upsertIf`, `createIf`,
@@ -263,10 +263,10 @@ changes to be compatible - see the Migration Guide.
 - Standardize state mutation in all operations
 - Change `bulk` signature to `bulk(operation, sObjectName, records, options)`
 - Remove callback support
-- a2cf9c7: Move `toUTF8()` to `util.UTF8()`. `toUTF8` is not an operation and
+- [a2cf9c7](https://github.com/OpenFn/adaptors/commit/a2cf9c7): Move `toUTF8()` to `util.UTF8()`. `toUTF8` is not an operation and
   cannot be called at the top level. Moving into the utils namespace should help
   make the usage of the function a little clearer
-- ca09ade: - Restructured response format for `bulk`, `create`,`update` and
+- [ca09ade](https://github.com/OpenFn/adaptors/commit/ca09ade): - Restructured response format for `bulk`, `create`,`update` and
   `destroy` functions into standardized result structure:
   ```
   {
@@ -275,11 +275,11 @@ changes to be compatible - see the Migration Guide.
     errors: [{ id message }],
   }
   ```
-- b1227a2: - add `query` option in `request` function
+- [b1227a2](https://github.com/OpenFn/adaptors/commit/b1227a2): - add `query` option in `request` function
 
 ### Minor Changes
 
-- b4a9c42: - Create `get()` and `post()` functions for all http requests against
+- [b4a9c42](https://github.com/OpenFn/adaptors/commit/b4a9c42): - Create `get()` and `post()` functions for all http requests against
   Salesforce
 - Update `describe()` to fetch all available sObjects metadata
 - update function examples and improve options documentation
@@ -303,7 +303,7 @@ changes to be compatible - see the Migration Guide.
 
 ### Patch Changes
 
-- b4a9c42: - Change internal `cleanupState` to `removeConnection` and tagged it
+- [b4a9c42](https://github.com/OpenFn/adaptors/commit/b4a9c42): - Change internal `cleanupState` to `removeConnection` and tagged it
   as private function
   - Rename `attrs` to `records` in docs
 - Update `@openfn/language-common` to `workspace:*`
@@ -322,27 +322,27 @@ with version number 5.0.2.
 
 ### Patch Changes
 
-- 3fd13c2: Update axios to 1.7.7
+- [3fd13c2](https://github.com/OpenFn/adaptors/commit/3fd13c2): Update axios to 1.7.7
 
 ## 4.8.4 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 4.8.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 4.8.2 - 31 July 2024
 
 ### Patch Changes
 
-- ce08e7f: Fix `autoFetch` behaviour in `query()` function. All records are
+- [ce08e7f](https://github.com/OpenFn/adaptors/commit/ce08e7f): Fix `autoFetch` behaviour in `query()` function. All records are
   merged into a single `records` array, and pushed to `[0]` in
   `state.references`.
 
@@ -353,16 +353,16 @@ with version number 5.0.2.
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 4.8.0 - 19 June 2024
 
 ### Minor Changes
 
-- 5fb82f07: Export `group` operation from common
-- b5e0c266: ### Added
+- [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07): Export `group` operation from common
+- [b5e0c266](https://github.com/OpenFn/adaptors/commit/b5e0c266): ### Added
 
   - `insert()` function as an alias for `create()`.
 
@@ -377,18 +377,18 @@ with version number 5.0.2.
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 4.7.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 4.6.11 - 11 June 2024
@@ -402,7 +402,7 @@ with version number 5.0.2.
 
 ### Patch Changes
 
-- 90f44c62: Include the Salesforce query response in the result, even if no
+- [90f44c62](https://github.com/OpenFn/adaptors/commit/90f44c62): Include the Salesforce query response in the result, even if no
   records are found.
 
 ## 4.6.9 - 28 May 2024
@@ -422,7 +422,7 @@ with version number 5.0.2.
 
 ### Patch Changes
 
-- 332225ec: - Set default API version to `47.0`
+- [332225ec](https://github.com/OpenFn/adaptors/commit/332225ec): - Set default API version to `47.0`
   - In `bulkQuery` throw errors if API version is less than `47.0`
   - Update `bulkQuery` jsdocs with a link to `Bulk API 2.0 Query`
 
@@ -430,20 +430,20 @@ with version number 5.0.2.
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 4.6.5 - 08 May 2024
 
 ### Patch Changes
 
-- b1c915b0: Add documentation about Salesforce API limits to query and bulkQuery
+- [b1c915b0](https://github.com/OpenFn/adaptors/commit/b1c915b0): Add documentation about Salesforce API limits to query and bulkQuery
 
 ## 4.6.4 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 4.6.3 - 08 May 2024
@@ -464,32 +464,32 @@ with version number 5.0.2.
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 4.6.0 - 19 March 2024
 
 ### Minor Changes
 
-- cfe1ccb: Add options and callback params in query function
+- [cfe1ccb](https://github.com/OpenFn/adaptors/commit/cfe1ccb): Add options and callback params in query function
 
 ## 4.5.2 - 19 March 2024
 
 ### Patch Changes
 
-- 2006e88: fix an issue with bulk jobs not closing
+- [2006e88](https://github.com/OpenFn/adaptors/commit/2006e88): fix an issue with bulk jobs not closing
 
 ## 4.5.1 - 05 March 2024
 
 ### Patch Changes
 
-- fa3e28fe: refactor bulk() to use newExpandReferences
+- [fa3e28fe](https://github.com/OpenFn/adaptors/commit/fa3e28fe): refactor bulk() to use newExpandReferences
 
 ## 4.5.0 - 02 February 2024
 
 ### Minor Changes
 
-- 0d2b478: Remove `instance_url` under `other_params` and put it at the root
+- [0d2b478](https://github.com/OpenFn/adaptors/commit/0d2b478): Remove `instance_url` under `other_params` and put it at the root
   level of the configuration schema
 
 ## 4.4.0 - 31 January 2024
@@ -498,92 +498,92 @@ Deprecated because it does not work with Lightning
 
 ### Minor Changes
 
-- 632b585: Add `OAuth` support
-- a12f434: Add `request(path, opts, cb)` function
+- [632b585](https://github.com/OpenFn/adaptors/commit/632b585): Add `OAuth` support
+- [a12f434](https://github.com/OpenFn/adaptors/commit/a12f434): Add `request(path, opts, cb)` function
 
 ## 4.3.1 - 16 December 2023
 
 ### Patch Changes
 
-- 1131c34: Remove regex pattern for validation and changed minLength to 1
+- [1131c34](https://github.com/OpenFn/adaptors/commit/1131c34): Remove regex pattern for validation and changed minLength to 1
 
 ## 4.3.0 - 01 December 2023
 
 ### Minor Changes
 
-- 1d5b62f: Add `toUTF8` function
+- [1d5b62f](https://github.com/OpenFn/adaptors/commit/1d5b62f): Add `toUTF8` function
 
 ## 4.2.2 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 4.2.1 - 18 September 2023
 
 ### Patch Changes
 
-- 07debe9: Update bulkQuery to use bulkv2
+- [07debe9](https://github.com/OpenFn/adaptors/commit/07debe9): Update bulkQuery to use bulkv2
 
 ## 4.2.0 - 14 September 2023
 
 ### Minor Changes
 
-- fc58f1c: add options in bulkQuery
+- [fc58f1c](https://github.com/OpenFn/adaptors/commit/fc58f1c): add options in bulkQuery
 
 ## 4.1.0 - 13 September 2023
 
 ### Minor Changes
 
-- 1e3a083: add bulkQuery function
+- [1e3a083](https://github.com/OpenFn/adaptors/commit/1e3a083): add bulkQuery function
 
 ## 4.0.8 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 4.0.7 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 4.0.6 - 03 August 2023
 
 ### Patch Changes
 
-- aceedd2: update jsforce and remove unused packages
+- [aceedd2](https://github.com/OpenFn/adaptors/commit/aceedd2): update jsforce and remove unused packages
 
 ## 4.0.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 4.0.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 4.0.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 4.0.2 - 23 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[111807f]
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 4.0.1 - 19 June 2023
@@ -598,7 +598,7 @@ Deprecated because it does not work with Lightning
 
 ### Major Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -610,106 +610,106 @@ Deprecated because it does not work with Lightning
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 3.0.7 - 20 April 2023
 
 ### Patch Changes
 
-- 7cc8efc: remove FakeAdaptor references
+- [7cc8efc](https://github.com/OpenFn/adaptors/commit/7cc8efc): remove FakeAdaptor references
 
 ## 3.0.6 - 31 March 2023
 
 ### Patch Changes
 
-- 705caab: Remove tools as devdependencies
+- [705caab](https://github.com/OpenFn/adaptors/commit/705caab): Remove tools as devdependencies
 
 ## 3.0.5 - 31 March 2023
 
 ### Patch Changes
 
-- 929bca6: Use metadata helper function from common
-- Updated dependencies \[929bca6]
+- [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6): Use metadata helper function from common
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 3.0.4 - 30 March 2023
 
 ### Patch Changes
 
-- ef828e7: update old urls in readme
-- Updated dependencies \[2b4c61a]
+- [ef828e7](https://github.com/OpenFn/adaptors/commit/ef828e7): update old urls in readme
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 3.0.3 - 21 March 2023
 
 ### Patch Changes
 
-- 06aced8: Fix dependencies
+- [06aced8](https://github.com/OpenFn/adaptors/commit/06aced8): Fix dependencies
 
 ## 3.0.2 - 17 March 2023
 
 ### Patch Changes
 
-- aed7e0b: fix required field in configuration schema
+- [aed7e0b](https://github.com/OpenFn/adaptors/commit/aed7e0b): fix required field in configuration schema
 
 ## 3.0.1 - 10 March 2023
 
 ### Patch Changes
 
-- c09b821: Add @magic annotations
+- [c09b821](https://github.com/OpenFn/adaptors/commit/c09b821): Add @magic annotations
 
 ## 3.0.0 - 03 March 2023
 
 ### Major Changes
 
-- 190f667: Remove curry from salesforce
+- [190f667](https://github.com/OpenFn/adaptors/commit/190f667): Remove curry from salesforce
 
 ## 2.12.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 2.12.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 2.12.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 2.12.0 - 18 November 2022
 
 ### Minor Changes
 
-- 5c883c6: Allow expansion for describe(), add describeAll()
+- [5c883c6](https://github.com/OpenFn/adaptors/commit/5c883c6): Allow expansion for describe(), add describeAll()
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 2.11.1 - 04 November 2022
 
 ### Patch Changes
 
-- e7bf865: chore(deps): update dependency sinon to v14
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [e7bf865](https://github.com/OpenFn/adaptors/commit/e7bf865): chore(deps): update dependency sinon to v14
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
 
 ## 2.11.0 - 25 October 2022
 
 ### Minor Changes
 
-- edff578: Migrate salesforce
+- [edff578](https://github.com/OpenFn/adaptors/commit/edff578): Migrate salesforce

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 3.0.0 - 11 August 2025
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -45,105 +45,105 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.1.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.1.0 - 10 July 2025
 
 ### Minor Changes
 
-- 19f2d7e: Exported `as()` function from common.
-- 8d78db4: Export `map()` function from common
+- [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e): Exported `as()` function from common.
+- [8d78db4](https://github.com/OpenFn/adaptors/commit/8d78db4): Export `map()` function from common
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 2.0.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 2.0.14 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 2.0.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 2.0.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 2.0.11 - 04 April 2025
 
 ### Patch Changes
 
-- cfaba6d: Export `util.uuid` from `common`
+- [cfaba6d](https://github.com/OpenFn/adaptors/commit/cfaba6d): Export `util.uuid` from `common`
 
 ## 2.0.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 2.0.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 2.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 2.0.7 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 2.0.6 - 04 November 2024
 
 ### Patch Changes
 
-- 7c528d3: Update docs with examples
+- [7c528d3](https://github.com/OpenFn/adaptors/commit/7c528d3): Update docs with examples
 
 ## 2.0.5 - 28 October 2024
 
@@ -157,29 +157,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 2.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 2.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 2.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 2.0.0 - 01 August 2024
@@ -192,41 +192,41 @@
 
 ### Patch Changes
 
-- f51c5d0: Enforce that absolute urls must not be passed to HTTP functions
-- Updated dependencies \[4fe527c]
+- [f51c5d0](https://github.com/OpenFn/adaptors/commit/f51c5d0): Enforce that absolute urls must not be passed to HTTP functions
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.1.3 - 25 July 2024
 
 ### Patch Changes
 
-- 73d0a02: Make documentation public
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02): Make documentation public
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.1.2 - 01 July 2024
 
 ### Patch Changes
 
-- 218a582: Added extra logging around errors
+- [218a582](https://github.com/OpenFn/adaptors/commit/218a582): Added extra logging around errors
 
 ## 1.1.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 1.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.0.1 - 11 June 2024

--- a/packages/senaite/CHANGELOG.md
+++ b/packages/senaite/CHANGELOG.md
@@ -4,49 +4,49 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.5 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.4 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.3 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.0.2 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.1 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.0 - 14 April 2025

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 3.0.0 - 11 August 2025
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -45,32 +45,32 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.0.16 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.0.15 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 2.0.14 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 2.0.13 - 03 June 2025
@@ -83,53 +83,53 @@
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 2.0.11 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 2.0.10 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 2.0.9 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 2.0.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 2.0.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 2.0.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 2.0.5 - 28 October 2024
@@ -144,29 +144,29 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 2.0.3 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 2.0.2 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 2.0.1 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 2.0.0 - 01 August 2024
@@ -179,33 +179,33 @@
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.1.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.1.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 ## 1.1.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.0.8 - 11 June 2024
@@ -219,14 +219,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[12f02ed5]
+- Updated dependencies [12f02ed5](https://github.com/OpenFn/adaptors/commit/12f02ed5)
   - @openfn/language-common@1.13.4
 
 ## 1.0.6 - 08 May 2024
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 1.0.5 - 08 May 2024
@@ -248,77 +248,77 @@
 
 ### Patch Changes
 
-- Updated dependencies \[1ad86651]
+- Updated dependencies [1ad86651](https://github.com/OpenFn/adaptors/commit/1ad86651)
   - @openfn/language-common@1.13.0
 
 ## 1.0.2 - 27 October 2023
 
 ### Patch Changes
 
-- a666a63: On error disconnect then throw
+- [a666a63](https://github.com/OpenFn/adaptors/commit/a666a63): On error disconnect then throw
 
 ## 1.0.1 - 24 October 2023
 
 ### Patch Changes
 
-- 771c814: - Properly disconnect on error
+- [771c814](https://github.com/OpenFn/adaptors/commit/771c814): - Properly disconnect on error
   - Improve operation logs
 
 ## 1.0.0 - 02 October 2023
 
 ### Major Changes
 
-- e52ba66: add `filter` option in `list()` function
+- [e52ba66](https://github.com/OpenFn/adaptors/commit/e52ba66): add `filter` option in `list()` function
 
 ## 0.8.8 - 20 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[c19efbe]
+- Updated dependencies [c19efbe](https://github.com/OpenFn/adaptors/commit/c19efbe)
   - @openfn/language-common@1.11.1
 
 ## 0.8.7 - 08 September 2023
 
 ### Patch Changes
 
-- Updated dependencies \[85c35b8]
+- Updated dependencies [85c35b8](https://github.com/OpenFn/adaptors/commit/85c35b8)
   - @openfn/language-common@1.11.0
 
 ## 0.8.6 - 14 August 2023
 
 ### Patch Changes
 
-- Updated dependencies \[df09270]
+- Updated dependencies [df09270](https://github.com/OpenFn/adaptors/commit/df09270)
   - @openfn/language-common@1.10.3
 
 ## 0.8.5 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[26a303e]
+- Updated dependencies [26a303e](https://github.com/OpenFn/adaptors/commit/26a303e)
   - @openfn/language-common@1.10.2
 
 ## 0.8.4 - 14 July 2023
 
 ### Patch Changes
 
-- Updated dependencies \[8c32eb3]
+- Updated dependencies [8c32eb3](https://github.com/OpenFn/adaptors/commit/8c32eb3)
   - @openfn/language-common@1.10.1
 
 ## 0.8.3 - 30 June 2023
 
 ### Patch Changes
 
-- Updated dependencies \[aad9549]
+- Updated dependencies [aad9549](https://github.com/OpenFn/adaptors/commit/aad9549)
   - @openfn/language-common@1.10.0
 
 ## 0.8.2 - 23 June 2023
 
 ### Patch Changes
 
-- d2c980e: Use `parseCsv` from language-common
-- c5d3ce1: improve connection handling
-- Updated dependencies \[111807f]
+- [d2c980e](https://github.com/OpenFn/adaptors/commit/d2c980e): Use `parseCsv` from language-common
+- [c5d3ce1](https://github.com/OpenFn/adaptors/commit/c5d3ce1): improve connection handling
+- Updated dependencies [111807f](https://github.com/OpenFn/adaptors/commit/111807f)
   - @openfn/language-common@1.9.0
 
 ## 0.8.1 - 19 June 2023
@@ -333,7 +333,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -345,108 +345,108 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.7.3 - 24 May 2023
 
 ### Patch Changes
 
-- 432dd0a: fix sftp connection wqautoclose
+- [432dd0a](https://github.com/OpenFn/adaptors/commit/432dd0a): fix sftp connection wqautoclose
 
 ## 0.7.2 - 23 May 2023
 
 ### Patch Changes
 
-- 205b806: remove asObjects key before parsing
+- [205b806](https://github.com/OpenFn/adaptors/commit/205b806): remove asObjects key before parsing
 
 ## 0.7.1 - 23 May 2023
 
 ### Patch Changes
 
-- 827c627: error handling
+- [827c627](https://github.com/OpenFn/adaptors/commit/827c627): error handling
 
 ## 0.7.0 - 22 May 2023
 
 ### Minor Changes
 
-- fa58216: Add csvtojson convertion option
+- [fa58216](https://github.com/OpenFn/adaptors/commit/fa58216): Add csvtojson convertion option
 
 ## 0.6.9 - 31 March 2023
 
 ### Patch Changes
 
-- Updated dependencies \[929bca6]
+- Updated dependencies [929bca6](https://github.com/OpenFn/adaptors/commit/929bca6)
   - @openfn/language-common@1.7.7
 
 ## 0.6.8 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.6.7 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.6.6 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.6.5 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 0.6.4 - 11 November 2022
 
 ### Patch Changes
 
-- f2a91a4: Update package exports
-- Updated dependencies \[f2a91a4]
+- [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4): Update package exports
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5
 
 ## 0.6.3 - 04 November 2022
 
 ### Patch Changes
 
-- 8566b26: Fix typings
-- b3d45ff: Fix CJS export of npm package.
-- 4126a62: Fix built bundle
-- ecf5d30: remove sinon since it was not being used
-- Updated dependencies \[8566b26]
-- Updated dependencies \[b3d45ff]
-- Updated dependencies \[b5eb665]
-- Updated dependencies \[ecf5d30]
+- [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26): Fix typings
+- [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff): Fix CJS export of npm package.
+- [4126a62](https://github.com/OpenFn/adaptors/commit/4126a62): Fix built bundle
+- [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30): remove sinon since it was not being used
+- Updated dependencies [8566b26](https://github.com/OpenFn/adaptors/commit/8566b26)
+- Updated dependencies [b3d45ff](https://github.com/OpenFn/adaptors/commit/b3d45ff)
+- Updated dependencies [b5eb665](https://github.com/OpenFn/adaptors/commit/b5eb665)
+- Updated dependencies [ecf5d30](https://github.com/OpenFn/adaptors/commit/ecf5d30)
   - @openfn/language-common@1.7.4
 
 ## 0.6.2 - 21 October 2022
 
 ### Patch Changes
 
-- e04aa28: Rename credential-schema to configuration-schema, update descriptions
+- [e04aa28](https://github.com/OpenFn/adaptors/commit/e04aa28): Rename credential-schema to configuration-schema, update descriptions
 
 ## 0.6.1 - 19 October 2022
 
 ### Patch Changes
 
-- 28dfbfa: add todo, fix build pack
+- [28dfbfa](https://github.com/OpenFn/adaptors/commit/28dfbfa): add todo, fix build pack
 
 ## 0.6.0 - 19 October 2022
 
 ### Minor Changes
 
-- f294a62: Added credential-schema.json for new ui
+- [f294a62](https://github.com/OpenFn/adaptors/commit/f294a62): Added credential-schema.json for new ui
 
 ## 0.5.0 - 18 October 2022
 
 ### Minor Changes
 
-- 2c04894: added sftp package
+- [2c04894](https://github.com/OpenFn/adaptors/commit/2c04894): added sftp package

--- a/packages/stripe/CHANGELOG.md
+++ b/packages/stripe/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-stripe
 
-## 1.0.0
+## 1.0.0 - 01 September 2025
 
 - Implement `list()`, and  `get()` functions for `stripe`.
 - Implement `http.get()`, `http.post()`, and `http.request()`  namespaced functions.

--- a/packages/surveycto/CHANGELOG.md
+++ b/packages/surveycto/CHANGELOG.md
@@ -4,98 +4,98 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 2.3.0 - 14 August 2025
 
 ### Minor Changes
 
-- af530fd: - Added `contentType` to `request()`
+- [af530fd](https://github.com/OpenFn/adaptors/commit/af530fd): - Added `contentType` to `request()`
   - Added `jsonToCSVBuffer`
 
 ## 2.2.7 - 14 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 2.2.6 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 2.2.5 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 2.2.4 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 2.2.3 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 2.2.2 - 06 August 2024
 
 ### Patch Changes
 
-- d54ab59: Fix an issue assembling surveyCTO urls (which manifested as
+- [d54ab59](https://github.com/OpenFn/adaptors/commit/d54ab59): Fix an issue assembling surveyCTO urls (which manifested as
   `TypeError: Cannot read properties of undefined (reading 'toString'`)
 
 ## 2.2.1 - 01 August 2024
 
 ### Patch Changes
 
-- f51c5d0: Enforce that absolute urls must not be passed to HTTP functions
-- Updated dependencies \[4fe527c]
+- [f51c5d0](https://github.com/OpenFn/adaptors/commit/f51c5d0): Enforce that absolute urls must not be passed to HTTP functions
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 2.2.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 2.1.1 - 17 May 2024
 
 ### Patch Changes
 
-- 6c588212: Fix `servername` typo in the `configuration-schema`
+- [6c588212](https://github.com/OpenFn/adaptors/commit/6c588212): Fix `servername` typo in the `configuration-schema`
 
 ## 2.1.0 - 08 May 2024
 
 ### Minor Changes
 
-- b67f81be: Add a `cursor()` function which adds support for the surveyCTO
+- [b67f81be](https://github.com/OpenFn/adaptors/commit/b67f81be): Add a `cursor()` function which adds support for the surveyCTO
   string format dates.
 
   The date option in `fetchSubmissions` can now accept a surveyCTO date, an
@@ -106,14 +106,14 @@
 
 ### Patch Changes
 
-- Updated dependencies \[88f99a8f]
+- Updated dependencies [88f99a8f](https://github.com/OpenFn/adaptors/commit/88f99a8f)
   - @openfn/language-common@1.13.3
 
 ## 2.0.0 - 23 April 2024
 
 ### Major Changes
 
-- 59ae7b50: - Refactor `fetchSubmissions()` function
+- [59ae7b50](https://github.com/OpenFn/adaptors/commit/59ae7b50): - Refactor `fetchSubmissions()` function
   - Update `instanceName` to `servername` in `configuration-schema.json`
   - Add `apiVersion` in `configuration-schema.json`. Defaults to `v1`
   - Add `request()` function for surveyCTO API requests
@@ -130,7 +130,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -142,42 +142,42 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.1.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 1.1.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 1.1.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 1.1.1 - 13 January 2023
 
 ### Patch Changes
 
-- 6d8de03: change @constructor to @function and remove /\*\_ @module Adaptor \_/
+- [6d8de03](https://github.com/OpenFn/adaptors/commit/6d8de03): change @constructor to @function and remove /\*\_ @module Adaptor \_/
 
 ## 1.1.0 - 18 November 2022
 
 ### Minor Changes
 
-- 776bb13: migrate surveycto
+- [776bb13](https://github.com/OpenFn/adaptors/commit/776bb13): migrate surveycto
 
 ### Patch Changes
 
-- Updated dependencies \[f2a91a4]
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -4,142 +4,142 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.3.16 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.3.15 - 10 July 2025
 
 ### Patch Changes
 
-- c4625fa: - Migrate from the deprecated `expandReferences` in `common` to the
+- [c4625fa](https://github.com/OpenFn/adaptors/commit/c4625fa): - Migrate from the deprecated `expandReferences` in `common` to the
   new `expandReferences` from common.util
   - Use `workspace:*` common version.
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.3.14 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.3.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.3.12 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.3.11 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.3.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.3.9 - 10 March 2025
 
 ### Patch Changes
 
-- 8a8c28d: - cleanup examples wrapped with `execute()` function
+- [8a8c28d](https://github.com/OpenFn/adaptors/commit/8a8c28d): - cleanup examples wrapped with `execute()` function
   - Add example caption and add sample payload
 
 ## 0.3.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.3.7 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.3.6 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.3.5 - 18 October 2024
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.3.4 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.3.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.3.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.3.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.2.1 - 19 June 2023
@@ -154,7 +154,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -166,42 +166,42 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.1.4 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.1.3 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.1.2 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.1.1 - 25 November 2022
 
 ### Patch Changes
 
-- e4ebcb6: Fix Large gzip Denial of Service in superagent
+- [e4ebcb6](https://github.com/OpenFn/adaptors/commit/e4ebcb6): Fix Large gzip Denial of Service in superagent
 
 ## 0.1.0 - 18 November 2022
 
 ### Minor Changes
 
-- 83ede44: migrate telerivet
+- [83ede44](https://github.com/OpenFn/adaptors/commit/83ede44): migrate telerivet
 
 ### Patch Changes
 
-- Updated dependencies \[f2a91a4]
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -4,75 +4,75 @@
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 1.0.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 1.0.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 1.0.7 - 18 October 2024
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 1.0.6 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 1.0.5 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 1.0.4 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.0.3 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.0.2 - 25 July 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4c08444]
-- Updated dependencies \[73d0a02]
+- Updated dependencies [4c08444](https://github.com/OpenFn/adaptors/commit/4c08444)
+- Updated dependencies [73d0a02](https://github.com/OpenFn/adaptors/commit/73d0a02)
   - @openfn/language-common@1.15.1
 
 ## 1.0.1 - 19 June 2024
 
 ### Patch Changes
 
-- Updated dependencies \[5fb82f07]
+- Updated dependencies [5fb82f07](https://github.com/OpenFn/adaptors/commit/5fb82f07)
   - @openfn/language-common@1.15.0
 
 .

--- a/packages/twilio/CHANGELOG.md
+++ b/packages/twilio/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- b7af59a: - Update `package.json` description to be LLM-readable
+- [b7af59a](https://github.com/OpenFn/adaptors/commit/b7af59a): - Update `package.json` description to be LLM-readable
 
 ## 1.0.0 - 11 August 2025
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -45,25 +45,25 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.5.4 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.5.3 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.5.2 - 15 October 2024
@@ -76,26 +76,26 @@
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.5.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.4.2 - 24 January 2024
 
 ### Patch Changes
 
-- 6afba70: Fix sendSMS
+- [6afba70](https://github.com/OpenFn/adaptors/commit/6afba70): Fix sendSMS
 
 ## 0.4.1 - 19 June 2023
 
@@ -109,7 +109,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -121,42 +121,42 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.3.4 - 06 April 2023
 
 ### Patch Changes
 
-- a22daa6: rename credential-schema to configuration-schemawq
+- [a22daa6](https://github.com/OpenFn/adaptors/commit/a22daa6): rename credential-schema to configuration-schemawq
 
 ## 0.3.3 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.3.2 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.3.1 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.3.0 - 18 November 2022
 
 ### Minor Changes
 
-- a36a072: ymigrated twilio to monorepo
+- [a36a072](https://github.com/OpenFn/adaptors/commit/a36a072): ymigrated twilio to monorepo
 
 ### Patch Changes
 
-- Updated dependencies \[f2a91a4]
+- Updated dependencies [f2a91a4](https://github.com/OpenFn/adaptors/commit/f2a91a4)
   - @openfn/language-common@1.7.5

--- a/packages/varo/CHANGELOG.md
+++ b/packages/varo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- a5cea4e: removed `http` export from `@openfn/language-common`
+- [a5cea4e](https://github.com/OpenFn/adaptors/commit/a5cea4e): removed `http` export from `@openfn/language-common`
 
   ### Migration Guide
 
@@ -39,60 +39,60 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.1.3 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.1.2 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.1.1 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.1.0 - 12 May 2025
 
 ### Minor Changes
 
-- c9453ed: Added streaming RTMD data support.
+- [c9453ed](https://github.com/OpenFn/adaptors/commit/c9453ed): Added streaming RTMD data support.
 
 ## 1.0.3 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.0.2 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.0.1 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.0.0 - 19 March 2025

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -4,85 +4,85 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.3.17 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.3.16 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.3.15 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 1.3.14 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 1.3.13 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 1.3.12 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 1.3.11 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 1.3.10 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 1.3.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 1.3.8 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 1.3.7 - 28 October 2024
@@ -97,53 +97,53 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 1.3.5 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 1.3.4 - 09 October 2024
 
 ### Patch Changes
 
-- 8d866e4: Update tough-cookie dependency
+- [8d866e4](https://github.com/OpenFn/adaptors/commit/8d866e4): Update tough-cookie dependency
 
 ## 1.3.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 1.3.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 1.3.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 1.3.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 1.2.1 - 19 June 2023
@@ -158,7 +158,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -170,31 +170,31 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 1.1.3 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 1.1.2 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 1.1.1 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 1.1.0 - 25 November 2022
 
 ### Minor Changes
 
-- b4a13ff: migrate vtiger
+- [b4a13ff](https://github.com/OpenFn/adaptors/commit/b4a13ff): migrate vtiger

--- a/packages/whatsapp/CHANGELOG.md
+++ b/packages/whatsapp/CHANGELOG.md
@@ -4,25 +4,25 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 1.0.2 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 1.0.1 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 1.0.0 - 08 July 2025

--- a/packages/wigal-sms/CHANGELOG.md
+++ b/packages/wigal-sms/CHANGELOG.md
@@ -4,70 +4,70 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.1.10 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.1.9 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.1.8 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.1.7 - 22 April 2025
 
 ### Patch Changes
 
-- 99e4b48: - Better handling of HTML content in http requests
+- [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48): - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.1.6 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.1.5 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.1.4 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.1.3 - 31 January 2025
 
 ### Patch Changes
 
-- 7c677a5: Update example for wigal sms
+- [7c677a5](https://github.com/OpenFn/adaptors/commit/7c677a5): Update example for wigal sms
 
 ## 0.1.2 - 30 January 2025
 

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -4,85 +4,85 @@
 
 ### Patch Changes
 
-- Updated dependencies \[9b5a4f8]
+- Updated dependencies [9b5a4f8](https://github.com/OpenFn/adaptors/commit/9b5a4f8)
   - @openfn/language-common@3.0.2
 
 ## 0.4.16 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[cf9c09f]
+- Updated dependencies [cf9c09f](https://github.com/OpenFn/adaptors/commit/cf9c09f)
   - @openfn/language-common@3.0.1
 
 ## 0.4.15 - 10 July 2025
 
 ### Patch Changes
 
-- Updated dependencies \[ea85695]
-- Updated dependencies \[3fce58f]
-- Updated dependencies \[19f2d7e]
-- Updated dependencies \[f26bd2b]
-- Updated dependencies \[19f2d7e]
+- Updated dependencies [ea85695](https://github.com/OpenFn/adaptors/commit/ea85695)
+- Updated dependencies [3fce58f](https://github.com/OpenFn/adaptors/commit/3fce58f)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
+- Updated dependencies [f26bd2b](https://github.com/OpenFn/adaptors/commit/f26bd2b)
+- Updated dependencies [19f2d7e](https://github.com/OpenFn/adaptors/commit/19f2d7e)
   - @openfn/language-common@3.0.0
 
 ## 0.4.14 - 20 June 2025
 
 ### Patch Changes
 
-- Updated dependencies \[28c2e8b]
+- Updated dependencies [28c2e8b](https://github.com/OpenFn/adaptors/commit/28c2e8b)
   - @openfn/language-common@2.5.0
 
 ## 0.4.13 - 22 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[99e4b48]
-- Updated dependencies \[13bf08f]
+- Updated dependencies [99e4b48](https://github.com/OpenFn/adaptors/commit/99e4b48)
+- Updated dependencies [13bf08f](https://github.com/OpenFn/adaptors/commit/13bf08f)
   - @openfn/language-common@2.4.0
 
 ## 0.4.12 - 16 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b089c56]
+- Updated dependencies [b089c56](https://github.com/OpenFn/adaptors/commit/b089c56)
   - @openfn/language-common@2.3.3
 
 ## 0.4.11 - 11 April 2025
 
 ### Patch Changes
 
-- Updated dependencies \[d7105c0]
+- Updated dependencies [d7105c0](https://github.com/OpenFn/adaptors/commit/d7105c0)
   - @openfn/language-common@2.3.2
 
 ## 0.4.10 - 14 March 2025
 
 ### Patch Changes
 
-- Updated dependencies \[23ccb01]
+- Updated dependencies [23ccb01](https://github.com/OpenFn/adaptors/commit/23ccb01)
   - @openfn/language-common@2.3.1
 
 ## 0.4.9 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[b3d7f59]
-- Updated dependencies \[2d709ff]
-- Updated dependencies \[41e8cc3]
+- Updated dependencies [b3d7f59](https://github.com/OpenFn/adaptors/commit/b3d7f59)
+- Updated dependencies [2d709ff](https://github.com/OpenFn/adaptors/commit/2d709ff)
+- Updated dependencies [41e8cc3](https://github.com/OpenFn/adaptors/commit/41e8cc3)
   - @openfn/language-common@2.3.0
 
 ## 0.4.8 - 16 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[6dffdbd]
+- Updated dependencies [6dffdbd](https://github.com/OpenFn/adaptors/commit/6dffdbd)
   - @openfn/language-common@2.2.1
 
 ## 0.4.7 - 09 January 2025
 
 ### Patch Changes
 
-- Updated dependencies \[a47d8d5]
-- Updated dependencies \[9240428]
+- Updated dependencies [a47d8d5](https://github.com/OpenFn/adaptors/commit/a47d8d5)
+- Updated dependencies [9240428](https://github.com/OpenFn/adaptors/commit/9240428)
   - @openfn/language-common@2.2.0
 
 ## 0.4.6 - 28 October 2024
@@ -97,47 +97,47 @@
 
 ### Patch Changes
 
-- Updated dependencies \[03a1a74]
+- Updated dependencies [03a1a74](https://github.com/OpenFn/adaptors/commit/03a1a74)
   - @openfn/language-common@2.1.0
 
 ## 0.4.4 - 15 October 2024
 
 ### Patch Changes
 
-- Fixed security vulnerability in jsonpath-plus \[33973a2]
+- Fixed security vulnerability in jsonpath-plus [33973a2](https://github.com/OpenFn/adaptors/commit/33973a2)
   - @openfn/language-common@2.0.3
 
 ## 0.4.3 - 24 September 2024
 
 ### Patch Changes
 
-- Updated dependencies \[77a690f]
+- Updated dependencies [77a690f](https://github.com/OpenFn/adaptors/commit/77a690f)
   - @openfn/language-common@2.0.2
 
 ## 0.4.2 - 16 August 2024
 
 ### Patch Changes
 
-- 8146c23: Fix typings in package.json
-- Updated dependencies \[8146c23]
+- [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23): Fix typings in package.json
+- Updated dependencies [8146c23](https://github.com/OpenFn/adaptors/commit/8146c23)
   - @openfn/language-common@2.0.1
 
 ## 0.4.1 - 01 August 2024
 
 ### Patch Changes
 
-- Updated dependencies \[4fe527c]
+- Updated dependencies [4fe527c](https://github.com/OpenFn/adaptors/commit/4fe527c)
   - @openfn/language-common@2.0.0
 
 ## 0.4.0 - 13 June 2024
 
 ### Minor Changes
 
-- 73433c20: Add `fnIf` operation
+- [73433c20](https://github.com/OpenFn/adaptors/commit/73433c20): Add `fnIf` operation
 
 ### Patch Changes
 
-- Updated dependencies \[106ecf6d]
+- Updated dependencies [106ecf6d](https://github.com/OpenFn/adaptors/commit/106ecf6d)
   - @openfn/language-common@1.14.0
 
 ## 0.3.1 - 19 June 2023
@@ -152,7 +152,7 @@
 
 ### Minor Changes
 
-- 2c1d603: Remove parameter reassignment to ensure proper functioning inside an
+- [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603): Remove parameter reassignment to ensure proper functioning inside an
   `each` block; add eslint
 
   The packages receiving a major bump here exposed functions that didn't work as
@@ -164,35 +164,35 @@
 
 ### Patch Changes
 
-- Updated dependencies \[2c1d603]
+- Updated dependencies [2c1d603](https://github.com/OpenFn/adaptors/commit/2c1d603)
   - @openfn/language-common@1.8.0
 
 ## 0.2.3 - 30 March 2023
 
 ### Patch Changes
 
-- 14f481e: mark execute as private
-- Updated dependencies \[2b4c61a]
+- [14f481e](https://github.com/OpenFn/adaptors/commit/14f481e): mark execute as private
+- Updated dependencies [2b4c61a](https://github.com/OpenFn/adaptors/commit/2b4c61a)
   - @openfn/language-common@1.7.6
 
 ## 0.2.2 - 15 February 2023
 
 ### Patch Changes
 
-- f7ebd3c: remove sample configuration
+- [f7ebd3c](https://github.com/OpenFn/adaptors/commit/f7ebd3c): remove sample configuration
 
 ## 0.2.1 - 15 February 2023
 
 ### Patch Changes
 
-- f2aed32: add examples
+- [f2aed32](https://github.com/OpenFn/adaptors/commit/f2aed32): add examples
 
 ## 0.2.0 - 25 November 2022
 
 ### Minor Changes
 
-- f9ac74a: migrate zoho
+- [f9ac74a](https://github.com/OpenFn/adaptors/commit/f9ac74a): migrate zoho
 
 ### Patch Changes
 
-- e4ebcb6: Fix Large gzip Denial of Service in superagent
+- [e4ebcb6](https://github.com/OpenFn/adaptors/commit/e4ebcb6): Fix Large gzip Denial of Service in superagent


### PR DESCRIPTION
## Summary

This PR is part of #1357. It updates all adaptors changelog with commit hash to include a GitHub hyperlink to that commit.  The changelog are updated by running `pnpm changelog` from adaptor directory 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA: If this is a new adaptor, added the adaptor on marketing website ?
- NA: If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
