### PR TITLE
adaptors: add `core` or `community` labels to adaptors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,7 +589,7 @@ importers:
         version: link:../common
       '@openfn/language-fhir':
         specifier: ^5.0.7
-        version: link:../fhir
+        version: 5.0.8
       '@types/fhir':
         specifier: ^0.0.41
         version: 0.0.41
@@ -2396,6 +2396,39 @@ importers:
       remark-stringify:
         specifier: ^11.0.0
         version: 11.0.0
+      yargs:
+        specifier: 17.6.0
+        version: 17.6.0
+
+  tools/docs-label:
+    dependencies:
+      '@types/node':
+        specifier: 18.17.5
+        version: 18.17.5
+      date-fns:
+        specifier: ^2.25.0
+        version: 2.30.0
+      inquirer:
+        specifier: ^9.2.15
+        version: 9.3.7
+      remark:
+        specifier: ^15.0.1
+        version: 15.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
+      ts-node:
+        specifier: 10.9.1
+        version: 10.9.1(@swc/core@1.12.7)(@types/node@18.17.5)(typescript@4.8.4)
+      tsup:
+        specifier: 6.3.0
+        version: 6.3.0(ts-node@10.9.1)(typescript@4.8.4)
+      typescript:
+        specifier: 4.8.4
+        version: 4.8.4
       yargs:
         specifier: 17.6.0
         version: 17.6.0
@@ -4813,6 +4846,26 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  /@openfn/language-common@3.0.3:
+    resolution: {integrity: sha512-oXtSwuOfYJI3DQh9MiDqs/iS26Qmft26gwNKlDBCx+1xSZCNmkxQNoA5yq5qaZU2G1n0Bw6rn75/JqRvAvONEA==}
+    dependencies:
+      ajv: 8.17.1
+      csv-parse: 5.6.0
+      csvtojson: 2.0.10
+      date-fns: 2.30.0
+      http-status-codes: 2.3.0
+      jsonpath-plus: 10.3.0
+      lodash: 4.17.21
+      undici: 5.29.0
+    dev: false
+
+  /@openfn/language-fhir@5.0.8:
+    resolution: {integrity: sha512-1jIKqBL59rdCDtBTXuYr0IPEPWE7bO6utXHnU0suK2pg4EotXepdlZs3I91FbcR/bljjuBK6rMdIdvC5jQ+0sg==}
+    dependencies:
+      '@openfn/language-common': 3.0.3
+      undici: 5.29.0
+    dev: false
 
   /@paralleldrive/cuid2@2.2.2:
     resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}

--- a/tools/docs-label/README.md
+++ b/tools/docs-label/README.md
@@ -1,0 +1,30 @@
+# @openfn/changelog
+
+A utility for maintaining and updating changelogs across all OpenFn language adaptors.
+
+This package supports two key use cases:
+
+- ✅ **Inserting the current release date** for new versions.
+- 📦 **Fetching historical versions from the NPM registry** and updating each version entry in the `CHANGELOG.md` file with its actual release date.
+
+---
+
+## 📅 Commands
+
+### 1. `update-latest-versions`
+
+Adds today’s date to the most recent version heading in each adaptor’s `CHANGELOG.md`.
+
+```bash
+pnpm update-latest-versions
+
+```
+
+### 2. `update-historical-versions`
+
+Fetches release versions and dates from the NPM registry for each adaptor (e.g., `@openfn/language-dhis2`) and adds release dates next to each version in the changelog.
+
+```bash
+pnpm update-historical-versions
+
+```

--- a/tools/docs-label/package.json
+++ b/tools/docs-label/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@openfn/docs-label",
+  "private": true,
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.ts",
+  "type": "module",
+  "bin": {
+    "generate": "src/cli.ts"
+  },
+  "scripts": {
+    "cli": "tsx src/cli.ts"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "date-fns": "^2.25.0",
+    "remark": "^15.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "yargs": "17.6.0",
+    "@types/node": "18.17.5",
+    "inquirer": "^9.2.15",
+    "ts-node": "10.9.1",
+    "tsup": "6.3.0",
+    "typescript": "4.8.4"
+  }
+}

--- a/tools/docs-label/src/cli.ts
+++ b/tools/docs-label/src/cli.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import yargs from "yargs";
+import process from 'node:process';
+import { hideBin } from "yargs/helpers";
+import { updateBadgeInName } from "./update-badge";
+
+
+
+yargs(hideBin(process.argv))
+  .command(
+    "badge <name>",
+    "Append (Core) or (Community) to a single adaptor's display name",
+    (y) =>
+      y
+        .positional("name", {
+          type: "string",
+          describe: "Adaptor name (folder & json base name)",
+        })
+        .option("tier", {
+          alias: "t",
+          choices: ["core", "community"] as const,
+          default: "core",
+          describe: "Badge to apply",
+        }),
+    (args) => {
+      updateBadgeInName({
+        name: String(args.name),
+        tier: args.tier as "core" | "community"
+      });
+    }
+  )
+  .demandCommand(1, "Please provide a command, e.g. ` badge <name> --tier core`")
+  .fail((msg, err, y) => {
+    if (msg) console.error(msg);
+    console.log("\nExamples:\n   badge odoo --tier core\n   badge dhis2 --tier community\n");
+    console.log(y.help());
+    process.exit(1);
+  })
+  .strict()
+  .help()
+  .parse();

--- a/tools/docs-label/src/update-badge.ts
+++ b/tools/docs-label/src/update-badge.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+import process from 'node:process';
+
+const packageDir = '../../packages';
+
+function stripSuffix(s: string) {
+  return String(s)
+    .replace(/\s*\((Core|Community)\)\s*$/i, '')
+    .trim();
+}
+
+function resolveJsonPath(adaptor: string) {
+  const file = path.resolve(
+    process.cwd(),
+    packageDir,
+    adaptor,
+    'docs',
+    `${adaptor}.json`
+  );
+  return file;
+}
+
+export function updateBadgeInName(opts: {
+  name: string;
+  tier: 'core' | 'community';
+}) {
+  const filePath = resolveJsonPath(opts.name);
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const json = JSON.parse(raw);
+
+  if (typeof json.name !== 'string' || !json.name.trim()) {
+    throw new Error(`'name' is missing or not a string in ${filePath}`);
+  }
+
+  const base = stripSuffix(json.name);
+  const suffix = opts.tier === 'core' ? ' (Core)' : ' (Community)';
+  const next = `${base}${suffix}`;
+
+  if (json.name === next) {
+    console.log(`No change: ${filePath} already "${next}"`);
+    return;
+  }
+
+  json.name = next;
+  const out = JSON.stringify(json, null, 2) + '\n';
+
+  fs.writeFileSync(filePath, out, 'utf8');
+  console.log(`√ Updated ${filePath} -> name="${json.name}"`);
+}


### PR DESCRIPTION
## Summary

Add `core` or `community` labels to adaptors.

Fixes #584 

## Details

Add a `core` or `community` label to adaptor names. i.e `zoho (Core)

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
