### PR TITLE
common: implement undici agent

### DIFF
--- a/.changeset/perfect-pets-carry.md
+++ b/.changeset/perfect-pets-carry.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-common': minor
----
-
-Switch from `undici` Client to Agent to allow cross-redirection for domains

--- a/.changeset/perfect-pets-carry.md
+++ b/.changeset/perfect-pets-carry.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': minor
+---
+
+Switch from `undici` Client to Agent to allow cross-redirection for domains

--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-asana
 
+## 5.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 5.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-asana",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "label": "Asana",
   "description": "OpenFn adaptor for accessing objects in Asana",
   "homepage": "https://docs.openfn.org",

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-azure-storage
 
+## 3.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 3.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/azure-storage/package.json
+++ b/packages/azure-storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-azure-storage",
   "label": "Azure Storage",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "OpenFn adaptor for Azure Storage",
   "type": "module",
   "exports": {

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-beyonic
 
+## 0.3.20 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.3.19 - 01 September 2025
 
 ### Patch Changes

--- a/packages/beyonic/package.json
+++ b/packages/beyonic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-beyonic",
   "label": "Beyonic",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "OpenFn adaptor for Beyonic",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-bigquery
 
+## 4.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 4.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-bigquery",
   "label": "BigQuery",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A Google BigQuery language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cartodb
 
+## 0.4.21 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.4.20 - 01 September 2025
 
 ### Patch Changes

--- a/packages/cartodb/package.json
+++ b/packages/cartodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-cartodb",
   "label": "CartoDB",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "cartodb Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/chatgpt/CHANGELOG.md
+++ b/packages/chatgpt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-chatgpt
 
+## 2.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/chatgpt/package.json
+++ b/packages/chatgpt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-chatgpt",
   "label": "ChatGPT",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "OpenFn adaptor for ChatGPT",
   "type": "module",
   "exports": {

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cht
 
+## 1.1.4 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.1.3 - 01 September 2025
 
 ### Patch Changes

--- a/packages/cht/package.json
+++ b/packages/cht/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-cht",
   "label": "Community Health Toolkit (CHT)",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "OpenFn adaptor for Community Health Toolkit (CHT)",
   "type": "module",
   "exports": {

--- a/packages/claude/CHANGELOG.md
+++ b/packages/claude/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-claude
 
+## 1.0.14 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.13 - 01 September 2025
 
 ### Patch Changes

--- a/packages/claude/package.json
+++ b/packages/claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-claude",
   "label": "Claude",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "OpenFn adaptor for Claude",
   "type": "module",
   "exports": {

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-collections
 
+## 0.7.15 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.7.14 - 01 September 2025
 
 ### Patch Changes

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-collections",
   "label": "Collections",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Collections Adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-commcare
 
+## 4.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 4.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-commcare",
   "label": "CommCare",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "OpenFn adaptor for CommCare (Dimagi)",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 3.0.1 - 11 July 2025
 
+## 3.1.0 - 18 September 2025
+
+### Minor Changes
+
+- e2bc436: Switch from `undici` Client to Agent to allow cross-redirection for
+  domains
+
 ## 3.0.3 - 01 September 2025
 
 ### Patch Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-common",
   "label": "Common",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Common Expressions for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -1,4 +1,4 @@
-import { MockAgent, Agent, setGlobalDispatcher } from 'undici';
+import { MockAgent, Agent } from 'undici';
 import { getReasonPhrase } from 'http-status-codes';
 import { Readable } from 'node:stream';
 import querystring from 'node:querystring';
@@ -35,7 +35,7 @@ export const logResponse = response => {
   return response;
 };
 
-export function getAgentForOrigin(origin, { tls = {}, ...agentOpts } = {}) {
+const getAgent = (origin, { tls = {}, ...agentOpts } = {}) => {
   if (!agents.has(origin)) {
     const agent = new Agent({
       connect: tls,
@@ -46,13 +46,6 @@ export function getAgentForOrigin(origin, { tls = {}, ...agentOpts } = {}) {
   }
 
   return agents.get(origin);
-}
-
-const getAgent = (origin, options) => {
-  const agent = getAgentForOrigin(origin, options);
-  setGlobalDispatcher(agent);
-
-  return agent;
 };
 
 export const enableMockClient = (baseUrl, options = {}) => {
@@ -108,7 +101,6 @@ export const enableMockClient = (baseUrl, options = {}) => {
 
     agents.set(baseUrl, client);
   }
-
   return client;
 };
 

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dhis2
 
+## 8.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 8.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-dhis2",
   "label": "DHIS2",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "OpenFn adaptor for DHIS2",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/divoc/CHANGELOG.md
+++ b/packages/divoc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-divoc
 
+## 0.1.10 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.1.9 - 01 September 2025
 
 ### Patch Changes

--- a/packages/divoc/package.json
+++ b/packages/divoc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-divoc",
   "label": "Divoc",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "OpenFn adaptor for DIVOC",
   "type": "module",
   "exports": {

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dynamics
 
+## 0.5.22 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.5.21 - 01 September 2025
 
 ### Patch Changes

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-dynamics",
   "label": "Dynamics",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "description": "OpenFn adaptor for Microsoft Dynamics",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-facebook
 
+## 0.4.20 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.4.19 - 01 September 2025
 
 ### Patch Changes

--- a/packages/facebook/package.json
+++ b/packages/facebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-facebook",
   "label": "Facebook",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "An Language Package for Facebook Messenger API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/fhir-4/CHANGELOG.md
+++ b/packages/fhir-4/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir-4
 
+## 0.1.11 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.1.10 - 01 September 2025
 
 ### Patch Changes

--- a/packages/fhir-4/package.json
+++ b/packages/fhir-4/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir-4",
   "label": "FHIR r4",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "OpenFn FHIR r4 adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-4 src docs",

--- a/packages/fhir-fr/CHANGELOG.md
+++ b/packages/fhir-fr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir-fr
 
+## 1.0.17 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.16 - 01 September 2025
 
 ### Patch Changes

--- a/packages/fhir-fr/package.json
+++ b/packages/fhir-fr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir-fr",
   "label": "FHIR-FR",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "OpenFn fhir-fr adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-fr src ast docs",

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-fhir-ndr-et
 
+## 0.1.20 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+  - @openfn/language-fhir@5.0.9
+
 ## 0.1.19 - 01 September 2025
 
 ### Patch Changes

--- a/packages/fhir-ndr-et/package.json
+++ b/packages/fhir-ndr-et/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir-ndr-et",
   "label": "FHIR NDR Ehtiopia",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "OpenFn fhir adaptor for NDR HIV in Ehtiopia",
   "type": "module",
   "exports": {
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@openfn/language-common": "workspace:*",
-    "@openfn/language-fhir": "^5.0.8",
+    "@openfn/language-fhir": "^5.0.9",
     "@types/fhir": "^0.0.41",
     "ast-types": "^0.14.2",
     "lodash": "^4.17.21",

--- a/packages/fhir/CHANGELOG.md
+++ b/packages/fhir/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir
 
+## 5.0.9 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 5.0.8 - 01 September 2025
 
 ### Patch Changes

--- a/packages/fhir/package.json
+++ b/packages/fhir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir",
   "label": "FHIR",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "description": "A FHIR adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/ghana-bdr/CHANGELOG.md
+++ b/packages/ghana-bdr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ghana-bdr
 
+## 0.1.13 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.1.12 - 01 September 2025
 
 ### Patch Changes

--- a/packages/ghana-bdr/package.json
+++ b/packages/ghana-bdr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-ghana-bdr",
   "label": "Ghana BDR",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "OpenFn adaptor for Ghana birth-death registry (BDR)",
   "type": "module",
   "exports": {

--- a/packages/ghana-nia/CHANGELOG.md
+++ b/packages/ghana-nia/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ghana-nia
 
+## 0.1.13 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.1.12 - 01 September 2025
 
 ### Patch Changes

--- a/packages/ghana-nia/package.json
+++ b/packages/ghana-nia/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-ghana-nia",
   "label": "Ghana NIA",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "OpenFn ghana-nia adaptor",
   "type": "module",
   "exports": {

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-gmail
 
+## 2.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-gmail",
   "label": "Gmail",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "badge": "Community",
   "description": "OpenFn gmail adaptor",
   "type": "module",

--- a/packages/godata/CHANGELOG.md
+++ b/packages/godata/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-godata
 
+## 3.5.9 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 3.5.8 - 01 September 2025
 
 ### Patch Changes

--- a/packages/godata/package.json
+++ b/packages/godata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-godata",
   "label": "GoData",
-  "version": "3.5.8",
+  "version": "3.5.9",
   "description": "An OpenFn adaptor for use with the WHO's GoData API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/googledrive/CHANGELOG.md
+++ b/packages/googledrive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googledrive
 
+## 2.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/googledrive/package.json
+++ b/packages/googledrive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-googledrive",
   "label": "Google Drive",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "OpenFn Google Drive adaptor",
   "type": "module",
   "exports": {

--- a/packages/googlehealthcare/CHANGELOG.md
+++ b/packages/googlehealthcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googlehealthcare
 
+## 1.1.8 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.1.7 - 01 September 2025
 
 ### Patch Changes

--- a/packages/googlehealthcare/package.json
+++ b/packages/googlehealthcare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-googlehealthcare",
   "label": "Google Health Care",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A Google Health Care language package for use with Open Function",
   "type": "module",
   "exports": {

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googlesheets
 
+## 4.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 4.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-googlesheets",
   "label": "Google Sheets",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A Google Sheets Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-hive
 
+## 0.3.20 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.3.19 - 01 September 2025
 
 ### Patch Changes

--- a/packages/hive/package.json
+++ b/packages/hive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-hive",
   "label": "Apache HIVE",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "An Apache HIVE adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-http
 
+## 7.2.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 7.2.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-http",
   "label": "HTTP",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/hubtel/CHANGELOG.md
+++ b/packages/hubtel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-hubtel
 
+## 1.0.12 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.11 - 01 September 2025
 
 ### Patch Changes

--- a/packages/hubtel/package.json
+++ b/packages/hubtel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-hubtel",
   "label": "Hubtel",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "OpenFn adaptor for Hubtel",
   "type": "module",
   "exports": {

--- a/packages/inform/CHANGELOG.md
+++ b/packages/inform/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-inform
 
+## 1.1.5 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.1.4 - 01 September 2025
 
 ### Patch Changes

--- a/packages/inform/package.json
+++ b/packages/inform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-inform",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "OpenFn inform adaptor for UNICEF InForm platform operations",
   "type": "module",
   "exports": {

--- a/packages/intuit/CHANGELOG.md
+++ b/packages/intuit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-intuit
 
+## 1.0.11 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.10 - 01 September 2025
 
 ### Patch Changes

--- a/packages/intuit/package.json
+++ b/packages/intuit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-intuit",
   "label": "Intuit",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "OpenFn adaptor for Intuit (QuickBooks)",
   "type": "module",
   "exports": {

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-khanacademy
 
+## 0.5.20 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.5.19 - 01 September 2025
 
 ### Patch Changes

--- a/packages/khanacademy/package.json
+++ b/packages/khanacademy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-khanacademy",
   "label": "Khan Academy",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "A Khan Academy Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-kobotoolbox
 
+## 4.2.4 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 4.2.3 - 01 September 2025
 
 ### Patch Changes

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-kobotoolbox",
   "label": "KoboToolbox",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "OpenFn adaptor for KoboToolbox",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailchimp
 
+## 1.0.21 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.20 - 01 September 2025
 
 ### Patch Changes

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mailchimp",
   "label": "Mailchimp",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "An OpenFn adaptor for use with Mailchimp",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailgun
 
+## 0.5.19 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.5.18 - 01 September 2025
 
 ### Patch Changes

--- a/packages/mailgun/package.json
+++ b/packages/mailgun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mailgun",
   "label": "Mailgun",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "mailgun Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-maximo
 
+## 0.5.22 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.5.21 - 01 September 2025
 
 ### Patch Changes

--- a/packages/maximo/package.json
+++ b/packages/maximo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-maximo",
   "label": "Maximo",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "description": "OpenFn adaptor for IBM Maximo EAM",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-medicmobile
 
+## 0.5.20 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.5.19 - 01 September 2025
 
 ### Patch Changes

--- a/packages/medicmobile/package.json
+++ b/packages/medicmobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-medicmobile",
   "label": "Medic Mobile",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "OpenFn adaptor for Medic Mobile",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -1,5 +1,12 @@
 v0.1.6
 
+## 0.6.4 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.6.3 - 01 September 2025
 
 ### Patch Changes

--- a/packages/mogli/package.json
+++ b/packages/mogli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mogli",
   "label": "Mogli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "OpenFn adaptor for Mogli SMS",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mojatax/CHANGELOG.md
+++ b/packages/mojatax/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mojatax
 
+## 1.0.15 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.14 - 01 September 2025
 
 ### Patch Changes

--- a/packages/mojatax/package.json
+++ b/packages/mojatax/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mojatax",
   "label": "MojaTax",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "OpenFn adaptor for MojaTax",
   "type": "module",
   "exports": {

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mongodb
 
+## 2.1.21 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.1.20 - 01 September 2025
 
 ### Patch Changes

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mongodb",
   "label": "MongoDB",
-  "version": "2.1.20",
+  "version": "2.1.21",
   "description": "A language package for working with MongoDb",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mpesa/CHANGELOG.md
+++ b/packages/mpesa/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mpesa
 
+## 1.1.5 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.1.4 - 01 September 2025
 
 ### Patch Changes

--- a/packages/mpesa/package.json
+++ b/packages/mpesa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mpesa",
   "label": "Mpesa",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "OpenFn adaptor for M-Pesa",
   "type": "module",
   "exports": {

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msgraph
 
+## 0.8.4 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.8.3 - 01 September 2025
 
 ### Patch Changes

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-msgraph",
   "label": "Microsoft Graph",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Microsoft Graph Language Pack for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mssql
 
+## 6.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 6.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mssql",
   "label": "MSSQL",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {

--- a/packages/msupply/CHANGELOG.md
+++ b/packages/msupply/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msupply
 
+## 1.0.8 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.7 - 01 September 2025
 
 ### Patch Changes

--- a/packages/msupply/package.json
+++ b/packages/msupply/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-msupply",
   "label": "mSupply",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OpenFn adaptor for mSupply",
   "type": "module",
   "exports": {

--- a/packages/mtn-momo/CHANGELOG.md
+++ b/packages/mtn-momo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mtn-momo
 
+## 1.1.4 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.1.3 - 01 September 2025
 
 ### Patch Changes

--- a/packages/mtn-momo/package.json
+++ b/packages/mtn-momo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mtn-momo",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "OpenFn mtn-momo adaptor for MTN Mobile Money payment operations",
   "type": "module",
   "exports": {

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mysql
 
+## 3.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 3.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mysql",
   "label": "MySQL",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A MySQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "main": "dist/index.cjs",

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-nexmo
 
+## 0.5.23 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.5.22 - 01 September 2025
 
 ### Patch Changes

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-nexmo",
   "label": "Nexmo",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "description": "OpenFn adaptor for Nexmo",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ocl
 
+## 1.2.21 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.2.20 - 01 September 2025
 
 ### Patch Changes

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-ocl",
   "label": "OCL",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "OpenFn adaptor for Open Concept Lab (ORL) terminology services",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-odk
 
+## 3.0.21 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 3.0.20 - 01 September 2025
 
 ### Patch Changes

--- a/packages/odk/package.json
+++ b/packages/odk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-odk",
   "label": "ODK",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "description": "OpenFn adaptor for Open Data Kit (ODK) data collection platform",
   "type": "module",
   "exports": {

--- a/packages/odoo/CHANGELOG.md
+++ b/packages/odoo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-odoo
 
+## 2.1.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.1.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/odoo/package.json
+++ b/packages/odoo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-odoo",
   "label": "Odoo",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "OpenFn adaptor for Odoo (ERP)",
   "type": "module",
   "exports": {

--- a/packages/openboxes/CHANGELOG.md
+++ b/packages/openboxes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openboxes
 
+## 1.0.9 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.8 - 01 September 2025
 
 ### Patch Changes

--- a/packages/openboxes/package.json
+++ b/packages/openboxes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openboxes",
   "label": "OpenBoxes",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "OpenFn adaptor for OpenBoxes",
   "type": "module",
   "exports": {

--- a/packages/opencrvs/CHANGELOG.md
+++ b/packages/opencrvs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-opencrvs
 
+## 1.0.5 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+  - @openfn/language-fhir-4@0.1.11
+
 ## 1.0.4 - 01 September 2025
 
 ### Patch Changes

--- a/packages/opencrvs/package.json
+++ b/packages/opencrvs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-opencrvs",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenFn adaptor for OpenCRVS",
   "type": "module",
   "exports": {

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openfn
 
+## 3.0.5 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 3.0.4 - 01 September 2025
 
 ### Patch Changes

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openfn",
   "label": "OpenFn",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "OpenFn adaptor for accessing the OpenFn web API",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openhim
 
+## 2.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/openhim/package.json
+++ b/packages/openhim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openhim",
   "label": "OpenHIM",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "OpenFn adaptor for OpenHIM",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openimis
 
+## 3.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 3.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/openimis/package.json
+++ b/packages/openimis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openimis",
   "label": "OpenIMIS",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "OpenFn adaptor for OpenIMIS",
   "type": "module",
   "exports": {

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openlmis
 
+## 1.1.4 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.1.3 - 01 September 2025
 
 ### Patch Changes

--- a/packages/openlmis/package.json
+++ b/packages/openlmis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openlmis",
   "label": "OpenLMIS",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "OpenFn adaptor for OpenLMIS",
   "type": "module",
   "exports": {

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openmrs
 
+## 5.3.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 5.3.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openmrs",
   "label": "OpenMRS",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "OpenFn adaptor for OpenMRS",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openspp
 
+## 3.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 3.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/openspp/package.json
+++ b/packages/openspp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openspp",
   "label": "OpenSPP",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "OpenFn adaptor for working with the OpenSPP json rpc",
   "type": "module",
   "exports": {

--- a/packages/pdfshift/CHANGELOG.md
+++ b/packages/pdfshift/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-pdfshift
 
+## 1.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/pdfshift/package.json
+++ b/packages/pdfshift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-pdfshift",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenFn adaptor for generating PDF documents",
   "badge": "Core",
   "type": "module",

--- a/packages/pesapal/CHANGELOG.md
+++ b/packages/pesapal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-pesapal
 
+## 1.1.6 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.1.5 - 01 September 2025
 
 ### Patch Changes

--- a/packages/pesapal/package.json
+++ b/packages/pesapal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-pesapal",
   "label": "Pesapal",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "OpenFn adaptor for Pesapal",
   "type": "module",
   "exports": {

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-postgresql
 
+## 7.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 7.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-postgresql",
   "label": "PostgreSQL",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "OpenFn adaptor for PostgreSQL",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-primero
 
+## 4.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 4.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-primero",
   "label": "Primero",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A UNICEF Primero language package for use with Open Function",
   "exports": {
     ".": {

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-progres
 
+## 2.0.4 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.0.3 - 01 September 2025
 
 ### Patch Changes

--- a/packages/progres/package.json
+++ b/packages/progres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-progres",
   "label": "ProGres",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "OpenFn adaptor for working with UNHCR's ProGres case management system",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-rapidpro
 
+## 2.0.4 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.0.3 - 01 September 2025
 
 ### Patch Changes

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-rapidpro",
   "label": "RapidPro",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "OpenFn adaptor for RapidPro",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-redis
 
+## 1.3.10 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.3.9 - 01 September 2025
 
 ### Patch Changes

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-redis",
   "label": "Redis",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "OpenFn adaptor for Redis",
   "type": "module",
   "exports": {

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-resourcemap
 
+## 0.4.21 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.4.20 - 01 September 2025
 
 ### Patch Changes

--- a/packages/resourcemap/package.json
+++ b/packages/resourcemap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-resourcemap",
   "label": "Resourcemap",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "OpenFn Resourcemap adaptor for geospatial platform operations",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-salesforce
 
+## 8.0.1 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 8.0.0 - 01 September 2025
 
 ### Major Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-salesforce",
   "label": "Salesforce",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "OpenFn adaptor for Salesforce",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-satusehat
 
+## 3.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 3.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/satusehat/package.json
+++ b/packages/satusehat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-satusehat",
   "label": "Satusehat",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "OpenFn adaptor for SATUSEHAT",
   "type": "module",
   "exports": {

--- a/packages/senaite/CHANGELOG.md
+++ b/packages/senaite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-senaite
 
+## 1.0.8 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.7 - 01 September 2025
 
 ### Patch Changes

--- a/packages/senaite/package.json
+++ b/packages/senaite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-senaite",
   "label": "Senaite",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OpenFn senaite adaptor for laboratory information management",
   "type": "module",
   "exports": {

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-sftp
 
+## 3.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 3.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-sftp",
   "label": "SFTP",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "OpenFn adaptor for SFTP",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/stripe/CHANGELOG.md
+++ b/packages/stripe/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-stripe
 
+## 1.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-stripe",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenFn adaptor for Stripe payment operations",
   "type": "module",
   "exports": {

--- a/packages/surveycto/CHANGELOG.md
+++ b/packages/surveycto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-surveycto
 
+## 2.3.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.3.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/surveycto/package.json
+++ b/packages/surveycto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-surveycto",
   "label": "SurveyCTO",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "OpenFn adaptor for SurveyCTO",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-telerivet
 
+## 0.3.19 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.3.18 - 01 September 2025
 
 ### Patch Changes

--- a/packages/telerivet/package.json
+++ b/packages/telerivet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-telerivet",
   "label": "Telerivet",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "OpenFn adaptor for Telerivet",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/twilio/CHANGELOG.md
+++ b/packages/twilio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-twilio
 
+## 1.0.3 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.2 - 01 September 2025
 
 ### Patch Changes

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-twilio",
   "label": "Twilio",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenFn adaptor for Twilio",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/varo/CHANGELOG.md
+++ b/packages/varo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-varo
 
+## 2.1.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 2.1.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/varo/package.json
+++ b/packages/varo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-varo",
   "label": "Varo",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "OpenFn varo adaptor for cold chain information",
   "type": "module",
   "exports": {

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-vtiger
 
+## 1.3.20 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.3.19 - 01 September 2025
 
 ### Patch Changes

--- a/packages/vtiger/package.json
+++ b/packages/vtiger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-vtiger",
   "label": "Vtiger",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "description": "OpenFn adaptor for Vtiger",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/whatsapp/CHANGELOG.md
+++ b/packages/whatsapp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-whatsapp
 
+## 1.0.5 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.4 - 01 September 2025
 
 ### Patch Changes

--- a/packages/whatsapp/package.json
+++ b/packages/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-whatsapp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenFn whatsapp adaptor",
   "type": "module",
   "exports": {

--- a/packages/wigal-sms/CHANGELOG.md
+++ b/packages/wigal-sms/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-wigal-sms
 
+## 0.1.13 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.1.12 - 01 September 2025
 
 ### Patch Changes

--- a/packages/wigal-sms/package.json
+++ b/packages/wigal-sms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-wigal-sms",
   "label": "Wigal SMS",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "OpenFn wigal-sms adaptor for SMS gateway operations",
   "type": "module",
   "exports": {

--- a/packages/zata/CHANGELOG.md
+++ b/packages/zata/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-zata
 
+## 1.0.2 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 1.0.1 - 01 September 2025
 
 ### Patch Changes

--- a/packages/zata/package.json
+++ b/packages/zata/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@openfn/language-zata",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An OpenFn adaptor for Zata tax compliance",
-  "badge":"Legacy",
+  "badge": "Legacy",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-zoho
 
+## 0.4.19 - 18 September 2025
+
+### Patch Changes
+
+- Updated dependencies \[e2bc436]
+  - @openfn/language-common@3.1.0
+
 ## 0.4.18 - 01 September 2025
 
 ### Patch Changes

--- a/packages/zoho/package.json
+++ b/packages/zoho/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-zoho",
   "label": "Zoho",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "OpenFn adaptor for Zoho",
   "main": "dist/index.cjs",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,7 +588,7 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@openfn/language-fhir':
-        specifier: ^5.0.8
+        specifier: ^5.0.9
         version: link:../fhir
       '@types/fhir':
         specifier: ^0.0.41


### PR DESCRIPTION
## Summary

Implement `undici Agent` in `common` instead of `Client` to allow redirects

Fixes #1307

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
