### PR TITLE
common: bump undici to `v7.15`

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -50,7 +50,7 @@
     "http-status-codes": "^2.3.0",
     "jsonpath-plus": "^10.3.0",
     "lodash": "^4.17.21",
-    "undici": "^5.29.0"
+    "undici": "^7.15.0"
   },
   "devDependencies": {
     "chai": "4.3.6",

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -6,7 +6,8 @@ import { request } from 'undici';
 import dateFns from 'date-fns';
 import _ from 'lodash';
 
-import { expandReferences, parseDate } from './util';
+import * as util  from './util/index.js';
+const { expandReferences, parseDate } = util;
 
 const schemaCache = {};
 

--- a/packages/common/src/beta.js
+++ b/packages/common/src/beta.js
@@ -1,4 +1,4 @@
-import { asData } from './Adaptor'
+import { asData } from './Adaptor.js'
 /**
  * Scopes an array of data based on a JSONPath.
  * Useful when the source data has `n` items you would like to map to

--- a/packages/common/src/http.js
+++ b/packages/common/src/http.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import { request, expandReferences } from './util';
+import * as util  from './util/index.js';
+const  { request, expandReferences } = util;
 
 const { set } = _;
 /**

--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -3,8 +3,8 @@ import { getReasonPhrase } from 'http-status-codes';
 import { Readable } from 'node:stream';
 import querystring from 'node:querystring';
 import path from 'node:path';
-import throwError from './throw-error';
-import { encode } from './base64';
+import throwError from './throw-error.js';
+import { encode } from './base64.js';
 
 const agents = new Map();
 

--- a/packages/common/src/util/index.js
+++ b/packages/common/src/util/index.js
@@ -1,7 +1,7 @@
-export * from './http';
-export * from './references';
+export * from './http.js';
+export * from './references.js';
 
-export { default as parseDate } from './parse-date';
-export { default as throwError } from './throw-error';
-export { encode, decode } from './base64';
-export { uuid } from './uuid';
+export { default as parseDate } from './parse-date.js';
+export { default as throwError } from './throw-error.js';
+export { encode, decode } from './base64.js';
+export { uuid } from './uuid.js';

--- a/packages/common/test/dateFns.test.js
+++ b/packages/common/test/dateFns.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { add } from 'date-fns';
-import * as dateFns from '../src/dateFns';
+import * as dateFns from '../src/dateFns.js'
 
 describe('date fns', () => {
   it('should parse a random given date', () => {

--- a/packages/common/test/each.test.js
+++ b/packages/common/test/each.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import testData from './fixtures/data.json' assert { type: 'json' };
-import { each } from '../src/Adaptor';
+import { each } from '../src/Adaptor.js';
 import * as beta from '../src/beta.js';
 
 function shouldBehaveLikeEach(each) {

--- a/packages/common/test/http.test.js
+++ b/packages/common/test/http.test.js
@@ -1,6 +1,6 @@
 import { expect, assert } from 'chai';
-import { request, get, post, options } from '../src/http';
-import { assertRelativeUrl, enableMockClient } from '../src/util/http';
+import { request, get, post, options } from '../src/http.js';
+import { assertRelativeUrl, enableMockClient } from '../src/util/http.js';
 
 const client = enableMockClient('https://a.com', {
   defaultContentType: 'text',

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -3,7 +3,8 @@ import path from 'node:path';
 import { assert, expect } from 'chai';
 import { request, MockAgent, setGlobalDispatcher } from 'undici';
 import testData from './fixtures/data.json' assert { type: 'json' };
-import {
+import * as Adaptor from '../src/Adaptor.js';
+const {
   arrayToString,
   chunk,
   combine,
@@ -28,13 +29,13 @@ import {
   splitKeys,
   toArray,
   validate,
-  assert as assertCommon,
+  assert:assertCommon,
   log,
   debug,
-  _ as lodash,
+  _:lodash,
   map,
   as,
-} from '../src/Adaptor';
+} = Adaptor;
 import { startOfToday } from 'date-fns';
 
 const mockAgent = new MockAgent();

--- a/packages/common/test/util/index.test.js
+++ b/packages/common/test/util/index.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { encode, decode, uuid } from '../../src/util';
+import * as util from '../../src/util/index.js';
+const { encode, decode, uuid } = util;
 
 describe('uuid', () => {
   it('should generate a uuid', () => {

--- a/packages/common/test/util/parse-date.test.js
+++ b/packages/common/test/util/parse-date.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import parseDate from '../../src/util/parse-date';
+import parseDate from '../../src/util/parse-date.js';
 import { startOfDay, subDays, subHours } from 'date-fns';
 
 // Check if two date are the same to ms resolution

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,8 +352,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       undici:
-        specifier: ^5.29.0
-        version: 5.29.0
+        specifier: ^7.15.0
+        version: 7.16.0
     devDependencies:
       chai:
         specifier: 4.3.6
@@ -15671,6 +15671,11 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.1
+
+  /undici@7.16.0:
+    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+    engines: {node: '>=20.18.1'}
+    dev: false
 
   /undici@7.8.0:
     resolution: {integrity: sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==}


### PR DESCRIPTION
## Summary

Bump `undici` version to `v7.15.0`

Fixes #1227 

## Details

Upgrade `undici` to version `7.15.0`
Upgrade `node` to use `v20.18.0`- compatible with `undici` upgrade
Update imports to include `.js` for files and destructure directory imports 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
