### PR TITLE
Export `http` in dhis2 `index.ts` file

### DIFF
--- a/.changeset/cool-bats-mate.md
+++ b/.changeset/cool-bats-mate.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-dhis2': patch
----
-
-Export `http` functions. This fixes the "http is not defined" error

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-dhis2
 
+## 8.0.3 - 23 September 2025
+
+### Patch Changes
+
+- 24c5f07: Export `http` functions. This fixes the "http is not defined" error
+
 ## 8.0.2 - 18 September 2025
 
 ### Patch Changes

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-dhis2",
   "label": "DHIS2",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "OpenFn adaptor for DHIS2",
   "homepage": "https://docs.openfn.org",
   "repository": {


### PR DESCRIPTION
## Summary

Running a dhis2  job locally which uses http functions was broken, throwing an error `[R/T] ✘ ReferenceError: http is not defined`. To fix this i added `export * as http from './http';` in `index.ts`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA: If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
