### PR TITLE
Remove path to `LOCAL_TEST.md` in formsg readme

### DIFF
--- a/packages/formsg/README.md
+++ b/packages/formsg/README.md
@@ -94,7 +94,7 @@ To build _only_ the docs run `pnpm build docs`.
 
 ### Testing Locally
 
-See [LOCAL_TEST.md](./LOCAL_TEST.md) for instructions on testing this adaptor locally with the OpenFn CLI.
+See `LOCAL_TEST.md` for instructions on testing this adaptor locally with the OpenFn CLI.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

[Docs build and deploy is failing](https://github.com/OpenFn/docs/actions/runs/18501200017) because of broken link to `LOCAL_TEST.md` file. This PR removes the link to `LOCAL_TEST.md` file. which should fix the docs build & deploy action on docs repo 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- NA: If this is a new adaptor, added the adaptor on marketing website ?
- NA: If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- NA: Are there any unit tests?
- NA: Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
