### PR TITLE
Truncate slack messages

### DIFF
--- a/tools/slack/src/index.js
+++ b/tools/slack/src/index.js
@@ -24,6 +24,12 @@ const getMessage = changes => {
     pkg => `${pkg.version.padEnd(10)} ${pkg.name}`
   );
 
+  if (versions.length > 10) {
+    const other = versions.length - 10;
+    versions.splice(9, Infinity);
+    versions.push(`... and ${other} other versions`);
+  }
+
   const attachments = [
     {
       blocks: [


### PR DESCRIPTION
When we release adaptors, we post to our internal slack with a list of all affected adaptors.

But if the list is too long, we get an error from Slack because the post length exceeds the limit.

This PR simply limits the length of published versions to 10. It's not useful to show every single version.