### PR TITLE
openHIM: Allow custom content-headers

### DIFF
--- a/.changeset/shaggy-poems-juggle.md
+++ b/.changeset/shaggy-poems-juggle.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-openhim': patch
----
-
-Allow custom content-type headers

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-bigquery
 
-## 4.0.10
+## 4.0.10 - 18 February 2026
 
 ### Patch Changes
 

--- a/packages/openelis/CHANGELOG.md
+++ b/packages/openelis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-openelis
 
-## 1.0.0
+## 1.0.0 - 18 February 2026
 
 Initial release.
 

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-openhim
 
+## 2.0.8 - 18 February 2026
+
+### Patch Changes
+
+- 0357386: Allow custom content-type headers
+
 ## 2.0.7 - 09 February 2026
 
 ### Patch Changes

--- a/packages/openhim/package.json
+++ b/packages/openhim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openhim",
   "label": "OpenHIM",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "OpenFn adaptor for OpenHIM",
   "main": "dist/index.cjs",
   "scripts": {


### PR DESCRIPTION
## Summary

Allow custom content-headers in requests.
Fix resending of options 


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
