### PR TITLE
Fix historical versions

### DIFF
--- a/packages/arcgis/CHANGELOG.md
+++ b/packages/arcgis/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.0
+## 1.0.0 - 16 October 2025
 
 ### Major Changes
 
@@ -48,6 +48,6 @@
 - Updated dependencies \[408a3a2]
   - @openfn/language-common@3.1.1
 
-## 0.0.1
+## 0.0.1 - 06 October 2025
 
 Initial release.

--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 5.0.4
+## 5.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.0.3
+## 3.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.3.21
+## 0.3.21 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Updated dependencies \[8ad6b98]
   - @openfn/language-common@3.2.2
 
-## 4.0.8
+## 4.0.8 - 26 January 2026
 
 ### Patch Changes
 
@@ -55,7 +55,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 4.0.3
+## 4.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/browserless/CHANGELOG.md
+++ b/packages/browserless/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Updated dependencies \[856f85c]
   - @openfn/language-common@3.2.3
 
-## 1.0.0
+## 1.0.0 - 24 February 2026
 
 Initial release with features:
 

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.4.22
+## 0.4.22 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/chatgpt/CHANGELOG.md
+++ b/packages/chatgpt/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 2.0.4
+## 2.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.1.5
+## 1.1.5 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/claude/CHANGELOG.md
+++ b/packages/claude/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.15
+## 1.0.15 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -57,7 +57,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.7.16
+## 0.7.16 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Updated dependencies \[8ad6b98]
   - @openfn/language-common@3.2.2
 
-## 4.0.8
+## 4.0.8 - 26 January 2026
 
 ### Patch Changes
 
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 4.0.4
+## 4.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 - Add support for gzipped payloads
 
-## 3.1.1
+## 3.1.1 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/dagu/CHANGELOG.md
+++ b/packages/dagu/CHANGELOG.md
@@ -22,6 +22,6 @@
 
 - Forwarding custom http headers to built in `getAccessToken` request
 
-## 1.0.0
+## 1.0.0 - 20 November 2025
 
 Initial release (renamed from `eapts`)

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Updated dependencies \[8ad6b98]
   - @openfn/language-common@3.2.2
 
-## 8.0.8
+## 8.0.8 - 26 January 2026
 
 ### Patch Changes
 
@@ -43,7 +43,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 8.0.4
+## 8.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/divoc/CHANGELOG.md
+++ b/packages/divoc/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.1.11
+## 0.1.11 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.5.23
+## 0.5.23 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/et-mfr/CHANGELOG.md
+++ b/packages/et-mfr/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.0
+## 1.0.0 - 29 October 2025
 
 - Implemented `get()`, `post()`, and `request()` functions that support getting
   and creating resources in `et-mfr`

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.4.21
+## 0.4.21 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/fhir-4/CHANGELOG.md
+++ b/packages/fhir-4/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-fhir-4
 
-## 0.2.10
+## 0.2.10 - 24 February 2026
 
 ### Patch Changes
 

--- a/packages/fhir-eswatini/CHANGELOG.md
+++ b/packages/fhir-eswatini/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-fhir-eswatini
 
-## 0.3.0
+## 0.3.0 - 24 February 2026
 
 ### Minor Changes
 
@@ -60,8 +60,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [213115b]
-- Updated dependencies [6ef5351]
+- Updated dependencies \[213115b]
+- Updated dependencies \[6ef5351]
   - @openfn/language-fhir-4@0.2.10
 
 ## 0.2.1 - 24 February 2026

--- a/packages/fhir-fr/CHANGELOG.md
+++ b/packages/fhir-fr/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.18
+## 1.0.18 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -42,7 +42,7 @@
   - @openfn/language-common@3.1.2
   - @openfn/language-fhir@5.0.11
 
-## 0.1.21
+## 0.1.21 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/fhir/CHANGELOG.md
+++ b/packages/fhir/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 5.0.10
+## 5.0.10 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/formsg/CHANGELOG.md
+++ b/packages/formsg/CHANGELOG.md
@@ -36,14 +36,14 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.1
+## 1.0.1 - 16 October 2025
 
 ### Patch Changes
 
 - Updated dependencies \[408a3a2]
   - @openfn/language-common@3.1.1
 
-## 1.0.0
+## 1.0.0 - 14 October 2025
 
 Initial release.
 

--- a/packages/gemini/CHANGELOG.md
+++ b/packages/gemini/CHANGELOG.md
@@ -15,6 +15,6 @@
 - Updated dependencies \[8ad6b98]
   - @openfn/language-common@3.2.2
 
-## 1.0.0
+## 1.0.0 - 27 January 2026
 
 Initial release.

--- a/packages/ghana-bdr/CHANGELOG.md
+++ b/packages/ghana-bdr/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.1.14
+## 0.1.14 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/ghana-nia/CHANGELOG.md
+++ b/packages/ghana-nia/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.1.14
+## 0.1.14 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Updated dependencies \[8ad6b98]
   - @openfn/language-common@3.2.2
 
-## 2.0.9
+## 2.0.9 - 26 January 2026
 
 ### Patch Changes
 
@@ -49,7 +49,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 2.0.4
+## 2.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/godata/CHANGELOG.md
+++ b/packages/godata/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.5.10
+## 3.5.10 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/googledrive/CHANGELOG.md
+++ b/packages/googledrive/CHANGELOG.md
@@ -40,13 +40,13 @@ list({ folderId; '21345', limit: 10 }) -> list('21345', { limit: 10 })
 - Updated dependencies \[8ad6b98]
   - @openfn/language-common@3.2.2
 
-## 2.1.0
+## 2.1.0 - 29 January 2026
 
 ### Minor Changes
 
 - 15dc2e4: add list method for listing files in a directory
 
-## 2.0.8
+## 2.0.8 - 28 January 2026
 
 ### Patch Changes
 
@@ -80,7 +80,7 @@ list({ folderId; '21345', limit: 10 }) -> list('21345', { limit: 10 })
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 2.0.3
+## 2.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/googlehealthcare/CHANGELOG.md
+++ b/packages/googlehealthcare/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.1.9
+## 1.1.9 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 4.0.3
+## 4.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.3.21
+## 0.3.21 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 7.2.3
+## 7.2.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/hubtel/CHANGELOG.md
+++ b/packages/hubtel/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.13
+## 1.0.13 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/ihris/CHANGELOG.md
+++ b/packages/ihris/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-ihris
 
-## 1.0.7
+## 1.0.7 - 24 February 2026
 
 ### Patch Changes
 
-- Updated dependencies [213115b]
-- Updated dependencies [6ef5351]
+- Updated dependencies \[213115b]
+- Updated dependencies \[6ef5351]
   - @openfn/language-fhir-4@0.2.10
 
 ## 1.0.6 - 24 February 2026

--- a/packages/inform/CHANGELOG.md
+++ b/packages/inform/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.1.6
+## 1.1.6 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/intuit/CHANGELOG.md
+++ b/packages/intuit/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.12
+## 1.0.12 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Updated dependencies \[8ad6b98]
   - @openfn/language-common@3.2.2
 
-## 0.5.26
+## 0.5.26 - 26 January 2026
 
 ### Patch Changes
 
@@ -49,7 +49,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.5.21
+## 0.5.21 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 4.2.5
+## 4.2.5 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.22
+## 1.0.22 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -35,14 +35,14 @@
 
 - Allow base64 string to be passed (and converted to buffer) for attachments
 
-## 0.5.21
+## 0.5.21 - 29 October 2025
 
 ### Patch Changes
 
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.5.20
+## 0.5.20 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.5.23
+## 0.5.23 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.5.21
+## 0.5.21 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/memento/CHANGELOG.md
+++ b/packages/memento/CHANGELOG.md
@@ -36,14 +36,14 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.1
+## 1.0.1 - 16 October 2025
 
 ### Patch Changes
 
 - Updated dependencies \[408a3a2]
   - @openfn/language-common@3.1.1
 
-## 1.0.0
+## 1.0.0 - 08 October 2025
 
 Initial release of the adaptor
 

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -42,7 +42,7 @@ v0.1.6
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.6.5
+## 0.6.5 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/mojatax/CHANGELOG.md
+++ b/packages/mojatax/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.16
+## 1.0.16 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 2.1.22
+## 2.1.22 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/motherduck/CHANGELOG.md
+++ b/packages/motherduck/CHANGELOG.md
@@ -37,6 +37,6 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.0
+## 1.0.0 - 23 October 2025
 
 Initial release.

--- a/packages/mpesa/CHANGELOG.md
+++ b/packages/mpesa/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.1.6
+## 1.1.6 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Updated dependencies \[8ad6b98]
   - @openfn/language-common@3.2.2
 
-## 0.8.9
+## 0.8.9 - 26 January 2026
 
 ### Patch Changes
 
@@ -43,7 +43,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.8.5
+## 0.8.5 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 6.0.4
+## 6.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/msupply/CHANGELOG.md
+++ b/packages/msupply/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.9
+## 1.0.9 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/mtn-momo/CHANGELOG.md
+++ b/packages/mtn-momo/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.1.5
+## 1.1.5 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - 6aa9800: Security update
 
-## 4.0.0
+## 4.0.0 - 02 December 2025
 
 ### Major Changes
 
@@ -92,7 +92,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.0.3
+## 3.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.5.24
+## 0.5.24 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.2.22
+## 1.2.22 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.0.22
+## 3.0.22 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/odoo/CHANGELOG.md
+++ b/packages/odoo/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 2.1.4
+## 2.1.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/openboxes/CHANGELOG.md
+++ b/packages/openboxes/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.10
+## 1.0.10 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/opencrvs/CHANGELOG.md
+++ b/packages/opencrvs/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-opencrvs
 
-## 1.0.17
+## 1.0.17 - 24 February 2026
 
 ### Patch Changes
 
-- Updated dependencies [213115b]
-- Updated dependencies [6ef5351]
+- Updated dependencies \[213115b]
+- Updated dependencies \[6ef5351]
   - @openfn/language-fhir-4@0.2.10
 
 ## 1.0.16 - 24 February 2026

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.0.6
+## 3.0.6 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 2.0.3
+## 2.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.0.3
+## 3.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.1.5
+## 1.1.5 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 5.3.3
+## 5.3.3 - 16 October 2025
 
 ### Patch Changes
 
@@ -94,7 +94,7 @@
 - Updated dependencies \[19f2d7e]
   - @openfn/language-common@3.0.0
 
-## 5.1.0
+## 5.1.0 - 08 July 2025
 
 ### Minor Changes
 

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.0.3
+## 3.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/pdfshift/CHANGELOG.md
+++ b/packages/pdfshift/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.4
+## 1.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/pesapal/CHANGELOG.md
+++ b/packages/pesapal/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.1.7
+## 1.1.7 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/ping/CHANGELOG.md
+++ b/packages/ping/CHANGELOG.md
@@ -14,6 +14,6 @@
 
 - 0fc470b: Update `http.post()` example. Remove `accessToken` from configuration
 
-## 1.0.0
+## 1.0.0 - 30 January 2026
 
 Implement `post` function for the PING adaptor

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -91,7 +91,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 7.0.4
+## 7.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 4.0.3
+## 4.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 2.0.5
+## 2.0.5 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 2.0.5
+## 2.0.5 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.3.11
+## 1.3.11 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.4.22
+## 0.4.22 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 9.0.0
+## 9.0.0 - 16 October 2025
 
 ### Major Changes
 

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.0.4
+## 3.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/senaite/CHANGELOG.md
+++ b/packages/senaite/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.9
+## 1.0.9 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.0.4
+## 3.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/stripe/CHANGELOG.md
+++ b/packages/stripe/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.3
+## 1.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/surveycto/CHANGELOG.md
+++ b/packages/surveycto/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Updated dependencies \[8ad6b98]
   - @openfn/language-common@3.2.2
 
-## 3.0.5
+## 3.0.5 - 26 January 2026
 
 ### Patch Changes
 
@@ -42,14 +42,14 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 3.0.1
+## 3.0.1 - 16 October 2025
 
 ### Patch Changes
 
 - Updated dependencies \[408a3a2]
   - @openfn/language-common@3.1.1
 
-## 3.0.0
+## 3.0.0 - 02 October 2025
 
 ### Major Changes
 

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.3.20
+## 0.3.20 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/twilio/CHANGELOG.md
+++ b/packages/twilio/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.4
+## 1.0.4 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/varo/CHANGELOG.md
+++ b/packages/varo/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 2.1.3
+## 2.1.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.3.21
+## 1.3.21 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/whatsapp/CHANGELOG.md
+++ b/packages/whatsapp/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.6
+## 1.0.6 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/wigal-sms/CHANGELOG.md
+++ b/packages/wigal-sms/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.1.14
+## 0.1.14 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/zata/CHANGELOG.md
+++ b/packages/zata/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 1.0.3
+## 1.0.3 - 16 October 2025
 
 ### Patch Changes
 

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updated dependencies
   - @openfn/language-common@3.1.2
 
-## 0.4.20
+## 0.4.20 - 16 October 2025
 
 ### Patch Changes
 


### PR DESCRIPTION
I noticed some release dates are wrong in the changelogs - this PR fixes them by running `pnpm -C tools/changelog update-historical-versions`