### PR TITLE
add title for `encrypt` and `trustServerCertificate`

### DIFF
--- a/.changeset/sunny-geckos-smile.md
+++ b/.changeset/sunny-geckos-smile.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-mssql': patch
----
-
-Add missiong titles in configuration-schema

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-mssql
 
+## 7.0.4 - 06 March 2026
+
+### Patch Changes
+
+- 81c1bfa: Add missiong titles in configuration-schema
+
 ## 7.0.3 - 04 March 2026
 
 ### Patch Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mssql",
   "label": "MSSQL",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

In `configuration-schema.json` of mssql adaptor both `encrypt` and `trustServerCertificate` were missing title. This PR add the title and description for `encrypt` config. This changes should fix the missing titles in mssql credential form

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
