### PR TITLE
add docs for a missing argument on keygen param

### DIFF
--- a/.changeset/dirty-doors-laugh.md
+++ b/.changeset/dirty-doors-laugh.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-collections': patch
+---
+
+Add docs for a missing argument on `keygen` param

--- a/.changeset/dirty-doors-laugh.md
+++ b/.changeset/dirty-doors-laugh.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-collections': patch
----
-
-Add docs for a missing argument on `keygen` param

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-collections
 
+## 0.8.6 - 14 April 2026
+
+### Patch Changes
+
+- 0df6720: Add docs for a missing argument on `keygen` param
+
 ## 0.8.5 - 07 April 2026
 
 ### Patch Changes

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-collections",
   "label": "Collections",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Collections Adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/collections/src/collections.js
+++ b/packages/collections/src/collections.js
@@ -86,7 +86,7 @@ export function get(name, query = {}) {
       })(scopedState);
 
       console.log(
-        `Collections: Fetched total of ${data.length} values from "${name}"`
+        `Collections: Fetched total of ${data.length} values from "${name}"`,
       );
 
       data.cursor = scopedState.data.cursor;
@@ -96,7 +96,7 @@ export function get(name, query = {}) {
       const response = await request(
         state,
         getClient(state),
-        `${resolvedName}/${key}`
+        `${resolvedName}/${key}`,
       );
 
       if (response.statusCode === 204) {
@@ -127,7 +127,7 @@ export function get(name, query = {}) {
  * @public
  * @function
  * @param {string} name - The name of the collection to fetch from
- * @param keygen - a function which generates a key for each value: (value, index) => key. Pass a string to set a static key for a single item.
+ * @param keygen - a function which generates a key for each value: (value, state, index) => key. Pass a string to set a static key for a single item.
  * @param values - an array of values to set, or a single value.
  * @example <caption>Set a number of values using each value's id property as a key</caption>
  * collections.set('my-collection', (item) => item.id, $.data)
@@ -157,7 +157,7 @@ export function set(name, keyGen, values) {
     const [resolvedName, resolvedValues] = expandReferences(
       state,
       name,
-      values
+      values,
     );
 
     let kvPairs;
@@ -194,7 +194,7 @@ export function set(name, keyGen, values) {
       const batch = kvPairs.splice(0, batchSize);
 
       console.log(
-        `Collections: uploading batch of ${batch.length} values to "${name}"...`
+        `Collections: uploading batch of ${batch.length} values to "${name}"...`,
       );
       const response = await request(state, getClient(state), resolvedName, {
         method: 'POST',
@@ -206,7 +206,7 @@ export function set(name, keyGen, values) {
 
       if (response.statusCode >= 400) {
         console.log(
-          `Collections: Error setting ${batch.length} values in "${name}"`
+          `Collections: Error setting ${batch.length} values in "${name}"`,
         );
         const text = await response.body.text();
         const e = new Error('ERROR from collections server:' + 400);
@@ -340,7 +340,7 @@ export function each(name, query = {}, callback = () => {}) {
       count += batchSize;
 
       console.log(
-        `Collections: fetched chunk of ${batchSize} values from "${name}"`
+        `Collections: fetched chunk of ${batchSize} values from "${name}"`,
       );
     } while (cursor && count < limit);
 

--- a/packages/ibipimo/CHANGELOG.md
+++ b/packages/ibipimo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-ibipimo
 
-## 1.0.5
+## 1.0.5 - 14 April 2026
 
 ### Patch Changes
 

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-primero
 
-## 4.0.12
+## 4.0.12 - 14 April 2026
 
 ### Patch Changes
 

--- a/packages/puntosolidario-rd/CHANGELOG.md
+++ b/packages/puntosolidario-rd/CHANGELOG.md
@@ -1,5 +1,5 @@
 # @openfn/language-puntosolidario-rd
 
-## 1.0.0
+## 1.0.0 - 14 April 2026
 
 Initial release of Punto Solidario adaptor with GET and POST HTTP request and authentication.

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-sftp
 
-## 3.0.12
+## 3.0.12 - 14 April 2026
 
 ### Patch Changes
 


### PR DESCRIPTION
## Summary

Add in jsdocs a missing argument (`state`) in `keygen` param for `collections.set()` function.  And code format

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
