### PR TITLE
Twilio import

### DIFF
--- a/.changeset/shy-lights-take.md
+++ b/.changeset/shy-lights-take.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-twilio': patch
----
-
-Replace `require('twilio')` with static ESM import

--- a/.changeset/shy-lights-take.md
+++ b/.changeset/shy-lights-take.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-twilio': patch
+---
+
+Replace `require('twilio')` with static ESM import

--- a/packages/twilio/CHANGELOG.md
+++ b/packages/twilio/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-twilio
 
+## 1.0.13
+
+### Patch Changes
+
+- 53d1e16: Replace `require('twilio')` with static ESM import
+
 ## 1.0.12 - 07 April 2026
 
 ### Patch Changes

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-twilio",
   "label": "Twilio",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "OpenFn adaptor for Twilio",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/twilio/src/Adaptor.js
+++ b/packages/twilio/src/Adaptor.js
@@ -1,5 +1,6 @@
 import { execute as commonExecute, composeNextState } from '@openfn/language-common';
 import { expandReferences } from '@openfn/language-common/util';
+import twilio from 'twilio';
 
 /**
  * Execute a sequence of operations.
@@ -46,7 +47,7 @@ export function sendSMS(params) {
     const [resolvedParams] = expandReferences(state, params);
     const { body, from, to } = resolvedParams;
 
-    const client = require('twilio')(accountSid, authToken);
+    const client = twilio(accountSid, authToken);
 
     return client.messages
       .create({ body, from, to })


### PR DESCRIPTION
## Summary

Fixes Twilio adaptor on production. 

Fixes #1648

## Details

Updates outdated `require('twilio')` import. I've tested this locally with the app pointing to my adaptors folder and working well.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
