### PR TITLE
Update collections adaptor to include project ID

### DIFF
--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Patch Changes
 
 - 0df6720: Add docs for a missing argument on `keygen` param
+- Add support for `project_id` on config
 
 ## 0.8.5 - 07 April 2026
 

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-collections
 
+## 0.9.0 - 20 April 2026
+
+### Minor Changes
+
+- Add support for project_id on config
+
 ## 0.8.6 - 14 April 2026
 
 ### Patch Changes

--- a/packages/collections/configuration-schema.json
+++ b/packages/collections/configuration-schema.json
@@ -23,6 +23,13 @@
       "description": "Access token for the collection",
       "writeOnly": true,
       "examples": ["x.y.z"]
+    },
+    "project_id": {
+      "title": "Project Id",
+      "type": "string",
+      "description": "The project id for the run",
+      "writeOnly": true,
+      "examples": ["46569296-9d82-4a32-8737-fbe64b7851cf"]
     }
   },
   "type": "object",

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-collections",
   "label": "Collections",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "description": "Collections Adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/collections/src/collections.js
+++ b/packages/collections/src/collections.js
@@ -481,12 +481,40 @@ export const request = async (state, client, path, options = {}) => {
 
   const response = await client.request(args);
   if (response.statusCode >= 400) {
-    await handleError(response, path, state.configuration.collections_endpoint);
+    await handleError(
+      response,
+      path,
+      state.configuration.collections_endpoint,
+      query.project_id,
+    );
   }
   return response;
 };
 
-export const handleError = async (response, path, endpoint) => {
+export const handleError = async (response, path, endpoint, project_id) => {
+  if (response.statusCode === 409) {
+    if (!project_id) {
+      const [collection] = path.split('/');
+      const e = new Error('NO_PROJECT_ID');
+
+      // 409 means a the collection name could not be resolved - probably there was no project id
+      e.code = 'NO_PROJECT_ID';
+      e.description = `The collection "${collection}" matched multiple collections on the server and project_id was omitted`;
+      e.collection = collection;
+      e.endpoint = endpoint;
+      e.fix =
+        'Set state.configuration.project_id before using the collections API';
+      throw e;
+    } else {
+      // We should never get here - if there's a project ID there should never be a conflcit
+      const e = new Error('COLLECTION_CONFLICT');
+      e.code = 'COLLECTION_CONFLICT';
+      e.description = `Multiple collections named "${collection}" were found on the server`;
+      e.collection = collection;
+      e.endpoint = endpoint;
+      e.fix = 'Contact your system administrator';
+    }
+  }
   if (response.statusCode === 404) {
     const [collection] = path.split('/');
     console.error(`Error! Collection ${collection} does not exist`);

--- a/packages/collections/src/collections.js
+++ b/packages/collections/src/collections.js
@@ -506,6 +506,7 @@ export const handleError = async (response, path, endpoint, project_id) => {
         'Set state.configuration.project_id before using the collections API';
       throw e;
     } else {
+      const [collection] = path.split('/');
       // We should never get here - if there's a project ID there should never be a conflcit
       const e = new Error('COLLECTION_CONFLICT');
       e.code = 'COLLECTION_CONFLICT';

--- a/packages/collections/src/collections.js
+++ b/packages/collections/src/collections.js
@@ -467,6 +467,10 @@ export const request = async (state, client, path, options = {}) => {
 
   const { headers: _h, query: _q, ...otherOptions } = options;
   const query = parseQuery(options);
+  if (state.configuration.project_id) {
+    query.project_id = state.configuration.project_id;
+  }
+
   const args = {
     path: nodepath.posix.join(basePath, path),
     headers,

--- a/packages/collections/src/mock.js
+++ b/packages/collections/src/mock.js
@@ -170,12 +170,12 @@ export function createServer(url = 'https://app.openfn.org') {
 
     try {
       let { name, key } = parsePath(req.path);
-
+      const projectId = req.query?.project_id ?? null;
       let body;
       let statusCode = 200;
 
       if (key) {
-        const collection = api.getCollection();
+        const collection = api.getCollection(projectId, name);
         const result = collection[key];
         if (!result) {
           body = {};
@@ -195,7 +195,7 @@ export function createServer(url = 'https://app.openfn.org') {
         const limit = params.get('limit') ?? Infinity;
         const cursor = params.get('cursor') ?? 0;
 
-        const { items, cursor: finalCursor } = api.fetch(name, key, {
+        const { items, cursor: finalCursor } = api.fetch(projectId, name, key, {
           limit,
           cursor,
         });
@@ -216,6 +216,9 @@ export function createServer(url = 'https://app.openfn.org') {
       if (e.message === COLLECTION_NOT_FOUND) {
         return { statusCode: 404 };
       }
+      if (e.message === MULTIPLE_MATCHES) {
+        return { statusCode: 409 };
+      }
     }
     return { statusCode: 500 };
   };
@@ -233,10 +236,11 @@ export function createServer(url = 'https://app.openfn.org') {
     try {
       const { name, key } = parsePath(req.path);
       const body = JSON.parse(req.body);
+      const projectId = req.query?.project_id ?? null;
 
       for (const { key, value } of body.items) {
         // TODO error if key or value not set
-        api.upsert(name, key, value);
+        api.upsert(projectId, name, key, value);
         upserted++;
       }
 
@@ -251,6 +255,9 @@ export function createServer(url = 'https://app.openfn.org') {
       if (e.message === COLLECTION_NOT_FOUND) {
         return { statusCode: 404 };
       }
+      if (e.message === MULTIPLE_MATCHES) {
+        return { statusCode: 409 };
+      }
     }
   };
 
@@ -263,12 +270,13 @@ export function createServer(url = 'https://app.openfn.org') {
 
     try {
       let { name, key } = parsePath(req.path);
+      const projectId = req.query?.project_id ?? null;
       if (!key) {
         const params = new URLSearchParams(req.query || req.path.split('?')[1]);
         key = params.get('key') ?? '*';
       }
 
-      const keys = api.remove(name, key);
+      const keys = api.remove(projectId, name, key);
 
       return {
         statusCode: 200,
@@ -280,6 +288,9 @@ export function createServer(url = 'https://app.openfn.org') {
     } catch (e) {
       if (e.message === COLLECTION_NOT_FOUND) {
         return { statusCode: 404 };
+      }
+      if (e.message === MULTIPLE_MATCHES) {
+        return { statusCode: 409 };
       }
     }
   };

--- a/packages/collections/src/mock.js
+++ b/packages/collections/src/mock.js
@@ -1,38 +1,62 @@
 import { MockAgent } from 'undici';
 
-const COLLECTION_NOT_FOUND = 'COLLECTION_NOT_FOUND';
-const INVALID_AUTH = 'INVALID_AUTH';
+export const MULTIPLE_MATCHES = 'MULTIPLE_MATCHES_FOUND';
+export const UNKNOWN_PROJECT = 'INVALID_PROJECT_ID';
+export const COLLECTION_NOT_FOUND = 'COLLECTION_NOT_FOUND';
+export const INVALID_AUTH = 'INVALID_AUTH';
 
 // This is a simple collections API backend to handle the actual logic of a collection
 // It is not designed to match lightning in any way
 export function API() {
-  let collections = {};
+  let collectionsByProject = {};
+  let collectionsByName = {};
 
-  const createCollection = (name, values = {}) => {
-    collections[name] = values;
+  // To simulate lightning, a project MUST  be created with a project id
+  const createCollection = (projectId, name, values = {}) => {
+    (collectionsByProject[projectId] ??= {})[name] = values;
+    (collectionsByName[name] ??= []).push(values);
+  };
+
+  // Find a collection by name or project id
+  const getCollection = (projectId, name) => {
+    if (projectId) {
+      if (!(projectId in collectionsByProject)) {
+        throw new Error(UNKNOWN_PROJECT);
+      }
+      if (!(name in collectionsByProject[projectId])) {
+        throw new Error(COLLECTION_NOT_FOUND);
+      }
+
+      return collectionsByProject[projectId][name];
+    } else {
+      const results = collectionsByName[name] ?? [];
+      if (results.length === 0) {
+        throw new Error(COLLECTION_NOT_FOUND);
+      }
+      if (results.length > 1) {
+        throw new Error(MULTIPLE_MATCHES);
+      }
+      return collectionsByName[name][0];
+    }
   };
 
   const reset = () => {
-    collections = api.collections = {};
+    api.collectionsByProject = collectionsByProject = {};
+    api.collectionsByName = collectionsByName = {};
   };
 
-  // This is a string store: values are expected to be strings
-  const upsert = (name, key, value) => {
-    if (!(name in collections)) {
-      throw new Error(COLLECTION_NOT_FOUND);
-    }
+  // Note that is a string store: values are expected to be strings
+  const upsert = (projectId, name, key, value) => {
+    const col = getCollection(projectId, name);
 
-    collections[name][key] = value;
+    col[key] = value;
   };
 
-  const fetch = (name, key, query = {}) => {
+  const fetch = (projectId, name, key, query = {}) => {
     const { cursor = 0, limit = Infinity } = query;
 
-    if (!(name in collections)) {
-      throw new Error(COLLECTION_NOT_FOUND);
-    }
+    const col = getCollection(projectId, name);
 
-    const col = collections[name];
     const items = [];
 
     let idx = 0;
@@ -66,33 +90,19 @@ export function API() {
     return result;
   };
 
-  // internal dev only api
-  const byKey = (name, key) => {
-    if (!(name in collections)) {
-      throw new Error(COLLECTION_NOT_FOUND);
-    }
-    return collections[name][key];
-  };
   const asJSON = (name, key) => {
-    if (!(name in collections)) {
-      throw new Error(COLLECTION_NOT_FOUND);
-    }
+    const col = getCollection(projectId, name);
     return JSON.parse(collections[name][key]);
   };
-  const count = name => {
-    if (!(name in collections)) {
-      throw new Error(COLLECTION_NOT_FOUND);
-    }
+  const count = (projectId, name) => {
+    const col = getCollection(projectId, name);
     return Object.keys(collections[name]).length;
   };
 
   // TODO strictly speaking this should support patterns
   // but keeping it super simple in the mock for now
-  const remove = (name, key) => {
-    if (!(name in collections)) {
-      throw new Error(COLLECTION_NOT_FOUND);
-    }
-    const col = collections[name];
+  const remove = (projectId, name, key) => {
+    const col = getCollection(projectId, name);
 
     const regex = new RegExp(key.replace('*', '(.*)'));
     const removed = [];
@@ -107,15 +117,16 @@ export function API() {
   };
 
   const api = {
-    collections,
+    asJSON,
+    collectionsByName,
+    collectionsByProject,
+    count,
     createCollection,
+    fetch,
+    getCollection,
+    remove,
     reset,
     upsert,
-    fetch,
-    remove,
-    byKey,
-    asJSON,
-    count,
   };
 
   return api;
@@ -164,8 +175,8 @@ export function createServer(url = 'https://app.openfn.org') {
       let statusCode = 200;
 
       if (key) {
-        // get one
-        const result = api.byKey(name, key);
+        const collection = api.getCollection();
+        const result = collection[key];
         if (!result) {
           body = {};
           statusCode = 204;

--- a/packages/collections/src/mock.js
+++ b/packages/collections/src/mock.js
@@ -213,7 +213,7 @@ export function createServer(url = 'https://app.openfn.org') {
         },
       };
     } catch (e) {
-      if (e.message === COLLECTION_NOT_FOUND) {
+      if (e.message === COLLECTION_NOT_FOUND || e.message === UNKNOWN_PROJECT) {
         return { statusCode: 404 };
       }
       if (e.message === MULTIPLE_MATCHES) {

--- a/packages/collections/src/mock.js
+++ b/packages/collections/src/mock.js
@@ -90,13 +90,13 @@ export function API() {
     return result;
   };
 
-  const asJSON = (name, key) => {
+  const asJSON = (projectId, name, key) => {
     const col = getCollection(projectId, name);
-    return JSON.parse(collections[name][key]);
+    return JSON.parse(col[key]);
   };
   const count = (projectId, name) => {
     const col = getCollection(projectId, name);
-    return Object.keys(collections[name]).length;
+    return Object.keys(col).length;
   };
 
   // TODO strictly speaking this should support patterns

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -32,6 +32,7 @@ const init = items => {
     configuration: {
       collections_token: 'x.y.z',
       collections_endpoint: 'https://app.openfn.org/collections',
+      project_id: PROJECT,
     },
   };
   return { state };
@@ -72,11 +73,12 @@ describe('each', () => {
 
     let count = 0;
 
+    const col = api.getCollection(PROJECT, COLLECTION);
     await collections.each(COLLECTION, '*', (state, value, key) => {
       count++;
       expect(state).to.eql(state);
 
-      const item = JSON.parse(api.byKey(COLLECTION, key));
+      const item = JSON.parse(col[key]);
       expect(item).not.to.be.undefined;
       expect(item).to.eql(value);
     })(state);
@@ -92,12 +94,12 @@ describe('each', () => {
     const { state } = init(items);
 
     let count = 0;
-
+    const col = api.getCollection(PROJECT, COLLECTION);
     await collections.each(COLLECTION, '*', (state, value, key) => {
       count++;
       expect(state).to.eql(state);
 
-      const item = JSON.parse(api.byKey(COLLECTION, key));
+      const item = JSON.parse(col[key]);
       expect(item).not.to.be.undefined;
       expect(item).to.eql(value);
     })(state);
@@ -462,7 +464,7 @@ describe('set', () => {
 
     await collections.set(COLLECTION, key, item)(state);
 
-    const result = api.asJSON(COLLECTION, key);
+    const result = api.asJSON(PROJECT, COLLECTION, key);
     expect(result).to.eql(item);
   });
 
@@ -474,7 +476,7 @@ describe('set', () => {
 
     await collections.set(COLLECTION, key, () => item)(state);
 
-    const result = api.asJSON(COLLECTION, key);
+    const result = api.asJSON(PROJECT, COLLECTION, key);
     expect(result).to.eql(item);
   });
 
@@ -486,7 +488,7 @@ describe('set', () => {
 
     await collections.set(COLLECTION, key, item)(state);
 
-    const result = api.asJSON(COLLECTION, key);
+    const result = api.asJSON(PROJECT, COLLECTION, key);
     expect(result).to.eql(item);
   });
 
@@ -498,7 +500,7 @@ describe('set', () => {
 
     await collections.set(COLLECTION, (_key, state) => state.key, item)(state);
 
-    const result = api.asJSON(COLLECTION, 'x');
+    const result = api.asJSON(PROJECT, COLLECTION, 'x');
     expect(result).to.eql(item);
   });
 
@@ -510,7 +512,7 @@ describe('set', () => {
 
     await collections.set(COLLECTION, key, state => item)(state);
 
-    const result = api.asJSON(COLLECTION, key);
+    const result = api.asJSON(PROJECT, COLLECTION, key);
     expect(result).to.eql(item);
   });
 
@@ -522,10 +524,10 @@ describe('set', () => {
 
     await collections.set(COLLECTION, keygen, items)(state);
 
-    const x = api.asJSON(COLLECTION, items[0].id);
+    const x = api.asJSON(PROJECT, COLLECTION, items[0].id);
     expect(x).to.eql(items[0]);
 
-    const y = api.asJSON(COLLECTION, items[1].id);
+    const y = api.asJSON(PROJECT, COLLECTION, items[1].id);
     expect(y).to.eql(items[1]);
   });
 
@@ -538,10 +540,10 @@ describe('set', () => {
 
     await collections.set(COLLECTION, keygen, items)(state);
 
-    const x = api.asJSON(COLLECTION, 'x');
+    const x = api.asJSON(PROJECT, COLLECTION, 'x');
     expect(x).to.eql([{ id: 'x' }]);
 
-    const y = api.asJSON(COLLECTION, 'y');
+    const y = api.asJSON(PROJECT, COLLECTION, 'y');
     expect(y).to.eql([{ id: 'y' }]);
   });
 
@@ -550,7 +552,7 @@ describe('set', () => {
     const { state } = init();
 
     // the collection has one item by default
-    expect(api.count(COLLECTION)).to.equal(1);
+    expect(api.count(PROJECT, COLLECTION)).to.equal(1);
 
     const items = new Array(2499).fill(1).map((_item, idx) => ({
       id: `${idx}`,
@@ -559,7 +561,7 @@ describe('set', () => {
 
     await collections.set(COLLECTION, keygen, items)(state);
 
-    expect(api.count(COLLECTION)).to.equal(2500);
+    expect(api.count(PROJECT, COLLECTION)).to.equal(2500);
   });
 });
 
@@ -591,25 +593,24 @@ describe('remove', () => {
 
   it('should remove an item', async () => {
     const { state } = init();
-    api.upsert(COLLECTION, 'x', { id: 'x' });
+    api.upsert(PROJECT, COLLECTION, 'x', { id: 'x' });
 
     await collections.remove(COLLECTION, 'x')(state);
 
-    const result = api.byKey(COLLECTION, 'x');
-    expect(result).to.be.undefined;
+    const col = api.getCollection(PROJECT, COLLECTION);
+    expect(col.x).to.be.undefined;
   });
 
   it('should remove several items', async () => {
     const { state } = init();
-    api.upsert(COLLECTION, 'x', { id: 'x' });
-    api.upsert(COLLECTION, 'y', { id: 'y' });
+    api.upsert(PROJECT, COLLECTION, 'x', { id: 'x' });
+    api.upsert(PROJECT, COLLECTION, 'y', { id: 'y' });
 
     await collections.remove(COLLECTION, '*')(state);
 
-    const x = api.byKey(COLLECTION, 'x');
-    expect(x).to.be.undefined;
-    const y = api.byKey(COLLECTION, 'y');
-    expect(y).to.be.undefined;
+    const col = api.getCollection(PROJECT, COLLECTION);
+    expect(col.x).to.be.undefined;
+    expect(col.y).to.be.undefined;
   });
 });
 

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -763,7 +763,6 @@ describe('project id', () => {
   it('should send a request even if project_id is not on the credential', async () => {
     const { state } = init();
     const response = await collections.get(COLLECTION, 'x')(state);
-    console.log(response);
     expect(response.data).to.eql({ id: 'x' });
   });
 
@@ -771,7 +770,6 @@ describe('project id', () => {
     const { state } = init();
     state.configuration.project_id = PROJECT;
     const response = await collections.get(COLLECTION, 'x')(state);
-    console.log(response);
     expect(response.data).to.eql({ id: 'x' });
   });
 

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -10,6 +10,7 @@ const { api } = client;
 setMockClient(client);
 
 const COLLECTION = 'my-collection';
+const PROJECT = 'project1';
 
 afterEach(() => {
   api.reset();
@@ -17,14 +18,14 @@ afterEach(() => {
 
 // Set up a simple collection with some defaults
 const init = items => {
-  api.createCollection(COLLECTION);
+  api.createCollection(PROJECT, COLLECTION);
 
   if (items) {
     for (const [key, value] of items) {
-      api.upsert(COLLECTION, key, JSON.stringify(value));
+      api.upsert(PROJECT, COLLECTION, key, JSON.stringify(value));
     }
   } else {
-    api.upsert(COLLECTION, 'x', JSON.stringify({ id: 'x' }));
+    api.upsert(PROJECT, COLLECTION, 'x', JSON.stringify({ id: 'x' }));
   }
 
   const state = {
@@ -156,7 +157,7 @@ describe('each', () => {
       (_state, value, key) => {
         count++;
         expect(key).to.match(/(bz1|bz2)/);
-      }
+      },
     )(state);
 
     expect(count).to.eql(2);
@@ -296,7 +297,7 @@ describe('get', () => {
     ]);
 
     const result = await collections.get(COLLECTION, { key: '*', limit: 2 })(
-      state
+      state,
     );
 
     expect(result.data.length).to.equal(2);
@@ -329,7 +330,7 @@ describe('get', () => {
     ]);
 
     const result = await collections.get(COLLECTION, { key: 'b*', limit: 1 })(
-      state
+      state,
     );
 
     expect(result.data.cursor).to.eql('2');
@@ -344,7 +345,7 @@ describe('get', () => {
 
     const result = await collections.get(
       () => COLLECTION,
-      () => 'b*'
+      () => 'b*',
     )(state);
 
     expect(result.data).to.eql([
@@ -751,5 +752,49 @@ describe('streamResponse', () => {
 
     expect(callbackValue).to.eql('str');
     expect(cursor).to.equal('b');
+  });
+});
+
+describe('project id', () => {
+  // Tests to ensure that the new adaptor includes project_id in the request, when available
+  // Not a lot to do here tbh because this is done at a very low level with not much logic
+
+  it('should send a request even if project_id is not on the credential', async () => {
+    const { state } = init();
+    const response = await collections.get(COLLECTION, 'x')(state);
+    console.log(response);
+    expect(response.data).to.eql({ id: 'x' });
+  });
+
+  it('should include project_id in a requests if it is on the credential', async () => {
+    const { state } = init();
+    state.configuration.project_id = PROJECT;
+    const response = await collections.get(COLLECTION, 'x')(state);
+    console.log(response);
+    expect(response.data).to.eql({ id: 'x' });
+  });
+
+  it('should throw if the wrong project_id is is sent', async () => {
+    const { state } = init();
+    state.configuration.project_id = 'blah';
+    try {
+      await collections.get(COLLECTION, 'x')(state);
+    } catch (e) {
+      expect(e.message).to.match(/COLLECTION_NOT_FOUND/);
+    }
+  });
+
+  it('should throw if the no project_id is send and projects conflict', async () => {
+    const { state } = init();
+
+    // create another collection with the same name in a different project
+    // This should error
+    api.createCollection('project2', COLLECTION);
+
+    try {
+      await collections.get(COLLECTION, 'x')(state);
+    } catch (e) {
+      expect(e.code).to.equal(409);
+    }
   });
 });

--- a/packages/collections/test/mock/api.test.js
+++ b/packages/collections/test/mock/api.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { API } from '../../src/mock.js';
+import { API, MULTIPLE_MATCHES } from '../../src/mock.js';
 
 describe('API', () => {
   let api;
@@ -15,79 +15,122 @@ describe('API', () => {
   it('should create an API', () => {
     expect(api).to.not.be.undefined;
 
-    expect(api.collections).to.eql({});
+    expect(api.collectionsByProject).to.eql({});
   });
 
   it('should create a collection', () => {
-    api.createCollection('a');
+    api.createCollection('p', 'c');
 
-    expect(api.collections).to.eql({ a: {} });
+    expect(api.collectionsByProject.p).to.eql({ c: {} });
+    expect(api.collectionsByName.c).to.eql([{}]);
   });
 
   it('should reset', () => {
-    api.createCollection('x');
+    api.createCollection('p', 'c');
 
-    expect(api.collections).to.eql({ x: {} });
+    expect(api.collectionsByProject).to.eql({ p: { c: {} } });
 
     api.reset();
 
-    expect(api.collections).to.eql({});
+    expect(api.collectionsByProject).to.eql({});
   });
 
   it('should create two APIs with two different collections', () => {
     const a = new API();
-    a.createCollection('a');
+    a.createCollection('p', 'a');
 
     const b = new API();
-    b.createCollection('b');
+    b.createCollection('p', 'b');
 
-    expect(a.collections.b).to.be.undefined;
-    expect(b.collections.a).to.be.undefined;
+    expect(a.collectionsByProject.p.a).to.be.ok;
+    expect(a.collectionsByProject.p.b).to.be.undefined;
+
+    expect(b.collectionsByProject.p.a).to.be.undefined;
+    expect(b.collectionsByProject.p.b).to.be.ok;
   });
 
-  it('should add to a collection', () => {
-    api.createCollection('a');
+  it('should upsert with project id and name', () => {
+    api.createCollection('p', 'a');
 
-    api.upsert('a', 'x', {});
+    api.upsert('p', 'a', 'x', {});
 
-    expect(api.collections.a).to.eql({ x: {} });
+    expect(api.collectionsByProject.p.a).to.eql({ x: {} });
+  });
+
+  it('should upsert with name only', () => {
+    api.createCollection('p', 'a');
+
+    api.upsert(null, 'a', 'x', {});
+
+    expect(api.collectionsByName.a).to.eql([{ x: {} }]);
+  });
+
+  it('should throw if upserting by name and there are multiple matches', () => {
+    api.createCollection('p1', 'a');
+    api.createCollection('p2', 'a');
+
+    expect(api.collectionsByName.a.length).to.equal(2);
+
+    try {
+      api.upsert(null, 'a', 'x', {});
+    } catch (e) {
+      expect(e.message).to.eql(MULTIPLE_MATCHES);
+    }
+
+    expect(api.collectionsByName.a[0]).to.eql({});
+    expect(api.collectionsByName.a[1]).to.eql({});
   });
 
   it("should throw if adding to add to a collection that doesn't exist", () => {
     try {
-      api.upsert('c', 'x', {});
+      api.upsert(null, 'c', 'x', {});
     } catch (e) {
       expect(e.message).to.eql('COLLECTION_NOT_FOUND');
     }
   });
 
-  it('should replace into a collection', () => {
-    api.createCollection('a');
+  it('should fetch from a collection with project id', () => {
+    api.createCollection('p', 'a');
 
-    api.upsert('a', 'x', []);
+    api.upsert('p', 'a', 'x', { id: 1 });
 
-    expect(api.collections.a).to.eql({ x: [] });
-  });
-
-  it('should fetch from a collection', () => {
-    api.createCollection('a');
-
-    api.upsert('a', 'x', { id: 1 });
-
-    const result = api.fetch('a', 'x', {});
+    const result = api.fetch('p', 'a', 'x', {});
 
     expect(result.items).to.eql([{ key: 'x', value: { id: 1 } }]);
   });
 
+  it('should fetch from a collection with name only', () => {
+    api.createCollection('p', 'a');
+
+    api.upsert('p', 'a', 'x', { id: 1 });
+
+    const result = api.fetch(null, 'a', 'x', {});
+
+    expect(result.items).to.eql([{ key: 'x', value: { id: 1 } }]);
+  });
+
+  it('should throw when fetching by name only with multiple matches', () => {
+    api.createCollection('p1', 'a');
+    api.createCollection('p2', 'a');
+
+    api.upsert('p1', 'a', 'x', { id: 1 });
+
+    try {
+      api.fetch(null, 'a', 'x', {});
+    } catch (e) {
+      expect(e.message).to.eql(MULTIPLE_MATCHES);
+    }
+  });
+
   it('should fetch from a collection with wildcard', () => {
-    api.createCollection('a');
+    api.createCollection('p', 'a');
 
-    api.upsert('a', 'x', { id: 1 });
-    api.upsert('a', 'xx', { id: 2 });
-    api.upsert('a', 'axb', { id: 3 });
-    api.upsert('a', 'yy', { id: 4 });
+    api.upsert('p', 'a', 'x', { id: 1 });
+    api.upsert('p', 'a', 'xx', { id: 2 });
+    api.upsert('p', 'a', 'axb', { id: 3 });
+    api.upsert('p', 'a', 'yy', { id: 4 });
 
-    const { items } = api.fetch('a', 'x*', {});
+    const { items } = api.fetch('p', 'a', 'x*', {});
 
     expect(items).to.eql([
       { key: 'x', value: { id: 1 } },
@@ -97,26 +140,26 @@ describe('API', () => {
   });
 
   it('should fetch with a count', () => {
-    api.createCollection('a');
+    api.createCollection('p', 'a');
 
-    api.upsert('a', 'x', { id: 1 });
-    api.upsert('a', 'xx', { id: 2 });
-    api.upsert('a', 'axb', { id: 3 });
-    api.upsert('a', 'yy', { id: 4 });
+    api.upsert('p', 'a', 'x', { id: 1 });
+    api.upsert('p', 'a', 'xx', { id: 2 });
+    api.upsert('p', 'a', 'axb', { id: 3 });
+    api.upsert('p', 'a', 'yy', { id: 4 });
 
-    const { count, cursor } = api.fetch('a', 'x*', {});
+    const { count, cursor } = api.fetch('p', 'a', 'x*', {});
 
     expect(count).to.eql(3);
     expect(cursor).to.be.undefined;
   });
 
   it('should fetch from a collection with a limit and include a cursor', () => {
-    api.createCollection('a');
+    api.createCollection('p', 'a');
 
-    api.upsert('a', 'x', { id: 1 });
-    api.upsert('a', 'xx', { id: 2 });
+    api.upsert('p', 'a', 'x', { id: 1 });
+    api.upsert('p', 'a', 'xx', { id: 2 });
 
-    const { items, count, cursor } = api.fetch('a', 'x*', { limit: 1 });
+    const { items, count, cursor } = api.fetch('p', 'a', 'x*', { limit: 1 });
 
     expect(count).to.eql(1);
     expect(items).to.eql([{ key: 'x', value: { id: 1 } }]);
@@ -124,35 +167,57 @@ describe('API', () => {
   });
 
   it('should fetch from a collection from a cursor', () => {
-    api.createCollection('a');
+    api.createCollection('p', 'a');
 
-    api.upsert('a', 'x', { id: 1 });
-    api.upsert('a', 'xx', { id: 2 });
+    api.upsert('p', 'a', 'x', { id: 1 });
+    api.upsert('p', 'a', 'xx', { id: 2 });
 
-    const { items } = api.fetch('a', 'x*', { cursor: 1 });
+    const { items } = api.fetch('p', 'a', 'x*', { cursor: 1 });
 
     expect(items).to.eql([{ key: 'xx', value: { id: 2 } }]);
   });
 
   it('should fetch from a collection with a limit and cursor', () => {
-    api.createCollection('a');
+    api.createCollection('p', 'a');
 
-    api.upsert('a', 'x', { id: 1 });
-    api.upsert('a', 'xx', { id: 2 });
-    api.upsert('a', 'xxx', { id: 3 });
+    api.upsert('p', 'a', 'x', { id: 1 });
+    api.upsert('p', 'a', 'xx', { id: 2 });
+    api.upsert('p', 'a', 'xxx', { id: 3 });
 
-    const { items } = api.fetch('a', 'x*', { cursor: 1, limit: 1 });
+    const { items } = api.fetch('p', 'a', 'x*', { cursor: 1, limit: 1 });
 
     expect(items).to.eql([{ key: 'xx', value: { id: 2 } }]);
   });
 
-  it('should remove from a collection', () => {
-    api.createCollection('a');
+  it('should remove from a collection with project id', () => {
+    api.createCollection('p', 'a');
 
-    api.upsert('a', 'x', { id: 1 });
+    api.upsert('p', 'a', 'x', { id: 1 });
 
-    api.remove('a', 'x');
+    api.remove('p', 'a', 'x');
 
-    expect(api.collections.a).to.eql({});
+    expect(api.collectionsByProject.p.a).to.eql({});
+  });
+
+  it('should remove from a collection with name only', () => {
+    api.createCollection('p', 'a');
+
+    api.upsert('p', 'a', 'x', { id: 1 });
+
+    api.remove(null, 'a', 'x');
+
+    expect(api.collectionsByProject.p.a).to.eql({});
+  });
+
+  it('should throw when removing from a collection by name only with multiple matches', () => {
+    api.createCollection('p', 'a');
+
+    api.upsert('p', 'a', 'x', { id: 1 });
+
+    try {
+      api.remove(null, 'a', 'x');
+    } catch (e) {
+      expect(e.message).to.eql(MULTIPLE_MATCHES);
+    }
   });
 });

--- a/packages/collections/test/mock/server.test.js
+++ b/packages/collections/test/mock/server.test.js
@@ -9,15 +9,27 @@ beforeEach(() => {
   ({ api, request } = createServer());
 });
 
-// TODO: support query options
-// TODO support timestamps
 describe('GET', () => {
-  it('should return 200 for a valid collection', async () => {
-    api.createCollection('my-collection');
+  it('should return 200 for a valid collection by name only', async () => {
+    api.createCollection('project1', 'my-collection');
 
     const response = await request({
       method: 'GET',
       path: 'collections/my-collection',
+    });
+    expect(response.statusCode).to.equal(200);
+  });
+
+  it('should return 200 for a valid collection with a project Id', async () => {
+    api.createCollection('project1', 'my-collection');
+    api.createCollection('project2', 'my-collection');
+
+    const response = await request({
+      method: 'GET',
+      path: 'collections/my-collection',
+      query: {
+        project_id: 'project2',
+      },
     });
     expect(response.statusCode).to.equal(200);
   });
@@ -31,7 +43,7 @@ describe('GET', () => {
   });
 
   it('should return 403 if no credential', async () => {
-    api.createCollection('my-collection');
+    api.createCollection('project1', 'my-collection');
 
     const response = await request({
       method: 'GET',
@@ -41,10 +53,21 @@ describe('GET', () => {
     expect(response.statusCode).to.equal(403);
   });
 
-  it('/collection/name/key should return a single item', async () => {
-    api.createCollection('my-collection');
+  it('should return 409 for an ambiguous request', async () => {
+    api.createCollection('project1', 'my-collection');
+    api.createCollection('project2', 'my-collection');
 
-    api.upsert('my-collection', 'x', { id: 'x' });
+    const response = await request({
+      method: 'GET',
+      path: 'collections/my-collection',
+    });
+    expect(response.statusCode).to.equal(409);
+  });
+
+  it('/collection/name/key should return a single item', async () => {
+    api.createCollection('project1', 'my-collection');
+
+    api.upsert('project1', 'my-collection', 'x', { id: 'x' });
 
     const response = await request({
       method: 'GET',
@@ -58,11 +81,11 @@ describe('GET', () => {
   });
 
   it('/collection/name should stream all results', async () => {
-    api.createCollection('my-collection');
+    api.createCollection('project1', 'my-collection');
 
-    api.upsert('my-collection', 'x', 'xx');
-    api.upsert('my-collection', 'y', 'yy');
-    api.upsert('my-collection', 'z', 'zz');
+    api.upsert('project1', 'my-collection', 'x', 'xx');
+    api.upsert('project1', 'my-collection', 'y', 'yy');
+    api.upsert('project1', 'my-collection', 'z', 'zz');
 
     const response = await request({
       method: 'GET',
@@ -80,11 +103,11 @@ describe('GET', () => {
   });
 
   it('/collection/name?key=* should stream some results', async () => {
-    api.createCollection('my-collection');
+    api.createCollection('project1', 'my-collection');
 
-    api.upsert('my-collection', 'ax', 'x');
-    api.upsert('my-collection', 'ay', 'y');
-    api.upsert('my-collection', 'az', 'z');
+    api.upsert('project1', 'my-collection', 'ax', 'x');
+    api.upsert('project1', 'my-collection', 'ay', 'y');
+    api.upsert('project1', 'my-collection', 'az', 'z');
 
     const response = await request({
       method: 'GET',
@@ -98,11 +121,11 @@ describe('GET', () => {
   });
 
   it('should limit and offset results and return a cursor', async () => {
-    api.createCollection('my-collection');
+    api.createCollection('project1', 'my-collection');
 
-    api.upsert('my-collection', 'x', 'xx');
-    api.upsert('my-collection', 'y', 'yy');
-    api.upsert('my-collection', 'z', 'zz');
+    api.upsert('project1', 'my-collection', 'x', 'xx');
+    api.upsert('project1', 'my-collection', 'y', 'yy');
+    api.upsert('project1', 'my-collection', 'z', 'zz');
 
     const response = await request({
       method: 'GET',
@@ -122,13 +145,28 @@ describe('GET', () => {
 });
 
 describe('POST', () => {
-  it('should return 200 for a valid collection', async () => {
-    api.createCollection('my-collection');
+  it('should return 200 for a valid collection with name only', async () => {
+    api.createCollection('project1', 'my-collection');
 
     const response = await request({
       method: 'POST',
       path: 'collections/my-collection',
       data: { items: [] },
+    });
+    expect(response.statusCode).to.equal(200);
+  });
+
+  it('should return 200 for a valid collection with projectId', async () => {
+    api.createCollection('project1', 'my-collection');
+    api.createCollection('project2', 'my-collection');
+
+    const response = await request({
+      method: 'POST',
+      path: 'collections/my-collection',
+      data: { items: [] },
+      query: {
+        project_id: 'project2',
+      },
     });
     expect(response.statusCode).to.equal(200);
   });
@@ -144,7 +182,7 @@ describe('POST', () => {
   });
 
   it('should return 403 if no credential', async () => {
-    api.createCollection('my-collection');
+    api.createCollection('project1', 'my-collection');
 
     const response = await request({
       method: 'POST',
@@ -154,8 +192,20 @@ describe('POST', () => {
     expect(response.statusCode).to.equal(403);
   });
 
+  it('should return 409 for for an ambiguous request', async () => {
+    api.createCollection('project1', 'my-collection');
+    api.createCollection('project2', 'my-collection');
+
+    const response = await request({
+      method: 'POST',
+      path: 'collections/my-collection',
+      data: { items: [{}] },
+    });
+    expect(response.statusCode).to.equal(409);
+  });
+
   it('should upsert a new item', async () => {
-    api.createCollection('my-collection');
+    api.createCollection('project1', 'my-collection');
 
     const item = { key: 'x', value: { id: 'x' } };
 
@@ -167,12 +217,13 @@ describe('POST', () => {
 
     expect(response.statusCode).to.equal(200);
 
-    const result = api.byKey('my-collection', item.key);
+    const collection = api.getCollection('project1', 'my-collection');
+    const result = collection[item.key];
     expect(result).to.eql(item.value);
   });
 
   it('should return a JSON summary', async () => {
-    api.createCollection('my-collection');
+    api.createCollection('project1', 'my-collection');
 
     const item = { key: 'x', value: { id: 'x' } };
 
@@ -190,12 +241,26 @@ describe('POST', () => {
 });
 
 describe('DELETE', () => {
-  it('should return 200 for a valid collection', async () => {
-    api.createCollection('my-collection');
+  it('should return 200 for a valid collection by name only', async () => {
+    api.createCollection('project1', 'my-collection');
 
     const response = await request({
       method: 'DELETE',
       path: 'collections/my-collection',
+    });
+    expect(response.statusCode).to.equal(200);
+  });
+
+  it('should return 200 for a valid collection with a project id', async () => {
+    api.createCollection('project1', 'my-collection');
+    api.createCollection('project2', 'my-collection');
+
+    const response = await request({
+      method: 'DELETE',
+      path: 'collections/my-collection',
+      query: {
+        project_id: 'project1',
+      },
     });
     expect(response.statusCode).to.equal(200);
   });
@@ -210,7 +275,7 @@ describe('DELETE', () => {
   });
 
   it('should return 403 if no credential', async () => {
-    api.createCollection('my-collection');
+    api.createCollection('project1', 'my-collection');
 
     const response = await request({
       method: 'DELETE',
@@ -220,9 +285,20 @@ describe('DELETE', () => {
     expect(response.statusCode).to.equal(403);
   });
 
+  it('should return 409 for an ambiguous request', async () => {
+    api.createCollection('project1', 'my-collection');
+    api.createCollection('project2', 'my-collection');
+
+    const response = await request({
+      method: 'DELETE',
+      path: 'collections/my-collection',
+    });
+    expect(response.statusCode).to.equal(409);
+  });
+
   it('should remove an item', async () => {
-    api.createCollection('my-collection');
-    api.upsert('my-collection', 'x', { id: 'x' });
+    api.createCollection('project1', 'my-collection');
+    api.upsert('project1', 'my-collection', 'x', { id: 'x' });
 
     const response = await request({
       method: 'DELETE',
@@ -231,14 +307,14 @@ describe('DELETE', () => {
 
     expect(response.statusCode).to.equal(200);
 
-    const result = api.byKey('my-collection', 'x');
-    expect(result).to.be.undefined;
+    const collection = api.getCollection('project1', 'my-collection');
+    expect(collection.x).to.be.undefined;
   });
 
   it('should remove items by pattern', async () => {
-    api.createCollection('my-collection');
-    api.upsert('my-collection', 'x', { id: 'x' });
-    api.upsert('my-collection', 'y', { id: 'y' });
+    api.createCollection('project1', 'my-collection');
+    api.upsert('project1', 'my-collection', 'x', { id: 'x' });
+    api.upsert('project1', 'my-collection', 'y', { id: 'y' });
 
     const response = await request({
       method: 'DELETE',
@@ -250,15 +326,14 @@ describe('DELETE', () => {
 
     expect(response.statusCode).to.equal(200);
 
-    const x = api.byKey('my-collection', 'x');
-    expect(x).to.be.undefined;
-    const y = api.byKey('my-collection', 'y');
-    expect(y).to.be.undefined;
+    const collection = api.getCollection('project1', 'my-collection');
+    expect(collection.x).to.be.undefined;
+    expect(collection.y).to.be.undefined;
   });
 
   it('should return a JSON summary', async () => {
-    api.createCollection('my-collection');
-    api.upsert('my-collection', 'x', { id: 'x' });
+    api.createCollection('project1', 'my-collection');
+    api.upsert('project1', 'my-collection', 'x', { id: 'x' });
 
     const response = await request({
       method: 'DELETE',


### PR DESCRIPTION
## Summary

Changes to how Lightning handles collections requires the collections adaptor to include `project_id` in the request.

Very simply PR actually - most of the logic is in an update in the mock to ensure unit tests are consistent with the new design. But the actual adaptor changes very little.

This requires a change in the worker to send `project_id` on the credential. But if it doesn't, nothing breaks.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
