### PR TITLE
Msupply: use randomUUID()

### DIFF
--- a/.changeset/wild-ravens-train.md
+++ b/.changeset/wild-ravens-train.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-msupply': patch
----
-
-Remove uuid package dependency in favour of native node.js solution

--- a/.changeset/wild-ravens-train.md
+++ b/.changeset/wild-ravens-train.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-msupply': patch
+---
+
+Remove uuid package dependency in favour of native node.js solution

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- Add support for project_id on config
+- Add support for project\_id on config
 
 ## 0.8.6 - 14 April 2026
 

--- a/packages/msupply/CHANGELOG.md
+++ b/packages/msupply/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-msupply
 
-## 1.0.17 - 23 April 2026
+## 1.0.17 - 14 May 2026
 
 ### Patch Changes
 

--- a/packages/msupply/CHANGELOG.md
+++ b/packages/msupply/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-msupply
 
+## 1.0.17 - 23 April 2026
+
+### Patch Changes
+
+- 427da5c: Remove uuid package dependency in favour of native node.js solution
+
 ## 1.0.16 - 07 April 2026
 
 ### Patch Changes

--- a/packages/msupply/package.json
+++ b/packages/msupply/package.json
@@ -29,8 +29,7 @@
     "configuration-schema.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "workspace:*",
-    "uuid": "^11.1.0"
+    "@openfn/language-common": "workspace:*"
   },
   "devDependencies": {
     "assertion-error": "2.0.0",

--- a/packages/msupply/package.json
+++ b/packages/msupply/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-msupply",
   "label": "mSupply",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "OpenFn adaptor for mSupply",
   "type": "module",
   "exports": {

--- a/packages/msupply/src/Adaptor.js
+++ b/packages/msupply/src/Adaptor.js
@@ -1,7 +1,11 @@
+import crypto from 'node:crypto';
 import { expandReferences } from '@openfn/language-common/util';
 import * as util from './Utils.js';
-import { getItemsQueryString, insertOutboundShipmentQuery, upsertOutboundShipmentQuery } from './queries.js'
-import { v4 as uuidv4 } from 'uuid';
+import {
+  getItemsQueryString,
+  insertOutboundShipmentQuery,
+  upsertOutboundShipmentQuery,
+} from './queries.js';
 
 /**
  * State object
@@ -11,7 +15,6 @@ import { v4 as uuidv4 } from 'uuid';
  * @property references - an array of all previous data objects used in the Job
  * @private
  **/
-
 
 /**
  * @typedef {Object} RequestBody
@@ -25,7 +28,6 @@ import { v4 as uuidv4 } from 'uuid';
  * @property {string} storeId - The msupply store id  the list is being fetched from
  */
 
-
 /**
  * @typedef {Object} InsertOutboundShipmentvariables
  * @property {string} otherPartyId - The recieving party id
@@ -37,7 +39,6 @@ import { v4 as uuidv4 } from 'uuid';
  * @property {Object} input - The payload for the target shipment
  * @property {string} storeId - The id of the store the shipment is being made from
  */
-
 
 /**
  * Get the list of items in the catalogue
@@ -59,14 +60,13 @@ export function getItemsWithStats(variables) {
     let opts = {
       body: {
         query: getItemsQueryString,
-        variables: resolvedVariables
+        variables: resolvedVariables,
       },
-    }
+    };
     const response = await util.request(state, opts);
-    return util.prepareNextState(state, response)
-  }
+    return util.prepareNextState(state, response);
+  };
 }
-
 
 /**
  * Create an outbound shipment.
@@ -89,14 +89,14 @@ export function insertOutboundShipment(variables) {
       body: {
         query: insertOutboundShipmentQuery,
         variables: {
-          id: uuidv4(),
-          ...resolvedVariables
-        }
+          id: crypto.randomUUID(),
+          ...resolvedVariables,
+        },
       },
-    }
+    };
     const response = await util.request(state, opts);
-    return util.prepareNextState(state, response)
-  }
+    return util.prepareNextState(state, response);
+  };
 }
 
 /**
@@ -126,15 +126,14 @@ export function upsertOutboundShipment(variables) {
     let opts = {
       body: {
         query: upsertOutboundShipmentQuery,
-        variables: resolvedVariables
+        variables: resolvedVariables,
       },
-    }
+    };
 
     const response = await util.request(state, opts);
-    return util.prepareNextState(state, response)
-  }
+    return util.prepareNextState(state, response);
+  };
 }
-
 
 /**
  * Make a generic GraphQL request
@@ -153,17 +152,18 @@ export function upsertOutboundShipment(variables) {
  */
 export function query(query, variables = {}) {
   return async state => {
-    const [resolvedQuery, resolvedVariables] = expandReferences(state, query, variables);
-
-    const response = await util.request(
+    const [resolvedQuery, resolvedVariables] = expandReferences(
       state,
-      {
-        body: {
-          query: resolvedQuery,
-          variables: resolvedVariables,
-        },
-      }
+      query,
+      variables,
     );
+
+    const response = await util.request(state, {
+      body: {
+        query: resolvedQuery,
+        variables: resolvedVariables,
+      },
+    });
 
     return util.prepareNextState(state, response);
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1808,9 +1808,6 @@ importers:
       '@openfn/language-common':
         specifier: workspace:*
         version: link:../common
-      uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
     devDependencies:
       assertion-error:
         specifier: 2.0.0
@@ -11709,10 +11706,6 @@ packages:
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
 
   uuid@2.0.3:
     resolution: {integrity: sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==}
@@ -22318,8 +22311,6 @@ snapshots:
       is-generator-function: 1.1.2
       is-typed-array: 1.1.15
       which-typed-array: 1.1.19
-
-  uuid@11.1.0: {}
 
   uuid@2.0.3: {}
 


### PR DESCRIPTION
## Summary

Raised in response to a security alert although I don't think this really helps.

Anyway, msupply was needlessly using the `uuid` package which has security advisories attached.

This PR uses native `crypto.randomUUID()` instead


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
