### PR TITLE
minio: Make `port` optional

### DIFF
--- a/.changeset/some-buses-count.md
+++ b/.changeset/some-buses-count.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-minio': patch
----
-
-Make `port` configuration optional

--- a/.changeset/some-buses-count.md
+++ b/.changeset/some-buses-count.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-minio': patch
+---
+
+Make `port` configuration optional

--- a/packages/minio/CHANGELOG.md
+++ b/packages/minio/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-minio
 
+## 1.0.1
+
+### Patch Changes
+
+- 7672894: Make `port` configuration optional
+
 ## 1.0.0
 
-Implemented MinIO adaptor operations for object upload, retrieval, listing, and tag management (`putObject`, `getObject`, `listObjects`, `setObjectTags`, and `getObjectTags`)
+Implemented MinIO adaptor operations for object upload, retrieval, listing, and
+tag management (`putObject`, `getObject`, `listObjects`, `setObjectTags`, and
+`getObjectTags`)

--- a/packages/minio/configuration-schema.json
+++ b/packages/minio/configuration-schema.json
@@ -10,13 +10,13 @@
     "port": {
       "title": "Port",
       "type": "integer",
-      "description": "Port number",
+      "description": "MinIO port number",
       "examples": [9000]
     },
     "useSSL": {
       "title": "Use SSL",
       "type": "boolean",
-      "description": "Whether to use SSL",
+      "description": "Whether to use SSL in MinIO connection",
       "default":true,
       "examples": [true]
     },

--- a/packages/minio/configuration-schema.json
+++ b/packages/minio/configuration-schema.json
@@ -9,7 +9,7 @@
     },
     "port": {
       "title": "Port",
-      "type": "number",
+      "type": "integer",
       "description": "Port number",
       "examples": [9000]
     },

--- a/packages/minio/configuration-schema.json
+++ b/packages/minio/configuration-schema.json
@@ -37,5 +37,5 @@
   },
   "type": "object",
   "additionalProperties": true,
-  "required": ["endPoint", "port", "accessKey", "secretKey"]
+  "required": ["endPoint", "accessKey", "secretKey"]
 }

--- a/packages/minio/package.json
+++ b/packages/minio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-minio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenFn minio adaptor",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Make `port` configuration optional
Change `port` data type to integer and updated its description
Updated `useSSL`  description

Fixes #

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
