### PR TITLE
Fix browserless baseUrl credential schema

### DIFF
--- a/.changeset/fix-browserless-baseurl-nullable.md
+++ b/.changeset/fix-browserless-baseurl-nullable.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-browserless': patch
+---
+
+Fix `baseUrl` in the credential configuration schema. The field is required and has `minLength: 1`, so the previously declared `["string", "null"]` type was contradictory and also crashed the OpenFn credential form on render.

--- a/.changeset/fix-browserless-baseurl-nullable.md
+++ b/.changeset/fix-browserless-baseurl-nullable.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-browserless': patch
----
-
-Fix `baseUrl` in the credential configuration schema. The field is required and has `minLength: 1`, so the previously declared `["string", "null"]` type was contradictory and also crashed the OpenFn credential form on render.

--- a/packages/browserless/CHANGELOG.md
+++ b/packages/browserless/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-browserless
 
+## 1.0.4 - 29 April 2026
+
+### Patch Changes
+
+- 4e5efe2: Make baseUrl a plain string in the credential configuration schema.
+
 ## 1.0.3 - 07 April 2026
 
 ### Patch Changes

--- a/packages/browserless/configuration-schema.json
+++ b/packages/browserless/configuration-schema.json
@@ -3,7 +3,7 @@
   "properties": {
     "baseUrl": {
       "title": "Base URL",
-      "type":["string", "null"],
+      "type": "string",
       "description": "The Browserless base URL (e.g. https://production-sfo.browserless.io)",
       "format": "uri",
       "minLength": 1,

--- a/packages/browserless/package.json
+++ b/packages/browserless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-browserless",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "OpenFn browserless adaptor",
   "type": "module",
   "exports": {

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- Add support for project_id on config
+- Add support for project\_id on config
 
 ## 0.8.6 - 14 April 2026
 

--- a/packages/minio/CHANGELOG.md
+++ b/packages/minio/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Move `minio` SDK from `devDependency` to `dependency` in `package.json`
 
-## 1.0.1
+## 1.0.1 - 29 April 2026
 
 ### Patch Changes
 


### PR DESCRIPTION
## Summary

Make `baseUrl` a plain `string` in the Browserless credential configuration schema. The current `["string", "null"]` declaration is contradictory (the field is in `required` with `minLength: 1`) and was crashing the OpenFn credential form on render.

Refs OpenFn/lightning#4647

## Details

`packages/browserless/configuration-schema.json` declared:

```json
"baseUrl": {
  "type": ["string", "null"],
  "minLength": 1,
  ...
}
```

paired with `"required": ["baseUrl", "token"]`. The `null` member can never be valid given the other constraints, so it was an authoring oversight. Drop it back to `"type": "string"` and add a `patch` changeset for `@openfn/language-browserless`.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?