### PR TITLE
minio: move minio sdk import to `dependencies`

### DIFF
--- a/packages/minio/CHANGELOG.md
+++ b/packages/minio/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-minio
 
+## 1.0.2
+
+### Patch Changes
+
+- Move `minio` SDK from `devDependency` to `dependency` in `package.json`
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/minio/package.json
+++ b/packages/minio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-minio",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenFn minio adaptor",
   "type": "module",
   "exports": {

--- a/packages/minio/package.json
+++ b/packages/minio/package.json
@@ -29,13 +29,13 @@
   ],
   "dependencies": {
     "@openfn/language-common": "workspace:*",
-    "csv-stringify": "^6.7.0"
+    "csv-stringify": "^6.7.0",
+    "minio": "^8.0.7"
   },
   "devDependencies": {
     "assertion-error": "2.0.0",
     "chai": "4.3.6",
     "deep-eql": "4.1.1",
-    "minio": "^8.0.7",
     "mocha": "^10.7.3",
     "rimraf": "3.0.2",
     "undici": "^7.19.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1590,6 +1590,9 @@ importers:
       csv-stringify:
         specifier: ^6.7.0
         version: 6.7.0
+      minio:
+        specifier: ^8.0.7
+        version: 8.0.7
     devDependencies:
       assertion-error:
         specifier: 2.0.0
@@ -1600,9 +1603,6 @@ importers:
       deep-eql:
         specifier: 4.1.1
         version: 4.1.1
-      minio:
-        specifier: ^8.0.7
-        version: 8.0.7
       mocha:
         specifier: ^10.7.3
         version: 10.8.2


### PR DESCRIPTION
## Summary

Move minio sdk import to `dependencies` in `package.json`

Fixes #

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
