### PR TITLE
Add promise support in the `combine` function

### DIFF
--- a/.changeset/good-planets-pull.md
+++ b/.changeset/good-planets-pull.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-common': patch
----
-
-Add promise support in `combine()`

--- a/.changeset/good-planets-pull.md
+++ b/.changeset/good-planets-pull.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-common': patch
+---
+
+add promise support in the `combine` function

--- a/.changeset/good-planets-pull.md
+++ b/.changeset/good-planets-pull.md
@@ -2,4 +2,4 @@
 '@openfn/language-common': patch
 ---
 
-add promise support in the `combine` function
+Add promise support in `combine()`

--- a/packages/arcgis/CHANGELOG.md
+++ b/packages/arcgis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-arcgis
 
+## 1.0.8
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.7 - 07 April 2026
 
 ### Patch Changes

--- a/packages/arcgis/package.json
+++ b/packages/arcgis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-arcgis",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OpenFn arcgis adaptor",
   "type": "module",
   "exports": {

--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-asana
 
+## 5.0.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 5.0.12 - 07 April 2026
 
 ### Patch Changes

--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-asana",
-  "version": "5.0.12",
+  "version": "5.0.13",
   "label": "Asana",
   "description": "OpenFn adaptor for accessing objects in Asana",
   "homepage": "https://docs.openfn.org",

--- a/packages/aws-s3/CHANGELOG.md
+++ b/packages/aws-s3/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-aws-s3
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.2 - 07 April 2026
 
 ### Patch Changes

--- a/packages/aws-s3/package.json
+++ b/packages/aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-aws-s3",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenFn aws-s3 adaptor",
   "type": "module",
   "exports": {

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-azure-storage
 
+## 3.0.11
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.0.10 - 07 April 2026
 
 ### Patch Changes

--- a/packages/azure-storage/package.json
+++ b/packages/azure-storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-azure-storage",
   "label": "Azure Storage",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "OpenFn adaptor for Azure Storage",
   "type": "module",
   "exports": {

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-beyonic
 
+## 0.3.30
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.3.29 - 07 April 2026
 
 ### Patch Changes

--- a/packages/beyonic/package.json
+++ b/packages/beyonic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-beyonic",
   "label": "Beyonic",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "OpenFn adaptor for Beyonic",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-bigquery
 
+## 4.0.15
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 4.0.14 - 07 April 2026
 
 ### Patch Changes

--- a/packages/bigquery/package.json
+++ b/packages/bigquery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-bigquery",
   "label": "BigQuery",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "description": "A Google BigQuery language package for use with Open Function",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/browserless/CHANGELOG.md
+++ b/packages/browserless/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-browserless
 
+## 1.0.5
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.4 - 29 April 2026
 
 ### Patch Changes

--- a/packages/browserless/package.json
+++ b/packages/browserless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-browserless",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenFn browserless adaptor",
   "type": "module",
   "exports": {

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cartodb
 
+## 0.4.31
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.4.30 - 07 April 2026
 
 ### Patch Changes

--- a/packages/cartodb/package.json
+++ b/packages/cartodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-cartodb",
   "label": "CartoDB",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "description": "cartodb Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/chatgpt/CHANGELOG.md
+++ b/packages/chatgpt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-chatgpt
 
+## 2.0.12
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 2.0.11 - 07 April 2026
 
 ### Patch Changes

--- a/packages/chatgpt/package.json
+++ b/packages/chatgpt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-chatgpt",
   "label": "ChatGPT",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "OpenFn adaptor for ChatGPT",
   "type": "module",
   "exports": {

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-cht
 
+## 1.1.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.1.12 - 07 April 2026
 
 ### Patch Changes

--- a/packages/cht/package.json
+++ b/packages/cht/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-cht",
   "label": "Community Health Toolkit (CHT)",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "OpenFn adaptor for Community Health Toolkit (CHT)",
   "type": "module",
   "exports": {

--- a/packages/claude/CHANGELOG.md
+++ b/packages/claude/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-claude
 
+## 1.0.24
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.23 - 07 April 2026
 
 ### Patch Changes

--- a/packages/claude/package.json
+++ b/packages/claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-claude",
   "label": "Claude",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "OpenFn adaptor for Claude",
   "type": "module",
   "exports": {

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,10 +1,17 @@
 # @openfn/language-collections
 
+## 0.9.1
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.9.0 - 20 April 2026
 
 ### Minor Changes
 
-- Add support for project\_id on config
+- Add support for project_id on config
 
 ## 0.8.6 - 14 April 2026
 

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-collections",
   "label": "Collections",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Collections Adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-commcare
 
+## 4.0.14
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 4.0.13 - 07 April 2026
 
 ### Patch Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-commcare",
   "label": "CommCare",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "description": "OpenFn adaptor for CommCare (Dimagi)",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 3.0.1 - 11 July 2025
 
+## 3.3.2
+
+### Patch Changes
+
+- 9d1e1ae: Add promise support in `combine()`
+
 ## 3.3.1 - 07 April 2026
 
 ### Patch Changes
@@ -384,7 +390,7 @@ content type to JSON.
 ### Minor Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access\_token" keys can be used for OAuth2-reliant adaptors
+  "access_token" keys can be used for OAuth2-reliant adaptors
 
 ## 1.9.0 - 23 June 2023
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-common",
   "label": "Common",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Common Expressions for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -352,11 +352,9 @@ export function combine(...operations) {
   return state => {
     return operations.reduce((state, operation) => {
       if (state.then) {
-        return state.then(state => {
-          return { ...state, ...operation(state) };
-        });
+        return state.then(operation);
       } else {
-        return { ...state, ...operation(state) };
+        return operation(state);
       }
     }, state);
   };
@@ -459,10 +457,10 @@ export function group(arrayOfObjects, keyPath, callback = s => s) {
     const [resolvedArray, resolvedKeyPath] = expandReferences(
       state,
       arrayOfObjects,
-      keyPath
+      keyPath,
     );
     const results = _.groupBy(resolvedArray, item =>
-      _.get(item, resolvedKeyPath)
+      _.get(item, resolvedKeyPath),
     );
     return callback({ ...state, data: _.omit(results, [undefined]) });
   };
@@ -576,7 +574,7 @@ export function splitKeys(obj, keys) {
 
       return [{ ...keep, [key]: value }, split];
     },
-    [{}, {}]
+    [{}, {}],
   );
 }
 
@@ -597,7 +595,7 @@ export function scrubEmojis(text, replacementChars) {
     console.warn(
       'Removing characters from a string may create injection vulnerabilities;',
       "It's better to replace than remove.",
-      'See https://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters'
+      'See https://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters',
     );
   }
 
@@ -678,13 +676,13 @@ export function parseCsv(csvData, parsingOptions = {}, callback) {
     const [resolvedCsvData, resolvedParsingOptions] = expandReferences(
       state,
       csvData,
-      parsingOptions
+      parsingOptions,
     );
 
     const filteredOptions = Object.fromEntries(
       Object.entries(resolvedParsingOptions).filter(
-        ([key]) => key in defaultOptions
-      )
+        ([key]) => key in defaultOptions,
+      ),
     );
 
     const options = { ...defaultOptions, ...filteredOptions };
@@ -861,7 +859,7 @@ export function cursor(value, options = {}) {
     const [resolvedValue, resolvedOptions] = expandReferences(
       state,
       value,
-      optionsWithoutFormat
+      optionsWithoutFormat,
     );
 
     const {
@@ -917,13 +915,13 @@ export function assert(expression, errorMessage) {
     const [resolvedValue, resolvedErrorMessage] = expandReferences(
       state,
       expression,
-      errorMessage
+      errorMessage,
     );
 
     if (!resolvedValue) {
       throw new Error(
         resolvedErrorMessage ||
-          `assertion statement failed with ${resolvedValue}`
+          `assertion statement failed with ${resolvedValue}`,
       );
     }
 

--- a/packages/common/src/Adaptor.js
+++ b/packages/common/src/Adaptor.js
@@ -352,9 +352,9 @@ export function combine(...operations) {
   return state => {
     return operations.reduce((state, operation) => {
       if (state.then) {
-        return state.then(operation);
+        return state.then(state => operation({ ...state }));
       } else {
-        return operation(state);
+        return operation({ ...state });
       }
     }, state);
   };

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -35,7 +35,7 @@ import {
   map,
   as,
 } from '../src/Adaptor.js';
-import { startOfToday,format } from 'date-fns';
+import { startOfToday, format } from 'date-fns';
 
 const mockAgent = new MockAgent();
 setGlobalDispatcher(mockAgent);
@@ -165,7 +165,7 @@ describe('map', () => {
         return {
           id: state.baseId + index,
         };
-      }
+      },
     )(state);
     expect(results.data).to.eql([
       { id: 'book-0' },
@@ -185,7 +185,7 @@ describe('map', () => {
           id: state.baseId + index,
           label: data.title,
         };
-      }
+      },
     )(state);
     expect(results.data).to.eql([
       { id: 'book-0', label: 'Sayings of the Century' },
@@ -216,7 +216,25 @@ describe('combine', () => {
   ];
 
   it('accepts serveral operations, and reduces them with the state', () => {
-    let result = combine.apply(null, operations)(state);
+    let result = combine(...operations)(state);
+    expect(result).to.eql({ hello: 6 });
+  });
+
+  it('chains operations where the first returns a promise', async () => {
+    let state = {};
+    let result = await combine(
+      state => Promise.resolve({ hello: 1 }),
+      state => ({ hello: state.hello + 5 }),
+    )(state);
+    expect(result).to.eql({ hello: 6 });
+  });
+
+  it('chains operations where all return promises', async () => {
+    let state = {};
+    let result = await combine(
+      state => Promise.resolve({ hello: 1 }),
+      state => Promise.resolve({ hello: state.hello + 5 }),
+    )(state);
     expect(result).to.eql({ hello: 6 });
   });
 });
@@ -226,7 +244,7 @@ describe('join', () => {
     let result = join(
       '$.store.book[*]',
       '$.store.bicycle.color',
-      'color'
+      'color',
     )(testData);
 
     expect(result[0]).to.eql({
@@ -257,8 +275,8 @@ describe('merge', () => {
       '$.store.book[*]',
       fields(
         field('color', sourceValue('$.store.bicycle.color')),
-        field('price', sourceValue('$.store.bicycle.price'))
-      )
+        field('price', sourceValue('$.store.bicycle.price')),
+      ),
     )(testData);
 
     expect(result[0].color).to.eql('red');
@@ -300,7 +318,7 @@ describe('Path Helpers', () => {
       expect(
         lastReferenceValue('foo')({
           references: [{ foo: 'bar' }, { baz: 'foo' }],
-        })
+        }),
       ).to.eql('bar');
     });
   });
@@ -314,7 +332,7 @@ describe('index', function () {
 
     let results = each(
       '$.data.store.book[*]',
-      operation
+      operation,
     )({
       references: [],
       data: testData,
@@ -448,7 +466,7 @@ describe('parseCsv', function () {
 
     assert.equal(
       error.message,
-      'Invalid Record Length: columns length is 3, got 4 on line 2'
+      'Invalid Record Length: columns length is 3, got 4 on line 2',
     );
   });
 
@@ -462,7 +480,7 @@ describe('parseCsv', function () {
       (state, rows) => {
         const { items } = state;
         return { ...state, data: rows, items: [...items, ...rows] };
-      }
+      },
     )(state);
 
     // Notice how the user has decided to discard all but the final chunk
@@ -495,7 +513,7 @@ describe('parseCsv', function () {
             });
           }, 1);
         });
-      }
+      },
     )(state);
 
     assert.deepEqual(resultingState, {
@@ -515,7 +533,7 @@ describe('parseCsv', function () {
           ...state,
           data: rows.reduce((sum, row) => sum + Number(row.b), state.data),
         };
-      }
+      },
     )(state);
 
     assert.deepEqual(resultingState, {
@@ -575,7 +593,7 @@ describe('parseCsv', function () {
     const state = { data: { something: 'came before' }, references: [] };
 
     const resultingStateWithChunk = await parseCsv(csv, { chunkSize: 2 })(
-      state
+      state,
     );
 
     assert.deepEqual(resultingStateWithChunk, {
@@ -596,7 +614,7 @@ describe('parseCsv', function () {
     let callCount = 0;
 
     const stream = fs.createReadStream(
-      path.resolve('./test/fixtures/data.csv')
+      path.resolve('./test/fixtures/data.csv'),
     );
 
     await parseCsv(stream, { chunkSize: 1 }, (state, chunk) => {
@@ -747,7 +765,7 @@ describe('validate', () => {
 
     const result = await validate(
       () => schema,
-      () => data
+      () => data,
     )(state);
     expect(result.validationErrors).to.have.lengthOf(1);
   });
@@ -1018,23 +1036,22 @@ describe('cursor', () => {
     const state = {};
     let originalLog;
     let consoleOutput = [];
-    
+
     originalLog = console.log;
     console.log = (...args) => consoleOutput.push(args.join(' '));
 
     const testDate = new Date();
     cursor('now')(state);
-  
-    
+
     const logOutput = consoleOutput[0];
     const timeMatch = logOutput.match(/(\d{2}):(\d{2})/);
-    
+
     expect(timeMatch).to.not.be.null;
     const displayedMinutes = parseInt(timeMatch[2]);
     const actualMinutes = testDate.getMinutes();
-  
+
     expect(displayedMinutes).to.equal(actualMinutes);
-    
+
     console.log = originalLog;
   });
 
@@ -1205,7 +1222,7 @@ describe('log', () => {
     log(
       'test',
       state => state.x,
-      state => `test ${state.y.z}`
+      state => `test ${state.y.z}`,
     )(input);
     expect(consoleOutput[0]).to.eq('test');
     expect(consoleOutput[1]).to.eq('a');
@@ -1253,7 +1270,7 @@ describe('debug', () => {
     debug(
       'test',
       state => state.x,
-      state => `test ${state.y.z}`
+      state => `test ${state.y.z}`,
     )(input);
 
     expect(consoleOutput[0]).to.eq('test');
@@ -1326,7 +1343,7 @@ describe('as', () => {
       state => state.key,
       state => {
         return { ...state, data: testData, responses: { status: 200 } };
-      }
+      },
     )(state);
     expect(results.comments).to.eql(testData);
   });

--- a/packages/common/test/index.test.js
+++ b/packages/common/test/index.test.js
@@ -215,7 +215,7 @@ describe('combine', () => {
     },
   ];
 
-  it('accepts serveral operations, and reduces them with the state', () => {
+  it('accepts several operations, and reduces them with the state', () => {
     let result = combine(...operations)(state);
     expect(result).to.eql({ hello: 6 });
   });
@@ -224,6 +224,16 @@ describe('combine', () => {
     let state = {};
     let result = await combine(
       state => Promise.resolve({ hello: 1 }),
+      state => ({ hello: state.hello + 5 }),
+    )(state);
+    expect(result).to.eql({ hello: 6 });
+  });
+
+  it('chains operations where the first returns an unresolved promise', async () => {
+    let state = {};
+
+    let result = await combine(
+      state => new Promise(r => setTimeout(() => r({ hello: 1 }), 1)),
       state => ({ hello: state.hello + 5 }),
     )(state);
     expect(result).to.eql({ hello: 6 });

--- a/packages/dagu/CHANGELOG.md
+++ b/packages/dagu/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dagu
 
+## 1.2.2
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.2.1 - 07 April 2026
 
 ### Patch Changes

--- a/packages/dagu/package.json
+++ b/packages/dagu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-dagu",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "OpenFn dagu adaptor",
   "type": "module",
   "exports": {

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dhis2
 
+## 8.0.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 8.0.12 - 07 April 2026
 
 ### Patch Changes

--- a/packages/dhis2/package.json
+++ b/packages/dhis2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-dhis2",
   "label": "DHIS2",
-  "version": "8.0.12",
+  "version": "8.0.13",
   "description": "OpenFn adaptor for DHIS2",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/divoc/CHANGELOG.md
+++ b/packages/divoc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-divoc
 
+## 0.1.19
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.1.18 - 07 April 2026
 
 ### Patch Changes

--- a/packages/divoc/package.json
+++ b/packages/divoc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-divoc",
   "label": "Divoc",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "OpenFn adaptor for DIVOC",
   "type": "module",
   "exports": {

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-dynamics
 
+## 0.5.32
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.5.31 - 07 April 2026
 
 ### Patch Changes
@@ -324,7 +331,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access\_token" keys can be used for OAuth2-reliant adaptors
+  "access_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-dynamics",
   "label": "Dynamics",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "description": "OpenFn adaptor for Microsoft Dynamics",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/erpnext/CHANGELOG.md
+++ b/packages/erpnext/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-erpnext
 
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.6 - 07 April 2026
 
 ### Patch Changes

--- a/packages/erpnext/package.json
+++ b/packages/erpnext/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-erpnext",
   "label": "ERPNext",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "OpenFn ERPNext adaptor",
   "type": "module",
   "exports": {

--- a/packages/et-mfr/CHANGELOG.md
+++ b/packages/et-mfr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-et-mfr
 
+## 1.0.8
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.7 - 07 April 2026
 
 ### Patch Changes

--- a/packages/et-mfr/package.json
+++ b/packages/et-mfr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-et-mfr",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OpenFn adaptor for Ethiopia MFR system",
   "type": "module",
   "exports": {

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-facebook
 
+## 0.4.30
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.4.29 - 07 April 2026
 
 ### Patch Changes
@@ -238,7 +245,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access\_token" keys can be used for OAuth2-reliant adaptors
+  "access_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/facebook/package.json
+++ b/packages/facebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-facebook",
   "label": "Facebook",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "An Language Package for Facebook Messenger API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/fhir-4/CHANGELOG.md
+++ b/packages/fhir-4/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir-4
 
+## 0.5.3
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.5.2 - 17 April 2026
 
 ### Patch Changes

--- a/packages/fhir-4/package.json
+++ b/packages/fhir-4/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir-4",
   "label": "FHIR r4",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "OpenFn FHIR r4 adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-4 src docs",

--- a/packages/fhir-eswatini/CHANGELOG.md
+++ b/packages/fhir-eswatini/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-fhir-eswatini
 
+## 0.7.7
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+  - @openfn/language-fhir-4@0.5.3
+
 ## 0.7.6 - 17 April 2026
 
 ### Patch Changes

--- a/packages/fhir-eswatini/package.json
+++ b/packages/fhir-eswatini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-fhir-eswatini",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "OpenFn fhir-eswatini adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-eswatini src ast docs",

--- a/packages/fhir-fr/CHANGELOG.md
+++ b/packages/fhir-fr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir-fr
 
+## 1.0.26
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.25 - 07 April 2026
 
 ### Patch Changes

--- a/packages/fhir-fr/package.json
+++ b/packages/fhir-fr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir-fr",
   "label": "FHIR-FR",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "OpenFn fhir-fr adaptor",
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-fr src ast docs",

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-fhir-ndr-et
 
+## 0.1.29
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+  - @openfn/language-fhir@5.0.18
+
 ## 0.1.28 - 07 April 2026
 
 ### Patch Changes

--- a/packages/fhir-ndr-et/package.json
+++ b/packages/fhir-ndr-et/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir-ndr-et",
   "label": "FHIR NDR Ehtiopia",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "OpenFn fhir adaptor for NDR HIV in Ehtiopia",
   "type": "module",
   "exports": {

--- a/packages/fhir/CHANGELOG.md
+++ b/packages/fhir/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-fhir
 
+## 5.0.18
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 5.0.17 - 07 April 2026
 
 ### Patch Changes

--- a/packages/fhir/package.json
+++ b/packages/fhir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-fhir",
   "label": "FHIR",
-  "version": "5.0.17",
+  "version": "5.0.18",
   "description": "A FHIR adaptor for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/flutterwave/CHANGELOG.md
+++ b/packages/flutterwave/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-flutterwave
 
+## 1.0.5
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.4 - 07 April 2026
 
 ### Patch Changes

--- a/packages/flutterwave/package.json
+++ b/packages/flutterwave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-flutterwave",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenFn flutterwave adaptor",
   "type": "module",
   "exports": {

--- a/packages/formsg/CHANGELOG.md
+++ b/packages/formsg/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-formsg
 
+## 1.0.9
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.8 - 07 April 2026
 
 ### Patch Changes

--- a/packages/formsg/package.json
+++ b/packages/formsg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-formsg",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "OpenFn formsg adaptor",
   "type": "module",
   "exports": {

--- a/packages/gemini/CHANGELOG.md
+++ b/packages/gemini/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-gemini
 
+## 1.0.5
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.4 - 07 April 2026
 
 ### Patch Changes

--- a/packages/gemini/package.json
+++ b/packages/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-gemini",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenFn gemini adaptor",
   "type": "module",
   "exports": {

--- a/packages/ghana-bdr/CHANGELOG.md
+++ b/packages/ghana-bdr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ghana-bdr
 
+## 0.1.22
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.1.21 - 07 April 2026
 
 ### Patch Changes

--- a/packages/ghana-bdr/package.json
+++ b/packages/ghana-bdr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-ghana-bdr",
   "label": "Ghana BDR",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "OpenFn adaptor for Ghana birth-death registry (BDR)",
   "type": "module",
   "exports": {

--- a/packages/ghana-nia/CHANGELOG.md
+++ b/packages/ghana-nia/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ghana-nia
 
+## 0.1.22
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.1.21 - 07 April 2026
 
 ### Patch Changes

--- a/packages/ghana-nia/package.json
+++ b/packages/ghana-nia/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-ghana-nia",
   "label": "Ghana NIA",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "OpenFn ghana-nia adaptor",
   "type": "module",
   "exports": {

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-gmail
 
+## 2.0.15
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 2.0.14 - 17 April 2026
 
 ### Patch Changes

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-gmail",
   "label": "Gmail",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "badge": "Community",
   "description": "OpenFn gmail adaptor",
   "type": "module",

--- a/packages/godata/CHANGELOG.md
+++ b/packages/godata/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-godata
 
+## 3.5.18
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.5.17 - 07 April 2026
 
 ### Patch Changes

--- a/packages/godata/package.json
+++ b/packages/godata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-godata",
   "label": "GoData",
-  "version": "3.5.17",
+  "version": "3.5.18",
   "description": "An OpenFn adaptor for use with the WHO's GoData API",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/googledrive/CHANGELOG.md
+++ b/packages/googledrive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googledrive
 
+## 3.0.6
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.0.5 - 17 April 2026
 
 ### Patch Changes

--- a/packages/googledrive/package.json
+++ b/packages/googledrive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-googledrive",
   "label": "Google Drive",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "OpenFn Google Drive adaptor",
   "type": "module",
   "exports": {

--- a/packages/googlehealthcare/CHANGELOG.md
+++ b/packages/googlehealthcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googlehealthcare
 
+## 1.1.17
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.1.16 - 07 April 2026
 
 ### Patch Changes
@@ -166,6 +173,6 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access\_token" keys can be used for OAuth2-reliant adaptors
+  "access_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0

--- a/packages/googlehealthcare/package.json
+++ b/packages/googlehealthcare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-googlehealthcare",
   "label": "Google Health Care",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "A Google Health Care language package for use with Open Function",
   "type": "module",
   "exports": {

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-googlesheets
 
+## 4.0.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 4.0.12 - 17 April 2026
 
 ### Patch Changes
@@ -312,7 +319,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access\_token" keys can be used for OAuth2-reliant adaptors
+  "access_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-googlesheets",
   "label": "Google Sheets",
-  "version": "4.0.12",
+  "version": "4.0.13",
   "description": "A Google Sheets Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-hive
 
+## 0.3.29
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.3.28 - 07 April 2026
 
 ### Patch Changes

--- a/packages/hive/package.json
+++ b/packages/hive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-hive",
   "label": "Apache HIVE",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "An Apache HIVE adaptor for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-http
 
+## 7.2.11
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 7.2.10 - 07 April 2026
 
 ### Patch Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-http",
   "label": "HTTP",
-  "version": "7.2.10",
+  "version": "7.2.11",
   "description": "An HTTP request language package for use with Open Function",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/hubtel/CHANGELOG.md
+++ b/packages/hubtel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-hubtel
 
+## 1.0.21
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.20 - 07 April 2026
 
 ### Patch Changes

--- a/packages/hubtel/package.json
+++ b/packages/hubtel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-hubtel",
   "label": "Hubtel",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "OpenFn adaptor for Hubtel",
   "type": "module",
   "exports": {

--- a/packages/ibipimo/CHANGELOG.md
+++ b/packages/ibipimo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ibipimo
 
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.5 - 14 April 2026
 
 ### Patch Changes

--- a/packages/ibipimo/package.json
+++ b/packages/ibipimo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ibipimo",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "OpenFn ibipimo adaptor",
   "type": "module",
   "exports": {

--- a/packages/ihris/CHANGELOG.md
+++ b/packages/ihris/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-ihris
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+  - @openfn/language-fhir-4@0.5.3
+
 ## 1.1.1 - 17 April 2026
 
 ### Patch Changes

--- a/packages/ihris/package.json
+++ b/packages/ihris/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ihris",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "OpenFn adaptor for iHRIS ",
   "type": "module",
   "exports": {

--- a/packages/inform/CHANGELOG.md
+++ b/packages/inform/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-inform
 
+## 1.2.6
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.2.5 - 07 April 2026
 
 ### Patch Changes

--- a/packages/inform/package.json
+++ b/packages/inform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-inform",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "OpenFn inform adaptor for UNICEF InForm platform operations",
   "type": "module",
   "exports": {

--- a/packages/intuit/CHANGELOG.md
+++ b/packages/intuit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-intuit
 
+## 1.0.20
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.19 - 07 April 2026
 
 ### Patch Changes

--- a/packages/intuit/package.json
+++ b/packages/intuit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-intuit",
   "label": "Intuit",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "OpenFn adaptor for Intuit (QuickBooks)",
   "type": "module",
   "exports": {

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-khanacademy
 
+## 0.5.31
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.5.30 - 07 April 2026
 
 ### Patch Changes

--- a/packages/khanacademy/package.json
+++ b/packages/khanacademy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-khanacademy",
   "label": "Khan Academy",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "description": "A Khan Academy Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-kobotoolbox
 
+## 4.2.14
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 4.2.13 - 07 April 2026
 
 ### Patch Changes

--- a/packages/kobotoolbox/package.json
+++ b/packages/kobotoolbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-kobotoolbox",
   "label": "KoboToolbox",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "description": "OpenFn adaptor for KoboToolbox",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/lamisplus/CHANGELOG.md
+++ b/packages/lamisplus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-lamisplus
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.1.3 - 07 April 2026
 
 ### Patch Changes

--- a/packages/lamisplus/package.json
+++ b/packages/lamisplus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-lamisplus",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenFn lamisplus adaptor",
   "type": "module",
   "exports": {

--- a/packages/magpi/CHANGELOG.md
+++ b/packages/magpi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-magpi
 
+## 1.2.12
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.2.11 - 07 April 2026
 
 ### Patch Changes

--- a/packages/magpi/package.json
+++ b/packages/magpi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-magpi",
   "label": "Magpi",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "OpenFn adaptor for Magpi",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailchimp
 
+## 1.0.32
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.31 - 06 May 2026
 
 ### Patch Changes

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mailchimp",
   "label": "Mailchimp",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "An OpenFn adaptor for use with Mailchimp",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mailgun
 
+## 0.6.7
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.6.6 - 07 April 2026
 
 ### Patch Changes

--- a/packages/mailgun/package.json
+++ b/packages/mailgun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mailgun",
   "label": "Mailgun",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "mailgun Language Pack for OpenFn",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-maximo
 
+## 0.5.33
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.5.32 - 07 April 2026
 
 ### Patch Changes

--- a/packages/maximo/package.json
+++ b/packages/maximo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-maximo",
   "label": "Maximo",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "description": "OpenFn adaptor for IBM Maximo EAM",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-medicmobile
 
+## 0.5.30
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.5.29 - 07 April 2026
 
 ### Patch Changes

--- a/packages/medicmobile/package.json
+++ b/packages/medicmobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-medicmobile",
   "label": "Medic Mobile",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "description": "OpenFn adaptor for Medic Mobile",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/memento/CHANGELOG.md
+++ b/packages/memento/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-memento
 
+## 1.0.9
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.8 - 07 April 2026
 
 ### Patch Changes

--- a/packages/memento/package.json
+++ b/packages/memento/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-memento",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "OpenFn adaptor for Memento Database",
   "type": "module",
   "exports": {

--- a/packages/minio/CHANGELOG.md
+++ b/packages/minio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-minio
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.2 - 06 May 2026
 
 ### Patch Changes

--- a/packages/minio/package.json
+++ b/packages/minio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-minio",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenFn minio adaptor",
   "type": "module",
   "exports": {

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -1,5 +1,12 @@
 v0.1.6
 
+## 0.6.15
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.6.14 - 07 April 2026
 
 ### Patch Changes

--- a/packages/mogli/package.json
+++ b/packages/mogli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mogli",
   "label": "Mogli",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "OpenFn adaptor for Mogli SMS",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/mojatax/CHANGELOG.md
+++ b/packages/mojatax/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mojatax
 
+## 1.0.24
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.23 - 07 April 2026
 
 ### Patch Changes

--- a/packages/mojatax/package.json
+++ b/packages/mojatax/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mojatax",
   "label": "MojaTax",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "OpenFn adaptor for MojaTax",
   "type": "module",
   "exports": {

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mongodb
 
+## 2.1.30
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 2.1.29 - 07 April 2026
 
 ### Patch Changes

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mongodb",
   "label": "MongoDB",
-  "version": "2.1.29",
+  "version": "2.1.30",
   "description": "A language package for working with MongoDb",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/monnify/CHANGELOG.md
+++ b/packages/monnify/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-monnify
 
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.5 - 07 April 2026
 
 ### Patch Changes

--- a/packages/monnify/package.json
+++ b/packages/monnify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-monnify",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "OpenFn monnify adaptor",
   "type": "module",
   "exports": {

--- a/packages/motherduck/CHANGELOG.md
+++ b/packages/motherduck/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-motherduck
 
+## 1.0.8
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.7 - 07 April 2026
 
 ### Patch Changes

--- a/packages/motherduck/package.json
+++ b/packages/motherduck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-motherduck",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OpenFn MotherDuck cloud database adaptor",
   "type": "module",
   "exports": {

--- a/packages/mpesa/CHANGELOG.md
+++ b/packages/mpesa/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mpesa
 
+## 1.1.14
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.1.13 - 07 April 2026
 
 ### Patch Changes
@@ -122,7 +129,7 @@
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- d1f7851: Fixed the title for the consumer\_secret on the configuration schema
+- d1f7851: Fixed the title for the consumer_secret on the configuration schema
 - Updated dependencies \[99e4b48]
 - Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0

--- a/packages/mpesa/package.json
+++ b/packages/mpesa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mpesa",
   "label": "Mpesa",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "OpenFn adaptor for M-Pesa",
   "type": "module",
   "exports": {

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msgraph
 
+## 0.8.14
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.8.13 - 07 April 2026
 
 ### Patch Changes
@@ -364,7 +371,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access\_token" keys can be used for OAuth2-reliant adaptors
+  "access_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-msgraph",
   "label": "Microsoft Graph",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "Microsoft Graph Language Pack for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mssql
 
+## 7.0.7
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 7.0.6 - 07 April 2026
 
 ### Patch Changes

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mssql",
   "label": "MSSQL",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "description": "A Microsoft SQL language pack for OpenFn",
   "exports": {
     ".": {

--- a/packages/msupply/CHANGELOG.md
+++ b/packages/msupply/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msupply
 
+## 1.0.18
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.17 - 14 May 2026
 
 ### Patch Changes

--- a/packages/msupply/package.json
+++ b/packages/msupply/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-msupply",
   "label": "mSupply",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "OpenFn adaptor for mSupply",
   "type": "module",
   "exports": {

--- a/packages/mtn-momo/CHANGELOG.md
+++ b/packages/mtn-momo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mtn-momo
 
+## 1.1.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.1.12 - 07 April 2026
 
 ### Patch Changes

--- a/packages/mtn-momo/package.json
+++ b/packages/mtn-momo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-mtn-momo",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "OpenFn mtn-momo adaptor for MTN Mobile Money payment operations",
   "type": "module",
   "exports": {

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-mysql
 
+## 4.0.6
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 4.0.5 - 07 April 2026
 
 ### Patch Changes

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-mysql",
   "label": "MySQL",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "A MySQL Language Pack for OpenFn",
   "homepage": "https://docs.openfn.org",
   "main": "dist/index.cjs",

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-nexmo
 
+## 0.5.34
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.5.33 - 07 April 2026
 
 ### Patch Changes

--- a/packages/nexmo/package.json
+++ b/packages/nexmo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-nexmo",
   "label": "Nexmo",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "description": "OpenFn adaptor for Nexmo",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ocl
 
+## 1.2.31
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.2.30 - 07 April 2026
 
 ### Patch Changes

--- a/packages/ocl/package.json
+++ b/packages/ocl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-ocl",
   "label": "OCL",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "OpenFn adaptor for Open Concept Lab (ORL) terminology services",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-odk
 
+## 3.0.30
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.0.29 - 07 April 2026
 
 ### Patch Changes

--- a/packages/odk/package.json
+++ b/packages/odk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-odk",
   "label": "ODK",
-  "version": "3.0.29",
+  "version": "3.0.30",
   "description": "OpenFn adaptor for Open Data Kit (ODK) data collection platform",
   "type": "module",
   "exports": {

--- a/packages/odoo/CHANGELOG.md
+++ b/packages/odoo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-odoo
 
+## 2.1.12
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 2.1.11 - 07 April 2026
 
 ### Patch Changes

--- a/packages/odoo/package.json
+++ b/packages/odoo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-odoo",
   "label": "Odoo",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "OpenFn adaptor for Odoo (ERP)",
   "type": "module",
   "exports": {

--- a/packages/openboxes/CHANGELOG.md
+++ b/packages/openboxes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openboxes
 
+## 1.0.18
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.17 - 07 April 2026
 
 ### Patch Changes

--- a/packages/openboxes/package.json
+++ b/packages/openboxes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openboxes",
   "label": "OpenBoxes",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "OpenFn adaptor for OpenBoxes",
   "type": "module",
   "exports": {

--- a/packages/opencrvs/CHANGELOG.md
+++ b/packages/opencrvs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-opencrvs
 
+## 1.1.1
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+  - @openfn/language-fhir-4@0.5.3
+
 ## 1.1.0 - 20 May 2026
 
 ### Minor Changes

--- a/packages/opencrvs/package.json
+++ b/packages/opencrvs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-opencrvs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenFn adaptor for OpenCRVS",
   "type": "module",
   "exports": {

--- a/packages/openelis/CHANGELOG.md
+++ b/packages/openelis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openelis
 
+## 1.0.4
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.3 - 07 April 2026
 
 ### Patch Changes

--- a/packages/openelis/package.json
+++ b/packages/openelis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-openelis",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "OpenFn openelis adaptor",
   "type": "module",
   "exports": {

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openfn
 
+## 3.0.14
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.0.13 - 07 April 2026
 
 ### Patch Changes

--- a/packages/openfn/package.json
+++ b/packages/openfn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openfn",
   "label": "OpenFn",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "OpenFn adaptor for accessing the OpenFn web API",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openhim
 
+## 2.0.12
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 2.0.11 - 07 April 2026
 
 ### Patch Changes

--- a/packages/openhim/package.json
+++ b/packages/openhim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openhim",
   "label": "OpenHIM",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "OpenFn adaptor for OpenHIM",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openimis
 
+## 3.0.11
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.0.10 - 07 April 2026
 
 ### Patch Changes

--- a/packages/openimis/package.json
+++ b/packages/openimis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openimis",
   "label": "OpenIMIS",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "OpenFn adaptor for OpenIMIS",
   "type": "module",
   "exports": {

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openlmis
 
+## 1.1.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.1.12 - 07 April 2026
 
 ### Patch Changes

--- a/packages/openlmis/package.json
+++ b/packages/openlmis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openlmis",
   "label": "OpenLMIS",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "OpenFn adaptor for OpenLMIS",
   "type": "module",
   "exports": {

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openmrs
 
+## 5.3.12
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 5.3.11 - 17 April 2026
 
 ### Patch Changes

--- a/packages/openmrs/package.json
+++ b/packages/openmrs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openmrs",
   "label": "OpenMRS",
-  "version": "5.3.11",
+  "version": "5.3.12",
   "description": "OpenFn adaptor for OpenMRS",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-openspp
 
+## 3.0.11
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.0.10 - 07 April 2026
 
 ### Patch Changes

--- a/packages/openspp/package.json
+++ b/packages/openspp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-openspp",
   "label": "OpenSPP",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "OpenFn adaptor for working with the OpenSPP json rpc",
   "type": "module",
   "exports": {

--- a/packages/pdfshift/CHANGELOG.md
+++ b/packages/pdfshift/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-pdfshift
 
+## 1.0.12
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.11 - 07 April 2026
 
 ### Patch Changes

--- a/packages/pdfshift/package.json
+++ b/packages/pdfshift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-pdfshift",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "OpenFn adaptor for generating PDF documents",
   "badge": "Core",
   "type": "module",

--- a/packages/pesapal/CHANGELOG.md
+++ b/packages/pesapal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-pesapal
 
+## 1.1.15
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.1.14 - 07 April 2026
 
 ### Patch Changes

--- a/packages/pesapal/package.json
+++ b/packages/pesapal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-pesapal",
   "label": "Pesapal",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "OpenFn adaptor for Pesapal",
   "type": "module",
   "exports": {

--- a/packages/ping/CHANGELOG.md
+++ b/packages/ping/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-ping
 
+## 1.0.5
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.4 - 07 April 2026
 
 ### Patch Changes

--- a/packages/ping/package.json
+++ b/packages/ping/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-ping",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenFn ping adaptor",
   "type": "module",
   "exports": {

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-postgresql
 
+## 8.0.5
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 8.0.4 - 07 April 2026
 
 ### Patch Changes

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-postgresql",
   "label": "PostgreSQL",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "description": "OpenFn adaptor for PostgreSQL",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-primero
 
+## 4.0.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 4.0.12 - 14 April 2026
 
 ### Patch Changes

--- a/packages/primero/package.json
+++ b/packages/primero/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-primero",
   "label": "Primero",
-  "version": "4.0.12",
+  "version": "4.0.13",
   "description": "A UNICEF Primero language package for use with Open Function",
   "exports": {
     ".": {

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-progres
 
+## 2.0.14
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 2.0.13 - 07 April 2026
 
 ### Patch Changes

--- a/packages/progres/package.json
+++ b/packages/progres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-progres",
   "label": "ProGres",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "OpenFn adaptor for working with UNHCR's ProGres case management system",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/puntosolidario-rd/CHANGELOG.md
+++ b/packages/puntosolidario-rd/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-puntosolidario-rd
 
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.0 - 14 April 2026
 
-Initial release of Punto Solidario adaptor with GET and POST HTTP request and authentication.
+Initial release of Punto Solidario adaptor with GET and POST HTTP request and
+authentication.

--- a/packages/puntosolidario-rd/package.json
+++ b/packages/puntosolidario-rd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-puntosolidario-rd",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenFn puntosolidario-rd adaptor",
   "type": "module",
   "exports": {

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-rapidpro
 
+## 2.0.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 2.0.12 - 07 April 2026
 
 ### Patch Changes

--- a/packages/rapidpro/package.json
+++ b/packages/rapidpro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-rapidpro",
   "label": "RapidPro",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "OpenFn adaptor for RapidPro",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-redis
 
+## 1.3.20
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.3.19 - 07 April 2026
 
 ### Patch Changes

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-redis",
   "label": "Redis",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "description": "OpenFn adaptor for Redis",
   "type": "module",
   "exports": {

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-resourcemap
 
+## 0.4.31
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.4.30 - 07 April 2026
 
 ### Patch Changes

--- a/packages/resourcemap/package.json
+++ b/packages/resourcemap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-resourcemap",
   "label": "Resourcemap",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "description": "OpenFn Resourcemap adaptor for geospatial platform operations",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-salesforce
 
+## 9.0.9
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 9.0.8 - 07 April 2026
 
 ### Patch Changes

--- a/packages/salesforce/package.json
+++ b/packages/salesforce/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-salesforce",
   "label": "Salesforce",
-  "version": "9.0.8",
+  "version": "9.0.9",
   "description": "OpenFn adaptor for Salesforce",
   "homepage": "https://docs.openfn.org",
   "exports": {

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-satusehat
 
+## 3.0.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.0.12 - 07 April 2026
 
 ### Patch Changes

--- a/packages/satusehat/package.json
+++ b/packages/satusehat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-satusehat",
   "label": "Satusehat",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "description": "OpenFn adaptor for SATUSEHAT",
   "type": "module",
   "exports": {

--- a/packages/senaite/CHANGELOG.md
+++ b/packages/senaite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-senaite
 
+## 1.0.17
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.16 - 07 April 2026
 
 ### Patch Changes

--- a/packages/senaite/package.json
+++ b/packages/senaite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-senaite",
   "label": "Senaite",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "OpenFn senaite adaptor for laboratory information management",
   "type": "module",
   "exports": {

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-sftp
 
+## 3.0.13
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.0.12 - 14 April 2026
 
 ### Patch Changes

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-sftp",
   "label": "SFTP",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "description": "OpenFn adaptor for SFTP",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/siuben-rd/CHANGELOG.md
+++ b/packages/siuben-rd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-siuben-rd
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.1 - 07 April 2026
 
 ### Patch Changes

--- a/packages/siuben-rd/package.json
+++ b/packages/siuben-rd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-siuben-rd",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenFn siuben-rd adaptor",
   "type": "module",
   "exports": {

--- a/packages/stripe/CHANGELOG.md
+++ b/packages/stripe/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-stripe
 
+## 1.0.11
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.10 - 07 April 2026
 
 ### Patch Changes

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-stripe",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "OpenFn adaptor for Stripe payment operations",
   "type": "module",
   "exports": {

--- a/packages/sunbird-rc/CHANGELOG.md
+++ b/packages/sunbird-rc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-sunbird-rc
 
+## 1.0.8
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.7 - 07 April 2026
 
 ### Patch Changes

--- a/packages/sunbird-rc/package.json
+++ b/packages/sunbird-rc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-sunbird-rc",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OpenFn sunbird-rc adaptor",
   "type": "module",
   "exports": {

--- a/packages/surveycto/CHANGELOG.md
+++ b/packages/surveycto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-surveycto
 
+## 3.0.10
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 3.0.9 - 07 April 2026
 
 ### Patch Changes

--- a/packages/surveycto/package.json
+++ b/packages/surveycto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-surveycto",
   "label": "SurveyCTO",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "OpenFn adaptor for SurveyCTO",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-telerivet
 
+## 0.3.28
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.3.27 - 07 April 2026
 
 ### Patch Changes

--- a/packages/telerivet/package.json
+++ b/packages/telerivet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-telerivet",
   "label": "Telerivet",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "description": "OpenFn adaptor for Telerivet",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/twilio/CHANGELOG.md
+++ b/packages/twilio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-twilio
 
+## 1.0.14
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.13 - 17 April 2026
 
 ### Patch Changes

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-twilio",
   "label": "Twilio",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "OpenFn adaptor for Twilio",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/varo/CHANGELOG.md
+++ b/packages/varo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-varo
 
+## 2.1.11
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 2.1.10 - 07 April 2026
 
 ### Patch Changes

--- a/packages/varo/package.json
+++ b/packages/varo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-varo",
   "label": "Varo",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "OpenFn varo adaptor for cold chain information",
   "type": "module",
   "exports": {

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-vtiger
 
+## 1.3.30
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.3.29 - 07 April 2026
 
 ### Patch Changes

--- a/packages/vtiger/package.json
+++ b/packages/vtiger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-vtiger",
   "label": "Vtiger",
-  "version": "1.3.29",
+  "version": "1.3.30",
   "description": "OpenFn adaptor for Vtiger",
   "main": "dist/index.cjs",
   "scripts": {

--- a/packages/whatsapp/CHANGELOG.md
+++ b/packages/whatsapp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-whatsapp
 
+## 1.0.14
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.13 - 07 April 2026
 
 ### Patch Changes

--- a/packages/whatsapp/package.json
+++ b/packages/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-whatsapp",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "OpenFn whatsapp adaptor",
   "type": "module",
   "exports": {

--- a/packages/wigal-sms/CHANGELOG.md
+++ b/packages/wigal-sms/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-wigal-sms
 
+## 0.1.22
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.1.21 - 07 April 2026
 
 ### Patch Changes

--- a/packages/wigal-sms/package.json
+++ b/packages/wigal-sms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-wigal-sms",
   "label": "Wigal SMS",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "OpenFn wigal-sms adaptor for SMS gateway operations",
   "type": "module",
   "exports": {

--- a/packages/zata/CHANGELOG.md
+++ b/packages/zata/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-zata
 
+## 1.0.11
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 1.0.10 - 07 April 2026
 
 ### Patch Changes

--- a/packages/zata/package.json
+++ b/packages/zata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-zata",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "An OpenFn adaptor for Zata tax compliance",
   "badge": "Legacy",
   "type": "module",

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-zoho
 
+## 0.4.29
+
+### Patch Changes
+
+- Updated dependencies [9d1e1ae]
+  - @openfn/language-common@3.3.2
+
 ## 0.4.28 - 07 April 2026
 
 ### Patch Changes

--- a/packages/zoho/package.json
+++ b/packages/zoho/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-zoho",
   "label": "Zoho",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "description": "OpenFn adaptor for Zoho",
   "main": "dist/index.cjs",
   "scripts": {


### PR DESCRIPTION
## Summary

This PR adds promise support in the `combine` function in common. 

## Details
Previously, `combine` did not account for async operations — if any of the passed functions returned a promise, it would proceed to the next operation without waiting for it to resolve, leading to unexpected behavior.
With this change, `combine` now detects and awaits promises before moving to the next operation. 

For example:
```js
combine(post(), fn())
```
`post()` will fully resolve before fn() is executed.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [x] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] Have you ticked a box under AI Usage?
