### PR TITLE
feat: add base in options for fhir schema generator

### DIFF
--- a/packages/fhir-eswatini/package.json
+++ b/packages/fhir-eswatini/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-eswatini src ast docs",
     "build:src": "pnpm generate-fhir fhir-eswatini --base fhir-4",
-    "build:spec": "pnpm generate-fhir fhir-eswatini",
+    "build:spec": "pnpm generate-fhir fhir-eswatini --respec",
     "test": "TS_NODE_TRANSPILE_ONLY=true mocha --experimental-specifier-resolution=node --no-warnings  --loader=ts-node/esm \"**/*.test.ts\"",
     "clean": "rimraf dist docs",
     "pack": "pnpm pack --pack-destination ../../dist"
@@ -15,8 +15,8 @@
   "type": "module",
   "fhir": {
     "specUrl": "http://172.209.216.154/definitions.json.zip",
-    "adaptorGeneratedDate": "2026-06-02T13:48:30.328Z",
-    "generatorVersion": "0.7.8",
+    "adaptorGeneratedDate": "2026-06-02T15:23:39.432Z",
+    "generatorVersion": "0.7.9",
     "options": {
       "base": "fhir-4"
     }

--- a/packages/fhir-eswatini/package.json
+++ b/packages/fhir-eswatini/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "pnpm clean && build-adaptor fhir-eswatini src ast docs",
     "build:src": "pnpm generate-fhir fhir-eswatini --base fhir-4",
-    "build:spec": "pnpm generate-fhir fhir-eswatini --respec",
+    "build:spec": "pnpm generate-fhir fhir-eswatini",
     "test": "TS_NODE_TRANSPILE_ONLY=true mocha --experimental-specifier-resolution=node --no-warnings  --loader=ts-node/esm \"**/*.test.ts\"",
     "clean": "rimraf dist docs",
     "pack": "pnpm pack --pack-destination ../../dist"
@@ -15,9 +15,11 @@
   "type": "module",
   "fhir": {
     "specUrl": "http://172.209.216.154/definitions.json.zip",
-    "adaptorGeneratedDate": "2026-03-30T13:45:30.759Z",
-    "generatorVersion": "0.7.7",
-    "options": {}
+    "adaptorGeneratedDate": "2026-06-02T13:48:30.328Z",
+    "generatorVersion": "0.7.8",
+    "options": {
+      "base": "fhir-4"
+    }
   },
   "dependencies": {
     "@openfn/language-common": "workspace:*",

--- a/tools/generate-fhir/package.json
+++ b/tools/generate-fhir/package.json
@@ -2,7 +2,7 @@
   "name": "@openfn/generate-fhir",
   "private": true,
   "type": "module",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Helper utility for fhir adaptor generator",
   "main": "src/index.ts",
   "license": "ISC",

--- a/tools/generate-fhir/src/generate.ts
+++ b/tools/generate-fhir/src/generate.ts
@@ -55,7 +55,7 @@ const generateAdaptor = async (adaptorName: string, options: Options = {}) => {
   const context = {
     options,
   } as GenContext;
-  const { base, respec, spec } = options;
+  const { respec, spec } = options;
 
   const dir = path.dirname(import.meta.url.replace('file://', ''));
   const monoRepoRoot = path.resolve(dir, `../../../`);
@@ -140,7 +140,8 @@ const generateAdaptor = async (adaptorName: string, options: Options = {}) => {
   }
 
   // Load options which may have been saved to the package
-  const { simpleBuilders } = options;
+  // Note: base must be read AFTER pkg.fhir.options is merged in above
+  const { simpleBuilders, base } = options;
 
   // Now generate from the spec
   const specPath = path.resolve(adaptorPath, 'spec', 'spec.json');
@@ -258,7 +259,7 @@ const generateAdaptor = async (adaptorName: string, options: Options = {}) => {
     ...meta,
     adaptorGeneratedDate: new Date().toISOString(),
     generatorVersion: toolPkg.version,
-    options: ['simpleBuilders']
+    options: ['simpleBuilders', 'base']
       .filter(o => o in options)
       .reduce((acc: any, o: string) => {
         acc[o] = options[o];


### PR DESCRIPTION
## Summary

When generating a FHIR adaptor with `--base fhir-4`, all profile files import shared types from `@openfn/language-fhir-4`. However, if subsequent runs (e.g. `build:spec`) omit the flag, the generator defaults to local imports — causing large noisy diffs every time the spec is rebuilt.

Changes:

`generate.ts`: Add `base` to the list of options persisted to `package.json:fhir.options`
`generate.ts`: Move `base` destructuring to after `pkg.fhir.options`, so saved values are picked up correctly on flag-less runs

With these changes, you do not need to pass `--base fhir-4` in `pnpm build:spec` as it will be automatically added


Fixes #1684 

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
