### PR TITLE
DHIS2: Schema should not require username/password when using a PAT

### DIFF
--- a/.changeset/major-ghosts-repair.md
+++ b/.changeset/major-ghosts-repair.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-dhis2': patch
+---
+
+Fix: DHIS2 schema will not require username/password when using a PAT

--- a/packages/dhis2/configuration-schema.json
+++ b/packages/dhis2/configuration-schema.json
@@ -60,8 +60,6 @@
   "type": "object",
   "additionalProperties": true,
   "required": [
-    "hostUrl",
-    "password",
-    "username"
+    "hostUrl"
   ]
 }

--- a/packages/dhis2/src/util.js
+++ b/packages/dhis2/src/util.js
@@ -164,15 +164,15 @@ export function prefixVersionToPath(
   return urlPath;
 }
 export const configureAuth = (auth, headers = {}) => {
-  if ('pat' in auth) {
+  if (auth.pat) {
     Object.assign(headers, {
       Authorization: `ApiToken ${auth.pat}`,
     });
-  } else if ('password' in auth) {
+  } else if (auth.username && auth.password) {
     Object.assign(headers, makeBasicAuthHeader(auth.username, auth.password));
   } else {
     throw new Error(
-      'Invalid authorization credentials. Include an pat, username or password in state.configuration'
+      'Invalid authorization credentials. Include a PAT or a username and password in state.configuration'
     );
   }
 

--- a/packages/dhis2/test/auth.test.js
+++ b/packages/dhis2/test/auth.test.js
@@ -14,29 +14,18 @@ const testServer = enableMockClient(hostUrl);
 
 
 describe('configureAuth', () => {
-  it('should set a PAT auth header', () => {
-    const headers = util.configureAuth({ pat: 'mytoken' });
+  it('should prefer PAT over username and password when both are provided', () => {
+    const headers = util.configureAuth({ pat: 'mytoken', username: 'admin', password: 'district' });
     expect(headers).to.eql({ Authorization: 'ApiToken mytoken' });
   });
 
-  it('should set a basic auth header', () => {
-    const headers = util.configureAuth({ username: 'admin', password: 'district' });
-    expect(headers).to.eql(makeBasicAuthHeader('admin', 'district'));
-  });
-
-  it('should throw if pat is empty', () => {
-    expect(() => util.configureAuth({ pat: '' })).to.throw(
-      'Invalid authorization credentials. Include a PAT or a username and password in state.configuration'
-    );
-  });
-
-  it('should throw if username is empty', () => {
+  it('should throw if password is provided without a username', () => {
     expect(() => util.configureAuth({ username: '', password: 'district' })).to.throw(
       'Invalid authorization credentials. Include a PAT or a username and password in state.configuration'
     );
   });
 
-  it('should throw if password is empty', () => {
+  it('should throw if username is provided without a password', () => {
     expect(() => util.configureAuth({ username: 'admin', password: '' })).to.throw(
       'Invalid authorization credentials. Include a PAT or a username and password in state.configuration'
     );

--- a/packages/dhis2/test/auth.test.js
+++ b/packages/dhis2/test/auth.test.js
@@ -1,0 +1,51 @@
+import chai from 'chai';
+import { execute, create, update, upsert, get } from '../src/Adaptor.js';
+import { dataValue } from '@openfn/language-common';
+import { enableMockClient } from '@openfn/language-common/util';
+import * as util from '../src/util.js';
+import {
+  makeBasicAuthHeader,
+} from '@openfn/language-common/util';
+
+const { expect } = chai;
+
+const hostUrl = 'https://auth.dhis2.org';
+const testServer = enableMockClient(hostUrl);
+
+
+describe('configureAuth', () => {
+  it('should set a PAT auth header', () => {
+    const headers = util.configureAuth({ pat: 'mytoken' });
+    expect(headers).to.eql({ Authorization: 'ApiToken mytoken' });
+  });
+
+  it('should set a basic auth header', () => {
+    const headers = util.configureAuth({ username: 'admin', password: 'district' });
+    expect(headers).to.eql(makeBasicAuthHeader('admin', 'district'));
+  });
+
+  it('should throw if pat is empty', () => {
+    expect(() => util.configureAuth({ pat: '' })).to.throw(
+      'Invalid authorization credentials. Include a PAT or a username and password in state.configuration'
+    );
+  });
+
+  it('should throw if username is empty', () => {
+    expect(() => util.configureAuth({ username: '', password: 'district' })).to.throw(
+      'Invalid authorization credentials. Include a PAT or a username and password in state.configuration'
+    );
+  });
+
+  it('should throw if password is empty', () => {
+    expect(() => util.configureAuth({ username: 'admin', password: '' })).to.throw(
+      'Invalid authorization credentials. Include a PAT or a username and password in state.configuration'
+    );
+  });
+
+  it('should throw if no valid credentials are provided', () => {
+    expect(() => util.configureAuth({})).to.throw(
+      'Invalid authorization credentials. Include a PAT or a username and password in state.configuration'
+    );
+  });
+
+})


### PR DESCRIPTION
## Summary

The configuration schema requires username and password even when authenticating with a PAT, forcing users to provide credentials that are silently ignored.

The schema currently has:
```
"required": ["hostUrl", "password", "username"]
```
And configureAuth uses a priority chain — PAT wins over password:
```
if ('pat' in auth) {
  Object.assign(headers, { Authorization: `ApiToken ${auth.pat}` });
} else if ('password' in auth) {
  Object.assign(headers, makeBasicAuthHeader(auth.username, auth.password));
}
```
The password branch doesn't check that username is also present, so CLI users (where the schema isn't enforced) can end up with silent auth failures.

Fixes #1547 

## Details
The schema currently has:

```json
"required": ["hostUrl", "password", "username"]
```

And `configureAuth` uses a priority chain — PAT wins over password:

```js
if ('pat' in auth) {
  Object.assign(headers, { Authorization: `ApiToken ${auth.pat}` });
} else if ('password' in auth) {
  Object.assign(headers, makeBasicAuthHeader(auth.username, auth.password));
}
```

The `password` branch doesn't check that `username` is also present, so CLI users (where the schema isn't enforced) can end up with silent auth failures.

## Expected behaviour

1. **Schema** should express that credentials are one-of: either `pat`, or both `username` + `password` — not all three required. A `oneOf`/`anyOf` structure would work.
2. **Runtime**: when falling back to Basic auth (no PAT), `configureAuth` should validate that both `username` and `password` are present and non-empty, and throw a descriptive error if either is missing.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] Have you ticked a box under AI Usage?
