### PR TITLE
add `createBlob` in common

### DIFF
--- a/packages/common/src/util/http.js
+++ b/packages/common/src/util/http.js
@@ -7,6 +7,8 @@ import { encode } from './base64.js';
 import { MockAgent, Agent, interceptors, FormData } from 'undici';
 import _ from 'lodash';
 
+export { FormData };
+
 // Maps undici dispatchers to keys (where a key is the base url + encoded options)
 const agents = new Map();
 
@@ -348,6 +350,21 @@ export async function request(method, fullUrlOrPath, options = {}) {
     requestResponse.query = queryParams;
   }
   return requestResponse;
+}
+
+/**
+ * Creates a typed, optionally named Blob from raw binary data.
+ * Pass the result as a value in the object given to encodeFormBody.
+ * @param {Buffer|ArrayBuffer|string} data - The binary content
+ * @param {string} type - MIME type (e.g. 'image/jpeg')
+ * @param {string} [filename] - Optional filename
+ * @returns {File|Blob}
+ */
+export function createBlob(data, type, filename) {
+  if (filename) {
+    return new File([data], filename, { type });
+  }
+  return new Blob([data], { type });
 }
 
 /**

--- a/packages/common/test/util/http.test.js
+++ b/packages/common/test/util/http.test.js
@@ -13,6 +13,7 @@ import {
   logResponse,
   generateAgentKey,
   encodeFormBody,
+  createBlob,
 } from '../../src/util/http.js';
 import { encode } from '../../src/util/base64.js';
 
@@ -1386,5 +1387,29 @@ describe('encodeFormBody', () => {
     const blob = new Blob(['data'], { type: 'text/plain' });
     const form = encodeFormBody({ file: blob });
     expect(form.get('file')).to.be.instanceof(Blob);
+  });
+
+  it('wraps a Buffer into a typed Blob via createBlob', () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff]);
+    const form = encodeFormBody({ file: createBlob(buf, 'image/jpeg') });
+    const appended = form.get('file');
+    expect(appended).to.be.instanceof(Blob);
+    expect(appended.type).to.equal('image/jpeg');
+    expect(appended.size).to.equal(3);
+  });
+
+  it('wraps a Buffer into a named File via createBlob', () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff]);
+    const form = encodeFormBody({ file: createBlob(buf, 'image/jpeg', 'photo.jpg') });
+    const appended = form.get('file');
+    expect(appended).to.be.instanceof(File);
+    expect(appended.type).to.equal('image/jpeg');
+    expect(appended.name).to.equal('photo.jpg');
+  });
+
+  it('createBlob without filename returns a Blob not a File', () => {
+    const entry = createBlob(Buffer.from('x'), 'text/plain');
+    expect(entry).to.be.instanceof(Blob);
+    expect(entry).to.not.be.instanceof(File);
   });
 });


### PR DESCRIPTION
## Summary
Add `createBlob` util function in common, and export `FormData` from `undici`

Fixes #1622 


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [x] Have you ticked a box under AI Usage?
