### PR TITLE
image-utils docs

### DIFF
--- a/.changeset/fancy-ravens-stand.md
+++ b/.changeset/fancy-ravens-stand.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-image-utils': patch
+---
+
+Fix adaptor docs

--- a/.changeset/fancy-ravens-stand.md
+++ b/.changeset/fancy-ravens-stand.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-image-utils': patch
----
-
-Fix adaptor docs

--- a/packages/arcgis/CHANGELOG.md
+++ b/packages/arcgis/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-arcgis
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/asana/CHANGELOG.md
+++ b/packages/asana/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-asana
 
-## 5.1.2
+## 5.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 5.1.1 - 27 May 2026

--- a/packages/aws-s3/CHANGELOG.md
+++ b/packages/aws-s3/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-aws-s3
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/azure-storage/CHANGELOG.md
+++ b/packages/azure-storage/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-azure-storage
 
-## 3.1.2
+## 3.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.1.1 - 27 May 2026

--- a/packages/beyonic/CHANGELOG.md
+++ b/packages/beyonic/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-beyonic
 
-## 0.4.2
+## 0.4.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.4.1 - 27 May 2026

--- a/packages/bigquery/CHANGELOG.md
+++ b/packages/bigquery/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-bigquery
 
-## 4.1.2
+## 4.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 4.1.1 - 27 May 2026

--- a/packages/browserless/CHANGELOG.md
+++ b/packages/browserless/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-browserless
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/cartodb/CHANGELOG.md
+++ b/packages/cartodb/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-cartodb
 
-## 0.5.2
+## 0.5.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.5.1 - 27 May 2026

--- a/packages/chatgpt/CHANGELOG.md
+++ b/packages/chatgpt/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-chatgpt
 
-## 2.1.2
+## 2.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 2.1.1 - 27 May 2026

--- a/packages/cht/CHANGELOG.md
+++ b/packages/cht/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-cht
 
-## 1.2.2
+## 1.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.2.1 - 27 May 2026

--- a/packages/claude/CHANGELOG.md
+++ b/packages/claude/CHANGELOG.md
@@ -1,12 +1,12 @@
 # @openfn/language-claude
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
 - faaea95: Update anthropic sdk
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/collections/CHANGELOG.md
+++ b/packages/collections/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-collections
 
-## 0.9.3
+## 0.9.3 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.9.2 - 27 May 2026
@@ -26,7 +26,7 @@
 
 ### Minor Changes
 
-- Add support for project_id on config
+- Add support for project\_id on config
 
 ## 0.8.6 - 14 April 2026
 

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-commcare
 
-## 4.1.2
+## 4.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 4.1.1 - 27 May 2026

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.1 - 11 July 2025
 
-## 3.3.4
+## 3.3.4 - 30 June 2026
 
 ### Patch Changes
 
@@ -402,7 +402,7 @@ content type to JSON.
 ### Minor Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 
 ## 1.9.0 - 23 June 2023
 

--- a/packages/dagu/CHANGELOG.md
+++ b/packages/dagu/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-dagu
 
-## 1.3.2
+## 1.3.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.3.1 - 27 May 2026

--- a/packages/dhis2/CHANGELOG.md
+++ b/packages/dhis2/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-dhis2
 
-## 8.2.0
+## 8.2.0 - 30 June 2026
 
 ### Minor Changes
 
@@ -10,7 +10,7 @@
 ### Patch Changes
 
 - 99b50c3: Fix: DHIS2 schema will not require username/password when using a PAT
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 8.1.1 - 27 May 2026

--- a/packages/divoc/CHANGELOG.md
+++ b/packages/divoc/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-divoc
 
-## 0.2.2
+## 0.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.2.1 - 27 May 2026

--- a/packages/dynamics/CHANGELOG.md
+++ b/packages/dynamics/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-dynamics
 
-## 0.6.2
+## 0.6.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.6.1 - 27 May 2026
@@ -352,7 +352,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/erpnext/CHANGELOG.md
+++ b/packages/erpnext/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-erpnext
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/et-mfr/CHANGELOG.md
+++ b/packages/et-mfr/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-et-mfr
 
-## 1.0.10
+## 1.0.10 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.0.9 - 27 May 2026

--- a/packages/facebook/CHANGELOG.md
+++ b/packages/facebook/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-facebook
 
-## 0.5.2
+## 0.5.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.5.1 - 27 May 2026
@@ -266,7 +266,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/fhir-4/CHANGELOG.md
+++ b/packages/fhir-4/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-fhir-4
 
-## 0.5.5
+## 0.5.5 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.5.4 - 27 May 2026

--- a/packages/fhir-eswatini/CHANGELOG.md
+++ b/packages/fhir-eswatini/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-fhir-eswatini
 
-## 0.8.0
+## 0.8.0 - 30 June 2026
 
 ### Minor Changes
 
@@ -8,7 +8,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
   - @openfn/language-fhir-4@0.5.5
 

--- a/packages/fhir-fr/CHANGELOG.md
+++ b/packages/fhir-fr/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-fhir-fr
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/fhir-ndr-et/CHANGELOG.md
+++ b/packages/fhir-ndr-et/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-fhir-ndr-et
 
-## 0.2.2
+## 0.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
   - @openfn/language-fhir@5.1.2
 

--- a/packages/fhir/CHANGELOG.md
+++ b/packages/fhir/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-fhir
 
-## 5.1.2
+## 5.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 5.1.1 - 27 May 2026

--- a/packages/flutterwave/CHANGELOG.md
+++ b/packages/flutterwave/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-flutterwave
 
-## 1.0.7
+## 1.0.7 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.0.6 - 27 May 2026

--- a/packages/formsg/CHANGELOG.md
+++ b/packages/formsg/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-formsg
 
-## 1.0.11
+## 1.0.11 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.0.10 - 27 May 2026

--- a/packages/gemini/CHANGELOG.md
+++ b/packages/gemini/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-gemini
 
-## 1.0.7
+## 1.0.7 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.0.6 - 27 May 2026

--- a/packages/ghana-bdr/CHANGELOG.md
+++ b/packages/ghana-bdr/CHANGELOG.md
@@ -15,7 +15,7 @@
     long-lived API `token` instead of `username` and `password`. Short-lived
     access tokens are fetched and refreshed automatically.
 
-## 0.2.2
+## 0.2.2 - 30 June 2026
 
 ### Patch Changes
 

--- a/packages/ghana-nia/CHANGELOG.md
+++ b/packages/ghana-nia/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-ghana-nia
 
-## 0.2.2
+## 0.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.2.1 - 27 May 2026

--- a/packages/gmail/CHANGELOG.md
+++ b/packages/gmail/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-gmail
 
-## 3.0.0
+## 3.0.0 - 08 July 2026
 
 ### Major Changes
 
@@ -58,12 +58,12 @@ const contents = [
 getContentsFromMessages({ query: $.query, contents });
 ```
 
-## 2.1.2
+## 2.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 2.1.1 - 27 May 2026

--- a/packages/godata/CHANGELOG.md
+++ b/packages/godata/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-godata
 
-## 3.6.2
+## 3.6.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.6.1 - 27 May 2026

--- a/packages/googledrive/CHANGELOG.md
+++ b/packages/googledrive/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-googledrive
 
-## 3.1.2
+## 3.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.1.1 - 27 May 2026

--- a/packages/googlehealthcare/CHANGELOG.md
+++ b/packages/googlehealthcare/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-googlehealthcare
 
-## 1.2.2
+## 1.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.2.1 - 27 May 2026
@@ -195,6 +195,6 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0

--- a/packages/googlesheets/CHANGELOG.md
+++ b/packages/googlesheets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @openfn/language-googlesheets
 
-## 5.0.0
+## 5.0.0 - 09 July 2026
 
 ### Major Changes
 
@@ -43,11 +43,11 @@
   Callback parameter has been removed from `appendValues()`,
   `batchUpdateValues()`, and `getValues()` in favor of a promise-based API.
 
-## 4.1.2
+## 4.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 4.1.1 - 27 May 2026
@@ -382,7 +382,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/hive/CHANGELOG.md
+++ b/packages/hive/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-hive
 
-## 0.4.2
+## 0.4.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.4.1 - 27 May 2026

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-http
 
-## 7.3.2
+## 7.3.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 7.3.1 - 27 May 2026

--- a/packages/hubtel/CHANGELOG.md
+++ b/packages/hubtel/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-hubtel
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/ibipimo/CHANGELOG.md
+++ b/packages/ibipimo/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-ibipimo
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/ihris/CHANGELOG.md
+++ b/packages/ihris/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-ihris
 
-## 1.2.2
+## 1.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
   - @openfn/language-fhir-4@0.5.5
 

--- a/packages/image-utils/CHANGELOG.md
+++ b/packages/image-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-image-fn
 
+## 1.0.1 - 13 July 2026
+
+### Patch Changes
+
+- 6105d93: Fix adaptor docs
+
 ## 1.0.0 - 08 July 2026
 
 Initial release.

--- a/packages/image-utils/CHANGELOG.md
+++ b/packages/image-utils/CHANGELOG.md
@@ -1,5 +1,5 @@
 # @openfn/language-image-fn
 
-## 1.0.0
+## 1.0.0 - 08 July 2026
 
 Initial release.

--- a/packages/image-utils/ast.json
+++ b/packages/image-utils/ast.json
@@ -1,5 +1,510 @@
 {
-  "operations": [],
+  "operations": [
+    {
+      "name": "resize",
+      "params": [
+        "base64ImgOrBuffer",
+        "options"
+      ],
+      "docs": {
+        "description": "Resize an image to the given dimensions.\nWrites `{ buffer, width, height }` to `state.data`.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "resize($.data.photoBase64, { width: 1200, height: 1600 })"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Base64 string, data URL, Buffer, or resolver fn",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "string"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Buffer"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Function"
+                }
+              ]
+            },
+            "name": "base64ImgOrBuffer"
+          },
+          {
+            "title": "param",
+            "description": null,
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "object"
+              }
+            },
+            "name": "options",
+            "default": "{}"
+          },
+          {
+            "title": "param",
+            "description": "Output width in pixels",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "number"
+              }
+            },
+            "name": "options.width"
+          },
+          {
+            "title": "param",
+            "description": "Output height in pixels",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "number"
+              }
+            },
+            "name": "options.height"
+          },
+          {
+            "title": "param",
+            "description": "Return format: `'buffer'` (default) or `'base64'`",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "UnionType",
+                "elements": [
+                  {
+                    "type": "StringLiteralType",
+                    "value": "buffer"
+                  },
+                  {
+                    "type": "StringLiteralType",
+                    "value": "base64"
+                  }
+                ]
+              }
+            },
+            "name": "options.parseAs",
+            "default": "'buffer'"
+          },
+          {
+            "title": "state",
+            "description": "{ImageState}"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
+    },
+    {
+      "name": "compress",
+      "params": [
+        "base64ImgOrBuffer",
+        "options"
+      ],
+      "docs": {
+        "description": "Compress an image by reducing image quality until it reaches the criteria.\nWrites `{ buffer, size, quality }` to `state.data`.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "compress(state.data.buffer, { maxBytes: 700 * 1024, minQuality: 20 })"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Base64 string, data URL, Buffer, or resolver fn",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "string"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Buffer"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Function"
+                }
+              ]
+            },
+            "name": "base64ImgOrBuffer"
+          },
+          {
+            "title": "param",
+            "description": null,
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "object"
+              }
+            },
+            "name": "options",
+            "default": "{}"
+          },
+          {
+            "title": "param",
+            "description": "Maximum output file size in bytes",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "number"
+              }
+            },
+            "name": "options.maxBytes",
+            "default": "716800"
+          },
+          {
+            "title": "param",
+            "description": "JPEG quality floor (1–100); compression stops here even if maxBytes is not met",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "number"
+              }
+            },
+            "name": "options.minQuality",
+            "default": "20"
+          },
+          {
+            "title": "param",
+            "description": "Return format: `'buffer'` (default) or `'base64'`",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "UnionType",
+                "elements": [
+                  {
+                    "type": "StringLiteralType",
+                    "value": "buffer"
+                  },
+                  {
+                    "type": "StringLiteralType",
+                    "value": "base64"
+                  }
+                ]
+              }
+            },
+            "name": "options.parseAs",
+            "default": "'buffer'"
+          },
+          {
+            "title": "state",
+            "description": "{ImageState}"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
+    },
+    {
+      "name": "stripMetadata",
+      "params": [
+        "base64ImgOrBuffer",
+        "options"
+      ],
+      "docs": {
+        "description": "Strip all EXIF metadata from an image. Output is always a JPEG buffer.\nWrites `{ buffer }` to `state.data`.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "stripMetadata($.data.photoBase64)"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Base64 string, data URL, Buffer, or resolver fn",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "string"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Buffer"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Function"
+                }
+              ]
+            },
+            "name": "base64ImgOrBuffer"
+          },
+          {
+            "title": "param",
+            "description": null,
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "object"
+              }
+            },
+            "name": "options",
+            "default": "{}"
+          },
+          {
+            "title": "param",
+            "description": "Return format: `'buffer'` (default) or `'base64'`",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "UnionType",
+                "elements": [
+                  {
+                    "type": "StringLiteralType",
+                    "value": "buffer"
+                  },
+                  {
+                    "type": "StringLiteralType",
+                    "value": "base64"
+                  }
+                ]
+              }
+            },
+            "name": "options.parseAs",
+            "default": "'buffer'"
+          },
+          {
+            "title": "state",
+            "description": "{ImageState}"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
+    },
+    {
+      "name": "embedMetadata",
+      "params": [
+        "base64ImgOrBuffer",
+        "exifObj",
+        "options"
+      ],
+      "docs": {
+        "description": "Embed EXIF metadata into a JPEG image.\nWrites `{ buffer }` to `state.data`.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "embedMetadata($.data.buffer, { UserComment: 'patient-id=42' })\nembedMetadata($.data.buffer, { UserComment: 'patient-id=42', Make: 'OpenFn' }, { parseAs: 'base64' })"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Base64 string, data URL, Buffer, or resolver fn",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "string"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Buffer"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Function"
+                }
+              ]
+            },
+            "name": "base64ImgOrBuffer"
+          },
+          {
+            "title": "param",
+            "description": "EXIF key-value pairs; keys must be valid EXIF tag names (e.g. UserComment, Make, Model)",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "exifObj"
+          },
+          {
+            "title": "param",
+            "description": null,
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "NameExpression",
+                "name": "object"
+              }
+            },
+            "name": "options",
+            "default": "{}"
+          },
+          {
+            "title": "param",
+            "description": "Return format: `'buffer'` (default) or `'base64'`",
+            "type": {
+              "type": "OptionalType",
+              "expression": {
+                "type": "UnionType",
+                "elements": [
+                  {
+                    "type": "StringLiteralType",
+                    "value": "buffer"
+                  },
+                  {
+                    "type": "StringLiteralType",
+                    "value": "base64"
+                  }
+                ]
+              }
+            },
+            "name": "options.parseAs",
+            "default": "'buffer'"
+          },
+          {
+            "title": "state",
+            "description": "{ImageState}"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": false
+    },
+    {
+      "name": "metadata",
+      "params": [
+        "base64ImgOrBuffer"
+      ],
+      "docs": {
+        "description": "Read image metadata without modifying the image.\nWrites `{ width, height, orientation, size, exif }` to `state.data`.\n`exif` is a flat object of human-readable EXIF tag names (e.g. `{ Make, Model, GPSLatitude, UserComment }`).\n`UserComment` has the `ASCII\\0\\0\\0` encoding prefix stripped. Images with no EXIF return `exif: {}`.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "metadata($.data.photoBase64)\nfn(state => {\n  if (state.data.size > 700 * 1024) { ... }\n  return state;\n})"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Base64 string, data URL, Buffer, or resolver fn",
+            "type": {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "string"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Buffer"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Function"
+                }
+              ]
+            },
+            "name": "base64ImgOrBuffer"
+          },
+          {
+            "title": "state",
+            "description": "{ImageState}"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    }
+  ],
   "exports": [],
   "common": [
     {

--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/language-image-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenFn image-utils adaptor",
   "type": "module",
   "exports": {

--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -18,8 +18,7 @@
     "test:integration": "mocha --experimental-specifier-resolution=node --no-warnings test/integration.js",
     "clean": "rimraf dist types docs",
     "pack": "pnpm pack --pack-destination ../../dist",
-    "lint": "eslint src",
-    "benchmark": "echo 'benchmark removed — jsquash dependency dropped'"
+    "lint": "eslint src"
   },
   "author": "Open Function Group",
   "license": "LGPLv3",

--- a/packages/image-utils/src/Adaptor.js
+++ b/packages/image-utils/src/Adaptor.js
@@ -1,13 +1,12 @@
 import { expandReferences } from '@openfn/language-common/util';
 import { composeNextState } from '@openfn/language-common';
 import {
+  stripImage,
   resizeImage,
   compressImage,
-  stripImage,
-  embedImageMetadata,
   getImageMetadata,
   decodeBase64Image,
-  getExifData,
+  embedImageMetadata,
 } from './Utils.js';
 
 function resolveInput(raw) {
@@ -31,8 +30,9 @@ function applyParseAs(result, parseAs) {
 /**
  * Resize an image to the given dimensions.
  * Writes `{ buffer, width, height }` to `state.data`.
+ * @public
  * @example
- * resize(state.data.photoBase64, { width: 1200, height: 1600 })
+ * resize($.data.photoBase64, { width: 1200, height: 1600 })
  * @function
  * @param {string|Buffer|Function} base64ImgOrBuffer - Base64 string, data URL, Buffer, or resolver fn
  * @param {object} [options={}]
@@ -63,6 +63,7 @@ export function resize(base64ImgOrBuffer, options = {}) {
 /**
  * Compress an image by reducing image quality until it reaches the criteria.
  * Writes `{ buffer, size, quality }` to `state.data`.
+ * @public
  * @example
  * compress(state.data.buffer, { maxBytes: 700 * 1024, minQuality: 20 })
  * @function
@@ -81,6 +82,7 @@ export function compress(base64ImgOrBuffer, options = {}) {
       base64ImgOrBuffer,
       options,
     );
+    const { maxBytes = 700 * 1024, minQuality = 20 } = resolvedOptions;
     const result = await compressImage(
       resolveInput(resolvedImg),
       resolvedOptions,
@@ -95,8 +97,9 @@ export function compress(base64ImgOrBuffer, options = {}) {
 /**
  * Strip all EXIF metadata from an image. Output is always a JPEG buffer.
  * Writes `{ buffer }` to `state.data`.
+ * @public
  * @example
- * stripMetadata(state.data.photoBase64)
+ * stripMetadata($.data.photoBase64)
  * @function
  * @param {string|Buffer|Function} base64ImgOrBuffer - Base64 string, data URL, Buffer, or resolver fn
  * @param {object} [options={}]
@@ -122,9 +125,10 @@ export function stripMetadata(base64ImgOrBuffer, options = {}) {
 /**
  * Embed EXIF metadata into a JPEG image.
  * Writes `{ buffer }` to `state.data`.
+ * @public
  * @example
- * embedMetadata(state.data.buffer, { UserComment: 'patient-id=42' })
- * embedMetadata(state.data.buffer, { UserComment: 'patient-id=42', Make: 'OpenFn' }, { parseAs: 'base64' })
+ * embedMetadata($.data.buffer, { UserComment: 'patient-id=42' })
+ * embedMetadata($.data.buffer, { UserComment: 'patient-id=42', Make: 'OpenFn' }, { parseAs: 'base64' })
  * @function
  * @param {string|Buffer|Function} base64ImgOrBuffer - Base64 string, data URL, Buffer, or resolver fn
  * @param {object} exifObj - EXIF key-value pairs; keys must be valid EXIF tag names (e.g. UserComment, Make, Model)
@@ -154,8 +158,9 @@ export function embedMetadata(base64ImgOrBuffer, exifObj, options = {}) {
  * Writes `{ width, height, orientation, size, exif }` to `state.data`.
  * `exif` is a flat object of human-readable EXIF tag names (e.g. `{ Make, Model, GPSLatitude, UserComment }`).
  * `UserComment` has the `ASCII\0\0\0` encoding prefix stripped. Images with no EXIF return `exif: {}`.
+ * @public
  * @example
- * metadata(state.data.photoBase64)
+ * metadata($.data.photoBase64)
  * fn(state => {
  *   if (state.data.size > 700 * 1024) { ... }
  *   return state;
@@ -172,7 +177,7 @@ export function metadata(base64ImgOrBuffer) {
     return composeNextState(state, result);
   };
 }
-export { getExifData };
+
 export {
   as,
   combine,

--- a/packages/image-utils/src/Utils.js
+++ b/packages/image-utils/src/Utils.js
@@ -73,7 +73,7 @@ export function embedImageMetadata(inputBuffer, kvPairs) {
 }
 
 export async function compressImage(inputBuffer, options = {}) {
-  const { maxBytes = 700 * 1024, minQuality = 20 } = options;
+  const { maxBytes, minQuality } = options;
   const kb = n => `${(n / 1024).toFixed(1)}KB`;
 
   const image = await Jimp.read(inputBuffer);
@@ -120,6 +120,7 @@ export async function getImageMetadata(inputBuffer) {
     exif: getExifData(inputBuffer),
   };
 }
+
 export function getExifData(inputBuffer, options = {}) {
   const { mergeOutput = true } = options;
   const exifObj = piexif.load(inputBuffer.toString('binary'));

--- a/packages/image-utils/test/integration.js
+++ b/packages/image-utils/test/integration.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { execute, assert } from '@openfn/language-common';
 import { toBuf, toBase64Str, saveBase64Image } from './helpers.js';
-import { decodeBase64Image } from '../src/Utils.js';
+import { decodeBase64Image, getExifData } from '../src/Utils.js';
 import {
   fn,
   each,
@@ -9,7 +9,6 @@ import {
   combine,
   dateFns,
   compress,
-  getExifData,
   embedMetadata,
 } from '../src/Adaptor.js';
 

--- a/packages/inform/CHANGELOG.md
+++ b/packages/inform/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-inform
 
-## 1.3.2
+## 1.3.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.3.1 - 27 May 2026

--- a/packages/intuit/CHANGELOG.md
+++ b/packages/intuit/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-intuit
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/khanacademy/CHANGELOG.md
+++ b/packages/khanacademy/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-khanacademy
 
-## 0.6.2
+## 0.6.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.6.1 - 27 May 2026

--- a/packages/kobotoolbox/CHANGELOG.md
+++ b/packages/kobotoolbox/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-kobotoolbox
 
-## 4.3.2
+## 4.3.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 4.3.1 - 27 May 2026

--- a/packages/lamisplus/CHANGELOG.md
+++ b/packages/lamisplus/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-lamisplus
 
-## 0.2.2
+## 0.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.2.1 - 27 May 2026

--- a/packages/magpi/CHANGELOG.md
+++ b/packages/magpi/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-magpi
 
-## 1.3.2
+## 1.3.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.3.1 - 27 May 2026

--- a/packages/mailchimp/CHANGELOG.md
+++ b/packages/mailchimp/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-mailchimp
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/mailgun/CHANGELOG.md
+++ b/packages/mailgun/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-mailgun
 
-## 0.7.2
+## 0.7.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.7.1 - 27 May 2026

--- a/packages/maximo/CHANGELOG.md
+++ b/packages/maximo/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-maximo
 
-## 0.6.2
+## 0.6.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.6.1 - 27 May 2026

--- a/packages/medicmobile/CHANGELOG.md
+++ b/packages/medicmobile/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-medicmobile
 
-## 0.6.2
+## 0.6.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.6.1 - 27 May 2026

--- a/packages/memento/CHANGELOG.md
+++ b/packages/memento/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-memento
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/minio/CHANGELOG.md
+++ b/packages/minio/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-minio
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/mogli/CHANGELOG.md
+++ b/packages/mogli/CHANGELOG.md
@@ -1,10 +1,10 @@
 v0.1.6
 
-## 0.7.2
+## 0.7.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.7.1 - 27 May 2026

--- a/packages/mojatax/CHANGELOG.md
+++ b/packages/mojatax/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-mojatax
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/mongodb/CHANGELOG.md
+++ b/packages/mongodb/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-mongodb
 
-## 2.2.2
+## 2.2.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 2.2.1 - 27 May 2026

--- a/packages/monnify/CHANGELOG.md
+++ b/packages/monnify/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-monnify
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/motherduck/CHANGELOG.md
+++ b/packages/motherduck/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-motherduck
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/mpesa/CHANGELOG.md
+++ b/packages/mpesa/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-mpesa
 
-## 1.2.2
+## 1.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.2.1 - 27 May 2026
@@ -151,7 +151,7 @@
 
 - 99e4b48: - Better handling of HTML content in http requests
   - When logging HTTP requests, include query parameters
-- d1f7851: Fixed the title for the consumer_secret on the configuration schema
+- d1f7851: Fixed the title for the consumer\_secret on the configuration schema
 - Updated dependencies \[99e4b48]
 - Updated dependencies \[13bf08f]
   - @openfn/language-common@2.4.0

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-msgraph
 
-## 0.9.2
+## 0.9.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.9.1 - 27 May 2026
@@ -393,7 +393,7 @@
 ### Patch Changes
 
 - aad9549: Ensure that standard OAuth2 credentials with snake-cased
-  "access_token" keys can be used for OAuth2-reliant adaptors
+  "access\_token" keys can be used for OAuth2-reliant adaptors
 - Updated dependencies \[aad9549]
   - @openfn/language-common@1.10.0
 

--- a/packages/mssql/CHANGELOG.md
+++ b/packages/mssql/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-mssql
 
-## 7.1.2
+## 7.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 7.1.1 - 27 May 2026

--- a/packages/msupply/CHANGELOG.md
+++ b/packages/msupply/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-msupply
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/mtn-momo/CHANGELOG.md
+++ b/packages/mtn-momo/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-mtn-momo
 
-## 1.2.2
+## 1.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.2.1 - 27 May 2026

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-mysql
 
-## 4.1.2
+## 4.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 4.1.1 - 27 May 2026

--- a/packages/nexmo/CHANGELOG.md
+++ b/packages/nexmo/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-nexmo
 
-## 0.6.2
+## 0.6.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.6.1 - 27 May 2026

--- a/packages/ocl/CHANGELOG.md
+++ b/packages/ocl/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-ocl
 
-## 1.3.2
+## 1.3.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.3.1 - 27 May 2026

--- a/packages/odk/CHANGELOG.md
+++ b/packages/odk/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-odk
 
-## 3.1.2
+## 3.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.1.1 - 27 May 2026

--- a/packages/odoo/CHANGELOG.md
+++ b/packages/odoo/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-odoo
 
-## 2.2.2
+## 2.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 2.2.1 - 27 May 2026

--- a/packages/openboxes/CHANGELOG.md
+++ b/packages/openboxes/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-openboxes
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/opencrvs/CHANGELOG.md
+++ b/packages/opencrvs/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-opencrvs
 
-## 1.2.2
+## 1.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
   - @openfn/language-fhir-4@0.5.5
 

--- a/packages/openelis/CHANGELOG.md
+++ b/packages/openelis/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-openelis
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/openfn/CHANGELOG.md
+++ b/packages/openfn/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-openfn
 
-## 3.1.2
+## 3.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.1.1 - 27 May 2026

--- a/packages/openhim/CHANGELOG.md
+++ b/packages/openhim/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-openhim
 
-## 2.1.2
+## 2.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 2.1.1 - 27 May 2026

--- a/packages/openimis/CHANGELOG.md
+++ b/packages/openimis/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-openimis
 
-## 3.1.2
+## 3.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.1.1 - 27 May 2026

--- a/packages/openlmis/CHANGELOG.md
+++ b/packages/openlmis/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-openlmis
 
-## 1.2.2
+## 1.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.2.1 - 27 May 2026

--- a/packages/openmrs/CHANGELOG.md
+++ b/packages/openmrs/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-openmrs
 
-## 5.4.2
+## 5.4.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 5.4.1 - 27 May 2026

--- a/packages/openspp/CHANGELOG.md
+++ b/packages/openspp/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-openspp
 
-## 3.1.2
+## 3.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.1.1 - 27 May 2026

--- a/packages/pdfshift/CHANGELOG.md
+++ b/packages/pdfshift/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-pdfshift
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/pesapal/CHANGELOG.md
+++ b/packages/pesapal/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-pesapal
 
-## 1.2.2
+## 1.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.2.1 - 27 May 2026

--- a/packages/ping/CHANGELOG.md
+++ b/packages/ping/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-ping
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-postgresql
 
-## 8.1.2
+## 8.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 8.1.1 - 27 May 2026

--- a/packages/primero/CHANGELOG.md
+++ b/packages/primero/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-primero
 
-## 4.1.2
+## 4.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 4.1.1 - 27 May 2026

--- a/packages/progres/CHANGELOG.md
+++ b/packages/progres/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-progres
 
-## 2.1.2
+## 2.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 2.1.1 - 27 May 2026

--- a/packages/puntosolidario-rd/CHANGELOG.md
+++ b/packages/puntosolidario-rd/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-puntosolidario-rd
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/rapidpro/CHANGELOG.md
+++ b/packages/rapidpro/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-rapidpro
 
-## 2.1.2
+## 2.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 2.1.1 - 27 May 2026

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-redis
 
-## 1.4.2
+## 1.4.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.4.1 - 27 May 2026

--- a/packages/resourcemap/CHANGELOG.md
+++ b/packages/resourcemap/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-resourcemap
 
-## 0.5.2
+## 0.5.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.5.1 - 27 May 2026

--- a/packages/salesforce/CHANGELOG.md
+++ b/packages/salesforce/CHANGELOG.md
@@ -1,25 +1,25 @@
 # @openfn/language-salesforce
 
-## 9.1.5
+## 9.1.5 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
-## 9.1.4
+## 9.1.4 - 25 June 2026
 
 ### Patch Changes
 
 - Fix connection
 
-## 9.1.3
+## 9.1.3 - 25 June 2026
 
 ### Patch Changes
 
 - Fix connection hanging on oauth clients
 
-## 9.1.2
+## 9.1.2 - 25 June 2026
 
 ### Patch Changes
 

--- a/packages/satusehat/CHANGELOG.md
+++ b/packages/satusehat/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-satusehat
 
-## 3.1.2
+## 3.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.1.1 - 27 May 2026

--- a/packages/senaite/CHANGELOG.md
+++ b/packages/senaite/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-senaite
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-sftp
 
-## 3.1.2
+## 3.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.1.1 - 27 May 2026

--- a/packages/siuben-rd/CHANGELOG.md
+++ b/packages/siuben-rd/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-siuben-rd
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/stripe/CHANGELOG.md
+++ b/packages/stripe/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-stripe
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/sunbird-rc/CHANGELOG.md
+++ b/packages/sunbird-rc/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-sunbird-rc
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/surveycto/CHANGELOG.md
+++ b/packages/surveycto/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-surveycto
 
-## 3.1.2
+## 3.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 3.1.1 - 27 May 2026

--- a/packages/telerivet/CHANGELOG.md
+++ b/packages/telerivet/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-telerivet
 
-## 0.4.2
+## 0.4.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.4.1 - 27 May 2026

--- a/packages/twilio/CHANGELOG.md
+++ b/packages/twilio/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-twilio
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/varo/CHANGELOG.md
+++ b/packages/varo/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-varo
 
-## 2.2.2
+## 2.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 2.2.1 - 27 May 2026

--- a/packages/vtiger/CHANGELOG.md
+++ b/packages/vtiger/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-vtiger
 
-## 1.4.2
+## 1.4.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.4.1 - 27 May 2026

--- a/packages/whatsapp/CHANGELOG.md
+++ b/packages/whatsapp/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-whatsapp
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/wigal-sms/CHANGELOG.md
+++ b/packages/wigal-sms/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-wigal-sms
 
-## 0.2.2
+## 0.2.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.2.1 - 27 May 2026

--- a/packages/zata/CHANGELOG.md
+++ b/packages/zata/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @openfn/language-zata
 
-## 1.1.2
+## 1.1.2 - 30 June 2026
 
 ### Patch Changes
 
 - c5f8728: Update undici dependency
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 1.1.1 - 27 May 2026

--- a/packages/zoho/CHANGELOG.md
+++ b/packages/zoho/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @openfn/language-zoho
 
-## 0.5.2
+## 0.5.2 - 30 June 2026
 
 ### Patch Changes
 
-- Updated dependencies [c5f8728]
+- Updated dependencies \[c5f8728]
   - @openfn/language-common@3.3.4
 
 ## 0.5.1 - 27 May 2026


### PR DESCRIPTION
## Summary

Currently [image-utils-docs](https://docs.openfn.org/adaptors/packages/image-utils-docs) are not generated for the adaptor functions. This pr  adds`@public` tag in all image-utils Adaptor functions to generate docs. 

## Details

- Add `@public` tag in Adaptor functions
- Remove `getExifData` from Adaptor export. `metadata` function is already using it internally
- Move defaults for `maxBytes` and `minQuality`  from util function to `compress` function
- Update integration test to use `getExifData` from `Utils.js`
- Remove `benchmark` command in package.json script
- Build `ast.json`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [x] Have you ticked a box under AI Usage?
