### PR TITLE
Surface Salesforce SOAP login errors

### DIFF
--- a/.changeset/quiet-clouds-login.md
+++ b/.changeset/quiet-clouds-login.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-salesforce': patch
+---
+
+Surface Salesforce SOAP login errors during username/password authentication.

--- a/packages/salesforce/src/Adaptor.js
+++ b/packages/salesforce/src/Adaptor.js
@@ -87,7 +87,7 @@ const connect = async state => {
         console.error(error.message);
         throwError('FAILED_AUTH', {
           fix: 'Check your username, password, and security token',
-          message: `Failed to connect to salesforce as ${username}`,
+          message: error.message,
         });
       });
   }

--- a/packages/salesforce/test/Adaptor.test.js
+++ b/packages/salesforce/test/Adaptor.test.js
@@ -1,5 +1,89 @@
 import { expect } from 'chai';
-import { create, upsert, query, http, setMockConnection } from '../src/index.js';
+import nock from 'nock';
+import {
+  create,
+  execute,
+  upsert,
+  query,
+  http,
+  setMockConnection,
+} from '../src/index.js';
+
+describe('execute', () => {
+  const loginUrl = 'https://login.salesforce.com';
+  const username = 'some@email.org';
+  const salesforceError =
+    'INVALID_OPERATION: SOAP API login() is disabled by default in this org. Contact the org administrator to enable SOAP API login().';
+
+  let originalConsoleInfo;
+  let originalConsoleError;
+  let infoLogs;
+  let errorLogs;
+
+  beforeEach(() => {
+    setMockConnection(null);
+    nock.disableNetConnect();
+
+    originalConsoleInfo = console.info;
+    originalConsoleError = console.error;
+    infoLogs = [];
+    errorLogs = [];
+    console.info = (...args) => infoLogs.push(args);
+    console.error = (...args) => errorLogs.push(args);
+  });
+
+  afterEach(() => {
+    console.info = originalConsoleInfo;
+    console.error = originalConsoleError;
+    nock.cleanAll();
+    nock.enableNetConnect();
+    setMockConnection(null);
+  });
+
+  it('passes through Salesforce SOAP login errors', async () => {
+    const scope = nock(loginUrl)
+      .post('/services/Soap/u/64.0')
+      .reply(
+        500,
+        `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+          <soapenv:Body>
+            <soapenv:Fault>
+              <faultcode>sf:INVALID_OPERATION</faultcode>
+              <faultstring>${salesforceError}</faultstring>
+            </soapenv:Fault>
+          </soapenv:Body>
+        </soapenv:Envelope>`,
+        { 'Content-Type': 'text/xml' },
+      );
+
+    let thrownError;
+    try {
+      await execute()({
+        configuration: {
+          loginUrl,
+          username,
+          password: 'password',
+          securityToken: 'token',
+          apiVersion: '64.0',
+        },
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(scope.isDone()).to.equal(true);
+    expect(infoLogs).to.deep.include([
+      `Attempting Salesforce connection for user: ${username}`,
+    ]);
+    expect(errorLogs).to.deep.equal([[salesforceError]]);
+    expect(thrownError).to.be.instanceOf(Error);
+    expect(thrownError.message).to.equal(salesforceError);
+    expect(thrownError.code).to.equal('FAILED_AUTH');
+    expect(thrownError.fix).to.equal(
+      'Check your username, password, and security token',
+    );
+  });
+});
 
 describe('Adaptor', () => {
   describe('get', () => {


### PR DESCRIPTION
## Summary

Improve error diagnostics during Salesforce authentication by surfacing the actual SOAP error message instead of a generic message. This helps users understand why login is failing (e.g., SOAP API disabled). Includes test coverage for SOAP fault handling.

Fixes #1715

## Details

Updated the username/password authentication path in the Salesforce adaptor’s internal `connect()` function.

When JSforce login fails, the adaptor previously logged the Salesforce error but replaced it in the thrown `FAILED_AUTH` error with:

`Failed to connect to salesforce as <username>`

The adaptor now passes `error.message` to `throwError()`. This preserves Salesforce’s actionable explanation while retaining:

- Error code: `FAILED_AUTH`
- Existing credential-check guidance in `error.fix`
- Existing error logging

This is important for Salesforce orgs where SOAP `login()` is disabled. Users will now receive the actual Salesforce message, such as `INVALID_OPERATION: SOAP API login() is disabled...`, rather than a generic authentication failure.

Added a Nock regression test that mocks a v64.0 SOAP login fault and verifies:

- The attempted username is logged.
- The Salesforce error message is logged.
- The rejected error exposes the Salesforce message.
- The error code remains `FAILED_AUTH`.
- The existing fix metadata is preserved.
- No live Salesforce requests are made.

OAuth authentication, public exports, schemas, metadata, and API-version handling remain unchanged.

Added a patch changeset for `@openfn/language-salesforce`.
## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [x ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [ ] Have you ticked a box under AI Usage?
