### PR TITLE
Use native fetch transport for Google & Claude adaptors

### DIFF
--- a/.changeset/fresh-taxis-fetch.md
+++ b/.changeset/fresh-taxis-fetch.md
@@ -1,0 +1,8 @@
+---
+'@openfn/language-claude': patch
+'@openfn/language-gmail': patch
+'@openfn/language-googledrive': patch
+'@openfn/language-googlesheets': patch
+---
+
+Use Node's native fetch transport to improve resilience to premature HTTP stream closures.

--- a/packages/claude/src/Adaptor.js
+++ b/packages/claude/src/Adaptor.js
@@ -26,6 +26,9 @@ export function createClient(state) {
 
   client = new Anthropic({
     apiKey,
+    // Use Node's native fetch transport to avoid node-fetch stream handling.
+    // See https://github.com/OpenFn/adaptors/issues/1707
+    fetch: globalThis.fetch,
   });
 
   return state;

--- a/packages/claude/test/transport.test.js
+++ b/packages/claude/test/transport.test.js
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import {
+  MockAgent,
+  getGlobalDispatcher,
+  setGlobalDispatcher,
+} from 'undici';
+import { execute, prompt } from '../src/Adaptor.js';
+
+const apiOrigin = 'https://api.anthropic.com';
+const messageRequest = { path: '/v1/messages', method: 'POST' };
+const state = { configuration: { apiKey: 'test-api-key' } };
+
+const prematureClose = () =>
+  Object.assign(new Error('Premature close'), {
+    code: 'ERR_STREAM_PREMATURE_CLOSE',
+  });
+
+const messageResponse = {
+  id: 'msg_test',
+  type: 'message',
+  role: 'assistant',
+  model: 'claude-sonnet-4-6',
+  content: [{ type: 'text', text: 'Recovered.' }],
+  stop_reason: 'end_turn',
+  stop_sequence: null,
+  usage: { input_tokens: 1, output_tokens: 1 },
+};
+
+describe('native fetch transport', () => {
+  let mockAgent;
+  let previousDispatcher;
+  let pool;
+
+  beforeEach(() => {
+    previousDispatcher = getGlobalDispatcher();
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
+    pool = mockAgent.get(apiOrigin);
+  });
+
+  afterEach(async () => {
+    setGlobalDispatcher(previousDispatcher);
+    await mockAgent.close();
+  });
+
+  it('recovers from a premature close using the SDK retry policy', async () => {
+    pool.intercept(messageRequest).replyWithError(prematureClose());
+    pool.intercept(messageRequest).reply(200, messageResponse, {
+      headers: {
+        'content-type': 'application/json',
+        'request-id': 'req_test',
+      },
+    });
+
+    const result = await execute(prompt('Reply briefly.'))(state);
+
+    expect(result.data).to.deep.equal(messageResponse);
+    expect(mockAgent.pendingInterceptors()).to.be.empty;
+  });
+
+  it('surfaces a premature close after the retry budget is exhausted', async () => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      pool.intercept(messageRequest).replyWithError(prematureClose());
+    }
+
+    let error;
+    try {
+      await execute(prompt('Reply briefly.'))(state);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal('Connection error.');
+    expect(error.cause?.cause?.code).to.equal('ERR_STREAM_PREMATURE_CLOSE');
+    expect(mockAgent.pendingInterceptors()).to.be.empty;
+  });
+});

--- a/packages/gmail/src/Utils.js
+++ b/packages/gmail/src/Utils.js
@@ -191,7 +191,13 @@ export function createConnection(state) {
   const auth = new google.auth.OAuth2();
   auth.credentials = { access_token };
 
-  gmail = google.gmail({ version: 'v1', auth });
+  gmail = google.gmail({
+    version: 'v1',
+    auth,
+    // Use Node's native fetch transport to avoid node-fetch stream handling.
+    // See https://github.com/OpenFn/adaptors/issues/1707
+    fetchImplementation: globalThis.fetch,
+  });
 
   return state;
 }

--- a/packages/gmail/test/transport.test.js
+++ b/packages/gmail/test/transport.test.js
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import {
+  MockAgent,
+  getGlobalDispatcher,
+  setGlobalDispatcher,
+} from 'undici';
+import {
+  execute,
+  getContentsFromMessages,
+  sendMessage,
+} from '../src/Adaptor.js';
+
+const apiOrigin = 'https://gmail.googleapis.com';
+const listRequest = {
+  path: /\/gmail\/v1\/users\/me\/messages/,
+  method: 'GET',
+};
+const sendRequest = {
+  path: /\/gmail\/v1\/users\/me\/messages\/send/,
+  method: 'POST',
+};
+const state = { configuration: { access_token: 'test-access-token' } };
+
+const prematureClose = () =>
+  Object.assign(new Error('Premature close'), {
+    code: 'ERR_STREAM_PREMATURE_CLOSE',
+  });
+
+describe('native fetch transport', () => {
+  let mockAgent;
+  let previousDispatcher;
+  let pool;
+
+  beforeEach(() => {
+    previousDispatcher = getGlobalDispatcher();
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
+    pool = mockAgent.get(apiOrigin);
+  });
+
+  afterEach(async () => {
+    setGlobalDispatcher(previousDispatcher);
+    await mockAgent.close();
+  });
+
+  it('retries a safe request after a premature close', async () => {
+    pool.intercept(listRequest).replyWithError(prematureClose());
+    pool.intercept(listRequest).reply(200, { messages: [] }, {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await execute(
+      getContentsFromMessages({ query: 'subject:test', contents: [] }),
+    )(state);
+
+    expect(result.data).to.deep.equal([]);
+    expect(mockAgent.pendingInterceptors()).to.be.empty;
+  });
+
+  it('surfaces an error after the retry budget is exhausted', async () => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      pool.intercept(listRequest).replyWithError(prematureClose());
+    }
+
+    let error;
+    try {
+      await execute(
+        getContentsFromMessages({ query: 'subject:test', contents: [] }),
+      )(state);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.include('fetch failed');
+    expect(mockAgent.pendingInterceptors()).to.be.empty;
+  });
+
+  it('does not replay sendMessage after an ambiguous transport failure', async () => {
+    pool.intercept(sendRequest).replyWithError(prematureClose());
+    pool.intercept(sendRequest).reply(200, { id: 'unexpected-retry' }, {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    let error;
+    try {
+      await execute(
+        sendMessage({
+          to: 'test@example.com',
+          subject: 'Test',
+          body: 'Test body',
+        }),
+      )(state);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.include('fetch failed');
+    expect(mockAgent.pendingInterceptors()).to.have.lengthOf(1);
+  });
+});

--- a/packages/googledrive/src/Adaptor.js
+++ b/packages/googledrive/src/Adaptor.js
@@ -29,7 +29,13 @@ function createConnection(state) {
   const { accessToken } = state.configuration;
   const auth = new google.auth.OAuth2();
   auth.credentials = { access_token: accessToken };
-  client = google.drive({ version: 'v3', auth });
+  client = google.drive({
+    version: 'v3',
+    auth,
+    // Use Node's native fetch transport to avoid node-fetch stream handling.
+    // See https://github.com/OpenFn/adaptors/issues/1707
+    fetchImplementation: globalThis.fetch,
+  });
   return state;
 }
 

--- a/packages/googledrive/test/transport.test.js
+++ b/packages/googledrive/test/transport.test.js
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import {
+  MockAgent,
+  getGlobalDispatcher,
+  setGlobalDispatcher,
+} from 'undici';
+import { create, execute, list } from '../src/Adaptor.js';
+
+const apiOrigin = 'https://www.googleapis.com';
+const listRequest = {
+  path: /\/drive\/v3\/files/,
+  method: 'GET',
+};
+const createRequest = {
+  path: /\/upload\/drive\/v3\/files/,
+  method: 'POST',
+};
+const state = { configuration: { access_token: 'test-access-token' } };
+
+const prematureClose = () =>
+  Object.assign(new Error('Premature close'), {
+    code: 'ERR_STREAM_PREMATURE_CLOSE',
+  });
+
+describe('native fetch transport', () => {
+  let mockAgent;
+  let previousDispatcher;
+  let pool;
+
+  beforeEach(() => {
+    previousDispatcher = getGlobalDispatcher();
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
+    pool = mockAgent.get(apiOrigin);
+  });
+
+  afterEach(async () => {
+    setGlobalDispatcher(previousDispatcher);
+    await mockAgent.close();
+  });
+
+  it('retries a safe request after a premature close', async () => {
+    pool.intercept(listRequest).replyWithError(prematureClose());
+    pool.intercept(listRequest).reply(200, { files: [] }, {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await execute(list('folder123'))(state);
+
+    expect(result.data).to.deep.equal([]);
+    expect(mockAgent.pendingInterceptors()).to.be.empty;
+  });
+
+  it('surfaces a premature close after the retry budget is exhausted', async () => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      pool.intercept(listRequest).replyWithError(prematureClose());
+    }
+
+    let error;
+    try {
+      await execute(list('folder123'))(state);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal('fetch failed');
+    expect(error.cause?.cause?.code).to.equal('ERR_STREAM_PREMATURE_CLOSE');
+    expect(mockAgent.pendingInterceptors()).to.be.empty;
+  });
+
+  it('does not replay create after an ambiguous transport failure', async () => {
+    pool.intercept(createRequest).replyWithError(prematureClose());
+    pool.intercept(createRequest).reply(200, { id: 'unexpected-retry' }, {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    let error;
+    try {
+      await execute(create(Buffer.from('file').toString('base64'), 'file.txt'))(
+        state,
+      );
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal('fetch failed');
+    expect(mockAgent.pendingInterceptors()).to.have.lengthOf(1);
+  });
+});

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -42,7 +42,8 @@
     "deep-eql": "4.1.1",
     "nock": "13.2.9",
     "rimraf": "3.0.2",
-    "sinon": "^21.1.2"
+    "sinon": "^21.1.2",
+    "undici": "^7.28.0"
   },
   "type": "module",
   "types": "types/index.d.ts",

--- a/packages/googlesheets/src/Adaptor.js
+++ b/packages/googlesheets/src/Adaptor.js
@@ -17,7 +17,13 @@ function createConnection(state) {
   const auth = new google.auth.OAuth2();
   auth.credentials = { access_token: accessToken };
 
-  client = google.sheets({ version: 'v4', auth });
+  client = google.sheets({
+    version: 'v4',
+    auth,
+    // Use Node's native fetch transport to avoid node-fetch stream handling.
+    // See https://github.com/OpenFn/adaptors/issues/1707
+    fetchImplementation: globalThis.fetch,
+  });
   return state;
 }
 

--- a/packages/googlesheets/test/transport.test.js
+++ b/packages/googlesheets/test/transport.test.js
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import {
+  MockAgent,
+  getGlobalDispatcher,
+  setGlobalDispatcher,
+} from 'undici';
+import {
+  appendValues,
+  execute,
+  getValues,
+} from '../src/Adaptor.js';
+
+const apiOrigin = 'https://sheets.googleapis.com';
+const getRequest = {
+  path: /\/v4\/spreadsheets\/sheet123\/values\//,
+  method: 'GET',
+};
+const appendRequest = {
+  path: /\/v4\/spreadsheets\/sheet123\/values\/.*:append/,
+  method: 'POST',
+};
+const state = { configuration: { access_token: 'test-access-token' } };
+
+const prematureClose = () =>
+  Object.assign(new Error('Premature close'), {
+    code: 'ERR_STREAM_PREMATURE_CLOSE',
+  });
+
+describe('native fetch transport', () => {
+  let mockAgent;
+  let previousDispatcher;
+  let pool;
+
+  beforeEach(() => {
+    previousDispatcher = getGlobalDispatcher();
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
+    pool = mockAgent.get(apiOrigin);
+  });
+
+  afterEach(async () => {
+    setGlobalDispatcher(previousDispatcher);
+    await mockAgent.close();
+  });
+
+  it('retries a safe request after a premature close', async () => {
+    pool.intercept(getRequest).replyWithError(prematureClose());
+    pool.intercept(getRequest).reply(200, { values: [['recovered']] }, {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await execute(getValues('sheet123', 'Sheet1!A1'))(state);
+
+    expect(result.data).to.deep.equal({ values: [['recovered']] });
+    expect(mockAgent.pendingInterceptors()).to.be.empty;
+  });
+
+  it('surfaces a premature close after the retry budget is exhausted', async () => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      pool.intercept(getRequest).replyWithError(prematureClose());
+    }
+
+    let error;
+    try {
+      await execute(getValues('sheet123', 'Sheet1!A1'))(state);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal('fetch failed');
+    expect(error.cause?.cause?.code).to.equal('ERR_STREAM_PREMATURE_CLOSE');
+    expect(mockAgent.pendingInterceptors()).to.be.empty;
+  });
+
+  it('does not replay appendValues after an ambiguous transport failure', async () => {
+    pool.intercept(appendRequest).replyWithError(prematureClose());
+    pool.intercept(appendRequest).reply(200, { updates: {} }, {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    let error;
+    try {
+      await execute(
+        appendValues('sheet123', 'Sheet1!A1:B1', [['a', 'b']]),
+      )(state);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal('fetch failed');
+    expect(mockAgent.pendingInterceptors()).to.have.lengthOf(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1134,6 +1134,9 @@ importers:
       sinon:
         specifier: ^21.1.2
         version: 21.1.2
+      undici:
+        specifier: ^7.28.0
+        version: 7.28.0
 
   packages/hive:
     dependencies:


### PR DESCRIPTION
## Summary

Switch Anthropic and Google client libraries to use Node's native fetch (globalThis.fetch) to avoid node-fetch stream handling and recover from ERR_STREAM_PREMATURE_CLOSE. Added transport tests (undici MockAgent) for claude, gmail, googledrive and googlesheets to validate retry behavior and ensure unsafe requests are not replayed. Added undici as a test dependency to googlesheets package.json, new .changeset entry, and updated pnpm lockfile.

Fixes #1707 

## Details

Configured Claude, Gmail, Google Sheets, and Google Drive to use Node’s native Undici-backed fetch instead of the SDKs’ node-fetch transport, which was implicated in transient ERR_STREAM_PREMATURE_CLOSE failures.

Added MockAgent regression tests covering:
- Recovery of safe requests through existing SDK retry policies.
- Errors after retry exhaustion.
- No automatic replay of mutating Gmail, Sheets, or Drive requests.

No public adaptor APIs or retry policies were changed.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [x] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [ ] Have you ticked a box under AI Usage?
