### PR TITLE
feat: update commcare

### DIFF
--- a/.changeset/hip-bats-admire.md
+++ b/.changeset/hip-bats-admire.md
@@ -1,0 +1,31 @@
+---
+'@openfn/language-commcare': major
+---
+
+Add support for CommCare's [Case Data API v2](https://commcare-hq.readthedocs.io/api/cases-v2.html) and make the API version configurable.
+
+**Breaking change:** The URL pattern used by `get()`, `post()`, and `fetchReportData()` has changed from `/api/v0.5/<resource>` to `/api/<resource>/<apiVersion>`. Existing jobs are unaffected as long as the CommCare v1 API is still available — the default `apiVersion` is `"v1"`.
+
+**`get()` now correctly handles individual resource fetches**, placing the ID after the API version in the URL (e.g. `get("case/12345")` resolves to `/api/case/v1/12345`).
+
+**New: configurable API version**
+
+Set `apiVersion` in `state.configuration` to target a specific CommCare API version (defaults to `"v1"`):
+
+```json
+{
+  "configuration": {
+    "hostUrl": "https://www.commcarehq.org",
+    "username": "...",
+    "password": "...",
+    "domain": "my-domain",
+    "apiVersion": "v2"
+  }
+}
+```
+
+**New: Case Data API v2 (`apiVersion: "v2"`)**
+
+The v2 case API introduces JSON-based case creation and updates (no XForm construction required), filtering by project-specific case properties, bulk operations, and a new response envelope. See the [v2 docs](https://commcare-hq.readthedocs.io/api/cases-v2.html) for full details.
+
+Note: auto-pagination is v1-only (uses `meta.next`). The v2 API uses cursor-based pagination via a top-level `next` field — follow it manually using `request()` if needed.

--- a/packages/commcare/ast.json
+++ b/packages/commcare/ast.json
@@ -102,7 +102,7 @@
           },
           {
             "title": "example",
-            "description": "post(\"case\", {\n  case_type: \"patient\",\n  case_name: \"Elizabeth Harmon\",\n  owner_id: \"20cc9dda-b90a-4af3-aa3d-fc67184e73ef\",\n  properties: { dob: \"1948-11-02\" }\n})\n// Note: set apiVersion: \"v2\" in state.configuration",
+            "description": "post(\"case\", {\n  case_type: \"patient\",\n  case_name: \"Elizabeth Harmon\",\n  owner_id: \"20cc9dda-b90a-4af3-aa3d-fc67184e73ef\",\n  properties: { dob: \"1948-11-02\" }\n})",
             "caption": "Create a case using the v2 API. Equivalent to `POST /a/<domain>/api/case/v2/`"
           },
           {
@@ -287,7 +287,7 @@
         "postUrl"
       ],
       "docs": {
-        "description": "Make a GET request to CommCare's Reports API\nand POST the response somewhere else.",
+        "description": "Make a GET request to CommCare's Reports API\nand POST the response somewhere else. Only works for v1 reports.",
         "tags": [
           {
             "title": "public",

--- a/packages/commcare/ast.json
+++ b/packages/commcare/ast.json
@@ -8,7 +8,7 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a GET request to CommCare. Use this to fetch resources directly from Commcare REST API.\nYou can pass Commcare query parameters as an object of key value pairs, which will map to parameters\nin the URL.\nThe response body will be returned to `state.data` as JSON.\nPaginated responses will be fully downloaded and returned as a single array, _unless_ an `offset` is passed.",
+        "description": "Make a GET request to CommCare. Use this to fetch resources directly from Commcare REST API.\nYou can pass Commcare query parameters as an object of key value pairs, which will map to parameters\nin the URL.\nThe response body will be returned to `state.data` as JSON.\nPaginated responses will be fully downloaded and returned as a single array, _unless_ an `offset` is passed.\nThe `apiVersion` in `state.configuration` controls the API version used (defaults to `\"v1\"`).\nNote: auto-pagination uses `meta.next` (v1-style); the v2 case API uses cursor-based pagination via a top-level `next` field and is not auto-paginated.\nSet `apiVersion: \"v2\"` in configuration to target the {@link https://commcare-hq.readthedocs.io/api/cases-v2.html Case Data API v2}.",
         "tags": [
           {
             "title": "public",
@@ -46,7 +46,7 @@
           },
           {
             "title": "param",
-            "description": "Input parameters for the request. These vary by endpoint,  see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957366/Data+APIs CommCare docs}.",
+            "description": "Input parameters for the request. These vary by endpoint. See {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957366/Data+APIs CommCare v1 docs} and {@link https://commcare-hq.readthedocs.io/api/cases-v2.html CommCare Case API v2 docs}.",
             "type": {
               "type": "OptionalType",
               "expression": {
@@ -93,12 +93,17 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a POST request to CommCare. Use this to send resources directly to Commcare REST API.\nYou can pass Commcare body data as a JSON object.",
+        "description": "Make a POST request to CommCare. Use this to send resources directly to Commcare REST API.\nYou can pass Commcare body data as a JSON object.\nTo create or bulk-create cases using the v2 API, set `apiVersion: \"v2\"` in configuration and\npass `\"case\"` as the path. See the {@link https://commcare-hq.readthedocs.io/api/cases-v2.html#create-case Create Case}\nand {@link https://commcare-hq.readthedocs.io/api/cases-v2.html#bulk-create-update-cases Bulk Create/Update Cases} docs.",
         "tags": [
           {
             "title": "example",
-            "description": "post(\"/user\", { \"username\":\"test\", \"password\":\"somepassword\" })",
-            "caption": "Create a user resource.Equivalent to `<baseUrl>/user`"
+            "description": "post(\"user\", { \"username\": \"test\", \"password\": \"somepassword\" })",
+            "caption": "Create a user resource. Equivalent to `POST /a/<domain>/api/user/v1/`"
+          },
+          {
+            "title": "example",
+            "description": "post(\"case\", {\n  case_type: \"patient\",\n  case_name: \"Elizabeth Harmon\",\n  owner_id: \"20cc9dda-b90a-4af3-aa3d-fc67184e73ef\",\n  properties: { dob: \"1948-11-02\" }\n})\n// Note: set apiVersion: \"v2\" in state.configuration",
+            "caption": "Create a case using the v2 API. Equivalent to `POST /a/<domain>/api/case/v2/`"
           },
           {
             "title": "function",
@@ -121,7 +126,7 @@
           },
           {
             "title": "param",
-            "description": "Object or JSON to create a resource",
+            "description": "Object or JSON to create a resource. For v2 case creation, see the {@link https://commcare-hq.readthedocs.io/api/cases-v2.html#case-create-update-upsert-format case format docs}.",
             "type": {
               "type": "NameExpression",
               "name": "object"
@@ -292,7 +297,7 @@
           {
             "title": "example",
             "description": "fetchReportData(\n  \"abcde\",\n  { limit: 10 },\n  \"https://www.example.com/api/\"\n)",
-            "caption": "Get 10 records from a report and post them to example.com. Equivalent to `<baseUrl>/configurablereportdata/abcde?limit=10`"
+            "caption": "Get 10 records from a report and post them to example.com. Equivalent to `GET <baseUrl>/a/<domain>/api/configurablereportdata/v1/abcde/?limit=10`"
           },
           {
             "title": "function",
@@ -355,13 +360,13 @@
         "tags": [
           {
             "title": "example",
-            "description": "request(\"GET\", \"/a/asri/api/v0.5/case\");",
-            "caption": "Get a resource. Equivalent to `<baseUrl>/a/asri/api/v0.5/case`"
+            "description": "request(\"GET\", \"/a/asri/api/case/v1/\")",
+            "caption": "Get a list of cases. Equivalent to `<baseUrl>/a/asri/api/case/v1/`"
           },
           {
             "title": "example",
-            "description": "request(\"GET\", \"/case\", {}, { offset:0, limit: 20 })",
-            "caption": "Get a resource using query parameters. Equivalent to `<baseUrl>/case?offset=0&limit=20`"
+            "description": "request(\"GET\", \"/a/asri/api/case/v2/79e25a30-8db5-4a5a-827b-0297b254e87f/\")",
+            "caption": "Get an individual case using the v2 API. Equivalent to `<baseUrl>/a/asri/api/case/v2/<case_id>/`"
           },
           {
             "title": "function",

--- a/packages/commcare/configuration-schema.json
+++ b/packages/commcare/configuration-schema.json
@@ -57,6 +57,16 @@
             "examples": [
                 "supersecretpassword"
             ]
+        },
+        "apiVersion": {
+            "title": "API Version",
+            "type": "string",
+            "description": "Commcare api version",
+            "minLength": 1,
+            "default": "v1",
+            "examples": [
+                "v1"
+            ]
         }
     },
     "type": "object",

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -43,6 +43,9 @@ export function execute(...operations) {
  * in the URL.
  * The response body will be returned to `state.data` as JSON.
  * Paginated responses will be fully downloaded and returned as a single array, _unless_ an `offset` is passed.
+ * The `apiVersion` in `state.configuration` controls the API version used (defaults to `"v1"`).
+ * Note: auto-pagination uses `meta.next` (v1-style); the v2 case API uses cursor-based pagination via a top-level `next` field and is not auto-paginated.
+ * Set `apiVersion: "v2"` in configuration to target the {@link https://commcare-hq.readthedocs.io/api/cases-v2.html Case Data API v2}.
  * @public
  * @function
  * @example <caption>Get a resource by Id. Equivalent to GET `<baseUrl>/case/12345`</caption>
@@ -55,24 +58,33 @@ export function execute(...operations) {
  *   return state;
  * })
  * @param {string} path - Path to resource
- * @param {Object} [params] - Input parameters for the request. These vary by endpoint,  see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957366/Data+APIs CommCare docs}.
+ * @param {Object} [params] - Input parameters for the request. These vary by endpoint. See {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957366/Data+APIs CommCare v1 docs} and {@link https://commcare-hq.readthedocs.io/api/cases-v2.html CommCare Case API v2 docs}.
  * @param {function} [callback] - Optional callback function. Invoked once per page of data retrieved.
  * @state {CommcareHttpState}
  * @returns {Operation}
  */
 export function get(path, params = {}, callback = s => s) {
   return async state => {
-    const { domain } = state.configuration;
+    const { domain, apiVersion = 'v1' } = state.configuration;
     const [resolvedPath, resolvedParams] = expandReferences(
       state,
       path,
-      params
+      params,
     );
 
     let offset, limit;
 
     let nextState = state;
     let result;
+    const resolvedPathParts = resolvedPath.split('/');
+
+    let newPath, resolvedId;
+    if (resolvedPathParts.length > 1) {
+      resolvedId = resolvedPathParts[resolvedPathParts.length - 1];
+      newPath = resolvedPathParts.slice(0, resolvedPathParts.length - 1);
+    } else {
+      newPath = resolvedPath;
+    }
 
     // Automatically paginate if the user did not pass an offset
     let allowPagination = isNaN(resolvedParams.offset);
@@ -83,15 +95,16 @@ export function get(path, params = {}, callback = s => s) {
       };
 
       do {
+        const idPresent = resolvedId ? `/${resolvedId}` : '';
         // Make the first request
         const response = await util.request(
           state.configuration,
-          `/a/${domain}/api/v0.5/${resolvedPath}`,
+          `/a/${domain}/api/${newPath}/${apiVersion}${idPresent}`,
           {
             method: 'GET',
             params: requestParams,
             contentType: 'application/json',
-          }
+          },
         );
 
         nextState = util.prepareNextState(state, response, callback);
@@ -137,12 +150,22 @@ export function get(path, params = {}, callback = s => s) {
 /**
  * Make a POST request to CommCare. Use this to send resources directly to Commcare REST API.
  * You can pass Commcare body data as a JSON object.
- * @example <caption>Create a user resource.Equivalent to `<baseUrl>/user`</caption>
- * post("/user", { "username":"test", "password":"somepassword" })
+ * To create or bulk-create cases using the v2 API, set `apiVersion: "v2"` in configuration and
+ * pass `"case"` as the path. See the {@link https://commcare-hq.readthedocs.io/api/cases-v2.html#create-case Create Case}
+ * and {@link https://commcare-hq.readthedocs.io/api/cases-v2.html#bulk-create-update-cases Bulk Create/Update Cases} docs.
+ * @example <caption>Create a user resource. Equivalent to `POST /a/<domain>/api/user/v1/`</caption>
+ * post("user", { "username": "test", "password": "somepassword" })
+ * @example <caption>Create a case using the v2 API. Equivalent to `POST /a/<domain>/api/case/v2/`</caption>
+ * post("case", {
+ *   case_type: "patient",
+ *   case_name: "Elizabeth Harmon",
+ *   owner_id: "20cc9dda-b90a-4af3-aa3d-fc67184e73ef",
+ *   properties: { dob: "1948-11-02" }
+ * })
  * @function
  * @public
  * @param {string} path - Path to resource
- * @param {object} data - Object or JSON to create a resource
+ * @param {object} data - Object or JSON to create a resource. For v2 case creation, see the {@link https://commcare-hq.readthedocs.io/api/cases-v2.html#case-create-update-upsert-format case format docs}.
  * @param {Object} [params] - Optional request params
  * @param {function} [callback] - Optional callback to handle the response
  * @returns {Operation}
@@ -150,24 +173,24 @@ export function get(path, params = {}, callback = s => s) {
  */
 export function post(path, data, params = {}, callback = s => s) {
   return async state => {
-    const { domain } = state.configuration;
+    const { domain, apiVersion = 'v1' } = state.configuration;
     const [resolvedPath, resolvedData, resolvedParams] = expandReferences(
       state,
       path,
       data,
-      params
+      params,
     );
 
     try {
       const response = await util.request(
         state.configuration,
-        `/a/${domain}/api/v0.5/${resolvedPath}`,
+        `/a/${domain}/api/${resolvedPath}/${apiVersion}`,
         {
           method: 'POST',
           data: resolvedData,
           params: resolvedParams,
           contentType: 'application/json',
-        }
+        },
       );
 
       return util.prepareNextState(state, response, callback);
@@ -276,9 +299,9 @@ export function submit(data) {
 
 /**
  * Make a GET request to CommCare's Reports API
- * and POST the response somewhere else.
+ * and POST the response somewhere else. Only works for v1 reports.
  * @public
- * @example <caption>Get 10 records from a report and post them to example.com. Equivalent to `<baseUrl>/configurablereportdata/abcde?limit=10`</caption>
+ * @example <caption>Get 10 records from a report and post them to example.com. Equivalent to `GET <baseUrl>/a/<domain>/api/configurablereportdata/v1/abcde/?limit=10`</caption>
  * fetchReportData(
  *   "abcde",
  *   { limit: 10 },
@@ -293,7 +316,8 @@ export function submit(data) {
  */
 export function fetchReportData(reportId, params, postUrl) {
   return async state => {
-    const path = `/a/${state.configuration.domain}/api/v0.5/configurablereportdata/${reportId}/`;
+    const { domain } = state.configuration;
+    const path = `/a/${domain}/api/configurablereportdata/v1/${reportId}/`;
 
     console.log('with params: '.concat(JSON.stringify(params)));
 
@@ -304,7 +328,6 @@ export function fetchReportData(reportId, params, postUrl) {
 
     await util.request(state.configuration, postUrl, {
       method: 'POST',
-      params,
       data: reportData,
       contentType: 'application/json',
     });
@@ -317,10 +340,10 @@ export function fetchReportData(reportId, params, postUrl) {
 
 /**
  * Make a general HTTP request against the Commcare server. Use this to make any request to Commcare REST API.
- * @example <caption>Get a resource. Equivalent to `<baseUrl>/a/asri/api/v0.5/case`</caption>
- * request("GET", "/a/asri/api/v0.5/case");
- * @example <caption>Get a resource using query parameters. Equivalent to `<baseUrl>/case?offset=0&limit=20`</caption>
- * request("GET", "/case", {}, { offset:0, limit: 20 })
+ * @example <caption>Get a list of cases. Equivalent to `<baseUrl>/a/asri/api/case/v1/`</caption>
+ * request("GET", "/a/asri/api/case/v1/")
+ * @example <caption>Get an individual case using the v2 API. Equivalent to `<baseUrl>/a/asri/api/case/v2/<case_id>/`</caption>
+ * request("GET", "/a/asri/api/case/v2/79e25a30-8db5-4a5a-827b-0297b254e87f/")
  * @function
  * @public
  * @param {string} method - HTTP method to use
@@ -395,7 +418,7 @@ export function bulk(type, data, params) {
     const [resolvedData, resolvedParams] = expandReferences(
       state,
       data,
-      params
+      params,
     );
     let path, file;
 

--- a/packages/commcare/test/index.js
+++ b/packages/commcare/test/index.js
@@ -1,6 +1,14 @@
 import { expect } from 'chai';
 import { enableMockClient } from '@openfn/language-common/util';
-import { execute, submitXls, get, post, request, bulk } from '../src/index.js';
+import {
+  execute,
+  submitXls,
+  get,
+  post,
+  request,
+  bulk,
+  fetchReportData,
+} from '../src/index.js';
 
 const hostUrl = 'http://example.commcare.com';
 const testServer = enableMockClient(hostUrl, {
@@ -24,6 +32,11 @@ const configuration = {
   appId: app,
   username: 'user',
   password: 'password',
+};
+
+const configurationV2 = {
+  ...configuration,
+  apiVersion: 'v2',
 };
 const paginatedResponse = (offset = 0, limit, objects = defaultObjects) => {
   const next =
@@ -183,7 +196,7 @@ describe('getCases', () => {
   it('should fetch cases', async () => {
     testServer
       .intercept({
-        path: `/a/${domain}/api/v0.5/case`,
+        path: `/a/${domain}/api/case/v1`,
         method: 'GET',
       })
       .reply(200, () => {
@@ -240,7 +253,7 @@ describe('getCases', () => {
   it('should fetch a single case', async () => {
     testServer
       .intercept({
-        path: `/a/${domain}/api/v0.5/case/12345`,
+        path: `/a/${domain}/api/case/v1/12345`,
         method: 'GET',
       })
       .reply(200, () => {
@@ -285,7 +298,7 @@ describe('getCases', () => {
   it('should fetch cases and call the callback', async () => {
     testServer
       .intercept({
-        path: `/a/${domain}/api/v0.5/case`,
+        path: `/a/${domain}/api/case/v1`,
         method: 'GET',
       })
       .reply(200, () => {
@@ -385,7 +398,7 @@ describe('get', () => {
 
     testServer
       .intercept({
-        path: /\/a\/my-domain\/api\/v0\.5\/case/,
+        path: /\/a\/my-domain\/api\/case\/v1/,
         method: 'GET',
       })
       .reply(200, req => {
@@ -412,7 +425,7 @@ describe('get', () => {
 
     testServer
       .intercept({
-        path: /\/a\/my-domain\/api\/v0\.5\/case/,
+        path: /\/a\/my-domain\/api\/case\/v1/,
         method: 'GET',
       })
       .reply(200, req => {
@@ -441,7 +454,7 @@ describe('get', () => {
     testServer
       .intercept({
         // This will fail if query params are added to the url
-        path: '/a/my-domain/api/v0.5/case',
+        path: '/a/my-domain/api/case/v1',
         method: 'GET',
       })
       .reply(200, () => {
@@ -468,7 +481,7 @@ describe('get', () => {
 
     testServer
       .intercept({
-        path: '/a/my-domain/api/v0.5/case',
+        path: '/a/my-domain/api/case/v1',
         method: 'GET',
         query: { offset: 1 },
       })
@@ -488,7 +501,7 @@ describe('get', () => {
   it("should respect the user's limit while paginating", async () => {
     testServer
       .intercept({
-        path: /\/a\/my-domain\/api\/v0\.5\/case/,
+        path: /\/a\/my-domain\/api\/case\/v1/,
         method: 'GET',
         query: {
           limit: 2,
@@ -513,7 +526,7 @@ describe('get', () => {
   it('should call the callback once for a single request', async () => {
     testServer
       .intercept({
-        path: `/a/${domain}/api/v0.5/case`,
+        path: `/a/${domain}/api/case/v1`,
         method: 'GET',
       })
       .reply(200, () => {
@@ -546,7 +559,7 @@ describe('createUser', () => {
   it('should create a user', async () => {
     testServer
       .intercept({
-        path: `/a/${domain}/api/v0.5/user`,
+        path: `/a/${domain}/api/user/v1`,
         method: 'POST',
       })
       .reply(201, () => {
@@ -578,7 +591,7 @@ describe('request', () => {
   it('makes a GET request', async () => {
     testServer
       .intercept({
-        path: `/a/asri/api/v0.5/case`,
+        path: `/a/asri/api/case/v1`,
         method: 'GET',
         query: {
           offset: 1,
@@ -595,7 +608,7 @@ describe('request', () => {
 
     const { data, response } = await request(
       'GET',
-      '/a/asri/api/v0.5/case',
+      '/a/asri/api/case/v1',
       {},
       { offset: 1 }
     )(state);
@@ -727,5 +740,217 @@ describe('Bulk', () => {
     // And the adaptor should have uploaded a reasonable looking formdata object
     expect(formdata.get('replace')).to.not.be.undefined;
     expect(formdata.get('replace')).to.equal('false');
+  });
+});
+
+describe('get (v2 case API)', () => {
+  // v2 list response: { matching_records, cases, next? }
+  // https://commcare-hq.readthedocs.io/api/cases-v2.html#get-list-of-cases
+  it('should list cases using the v2 API', async () => {
+    testServer
+      .intercept({
+        path: `/a/${domain}/api/case/v2`,
+        method: 'GET',
+      })
+      .reply(200, () => {
+        return {
+          matching_records: 1,
+          next: null,
+          cases: [
+            {
+              case_id: '79e25a30-8db5-4a5a-827b-0297b254e87f',
+              case_type: 'patient',
+              case_name: 'Elizabeth Harmon',
+              external_id: '1',
+              owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
+              date_opened: '2020-03-19T14:31:34.133000Z',
+              last_modified: '2020-03-19T14:31:34.133000Z',
+              closed: false,
+              date_closed: null,
+              properties: { dob: '1948-11-02' },
+            },
+          ],
+        };
+      });
+
+    const state = { configuration: configurationV2 };
+
+    // v2 returns the whole body on state.data (no body.objects to unwrap)
+    const { data } = await execute(get('case'))(state);
+    expect(data.matching_records).to.equal(1);
+    expect(data.cases).to.have.length(1);
+    expect(data.cases[0].case_id).to.equal(
+      '79e25a30-8db5-4a5a-827b-0297b254e87f'
+    );
+    expect(data.cases[0].case_type).to.equal('patient');
+  });
+
+  it('should list cases filtered by case_type using the v2 API', async () => {
+    testServer
+      .intercept({
+        path: `/a/${domain}/api/case/v2`,
+        method: 'GET',
+        query: { case_type: 'patient', closed: 'false' },
+      })
+      .reply(200, () => {
+        return {
+          matching_records: 1,
+          next: null,
+          cases: [{ case_id: 'abc', case_type: 'patient', closed: false }],
+        };
+      });
+
+    const state = { configuration: configurationV2 };
+
+    const { data } = await execute(
+      get('case', { case_type: 'patient', closed: false })
+    )(state);
+    expect(data.matching_records).to.equal(1);
+    expect(data.cases[0].case_type).to.equal('patient');
+  });
+
+
+  it('should get an individual case by ID using the v2 API', async () => {
+    testServer
+      .intercept({
+        path: `/a/${domain}/api/case/v2/79e25a30-8db5-4a5a-827b-0297b254e87f`,
+        method: 'GET',
+      })
+      .reply(200, () => {
+        return {
+          case_id: '79e25a30-8db5-4a5a-827b-0297b254e87f',
+          case_type: 'patient',
+          case_name: 'Elizabeth Harmon',
+          closed: false,
+          date_closed: null,
+          properties: { dob: '1948-11-02' },
+        };
+      });
+
+    const state = { configuration: configurationV2 };
+
+    const { data } = await execute(
+      get('case/79e25a30-8db5-4a5a-827b-0297b254e87f')
+    )(state);
+    expect(data.case_id).to.equal('79e25a30-8db5-4a5a-827b-0297b254e87f');
+    expect(data.case_type).to.equal('patient');
+    expect(data.closed).to.equal(false);
+  });
+});
+
+describe('post (v2 case API)', () => {  
+  it('should create a single case using the v2 API', async () => {
+    testServer
+      .intercept({
+        path: `/a/${domain}/api/case/v2`,
+        method: 'POST',
+      })
+      .reply(201, () => {
+        return {
+          xform_id: 'form-abc-123',
+          case: {
+            case_id: 'new-case-uuid',
+            case_type: 'patient',
+            case_name: 'Elizabeth Harmon',
+            closed: false,
+            properties: { dob: '1948-11-02' },
+          },
+        };
+      });
+
+    const state = { configuration: configurationV2 };
+
+    const { data, response } = await execute(
+      post('case', {
+        case_type: 'patient',
+        case_name: 'Elizabeth Harmon',
+        owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
+        properties: { dob: '1948-11-02' },
+      })
+    )(state);
+
+    expect(response.statusCode).to.equal(201);
+    expect(data.xform_id).to.equal('form-abc-123');
+    expect(data.case.case_id).to.equal('new-case-uuid');
+  });
+
+
+  it('should bulk create cases using the v2 API', async () => {
+    testServer
+      .intercept({
+        path: `/a/${domain}/api/case/v2`,
+        method: 'POST',
+      })
+      .reply(200, () => {
+        return {
+          xform_id: 'form-bulk-456',
+          cases: [
+            { case_id: 'case-1-uuid', case_type: 'mother', closed: false },
+            { case_id: 'case-2-uuid', case_type: 'baby', closed: false },
+          ],
+        };
+      });
+
+    const state = { configuration: configurationV2 };
+
+    const { data } = await execute(
+      post('case', [
+        {
+          create: true,
+          case_type: 'mother',
+          case_name: 'Cersei Lannister',
+          owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
+          temporary_id: '1',
+          properties: { dob: '1988-11-02' },
+        },
+        {
+          create: true,
+          case_type: 'baby',
+          case_name: 'Tommen Baratheon',
+          owner_id: '9dd08c69-4ace-4e1d-9929-146d22d1070c',
+          properties: { dob: '2008-03-01' },
+          indices: {
+            parent: { temporary_id: '1', case_type: 'mother', relationship: 'child' },
+          },
+        },
+      ])
+    )(state);
+
+    expect(data.xform_id).to.equal('form-bulk-456');
+    expect(data.cases).to.have.length(2);
+    expect(data.cases[0].case_type).to.equal('mother');
+  });
+});
+
+describe('fetchReportData', () => {
+  it('should GET report data from CommCare and POST it to a given URL', async () => {
+    const reportId = '3cb6840b03c79fde8f4075246b7a8c4b';
+    const reportData = { meta: {}, data: [{ row: 1 }] };
+
+    testServer
+      .intercept({
+        path: `/a/${domain}/api/configurablereportdata/v1/${reportId}/`,
+        method: 'GET',
+      })
+      .reply(200, () => reportData);
+
+    let posted;
+    testServer
+      .intercept({
+        path: '/webhook/',
+        method: 'POST',
+      })
+      .reply(200, req => {
+        posted = req.body;
+        return { ok: true };
+      });
+
+    const state = { configuration };
+
+    await execute(
+      fetchReportData(reportId, {}, `${hostUrl}/webhook/`)
+    )(state);
+
+    expect(JSON.parse(posted)).to.deep.equal(reportData);
   });
 });

--- a/packages/commcare/test/integrations/JobExample.js
+++ b/packages/commcare/test/integrations/JobExample.js
@@ -31,8 +31,64 @@ fetchReportData(
     offset: 20,
     limit: 10,
   },
-  '/a/your-domain/api/v0.5/form/'
+  '/a/your-domain/api/form/v1/'
 );
 fn(state => {
   console.log(state);
+});
+
+// --- Case Data API v2 examples ---
+// https://commcare-hq.readthedocs.io/api/cases-v2.html
+// Requires apiVersion: "v2" in state.configuration
+
+// List cases (with optional filters)
+get('case', { case_type: 'patient', closed: false });
+fn(state => {
+  console.log('matching_records:', state.data.matching_records);
+  console.log('cases:', state.data.cases);
+});
+
+// Get a single case by ID
+request('GET', '/a/your-domain/api/case/v2/your-case-id/');
+fn(state => {
+  console.log(state.data);
+});
+
+// Create a case
+post('case', {
+  case_type: 'patient',
+  case_name: 'Elizabeth Harmon',
+  owner_id: 'your-owner-id',
+  properties: { dob: '1948-11-02' },
+});
+fn(state => {
+  console.log('xform_id:', state.data.xform_id);
+  console.log('created case:', state.data.case);
+});
+
+// Bulk create/update cases (each must include create: true/false)
+// https://commcare-hq.readthedocs.io/api/cases-v2.html#bulk-create-update-cases
+post('case', [
+  {
+    create: true,
+    case_type: 'mother',
+    case_name: 'Cersei Lannister',
+    owner_id: 'your-owner-id',
+    temporary_id: '1',
+    properties: { dob: '1988-11-02' },
+  },
+  {
+    create: true,
+    case_type: 'baby',
+    case_name: 'Tommen Baratheon',
+    owner_id: 'your-owner-id',
+    properties: { dob: '2008-03-01' },
+    indices: {
+      parent: { temporary_id: '1', case_type: 'mother', relationship: 'child' },
+    },
+  },
+]);
+fn(state => {
+  console.log('xform_id:', state.data.xform_id);
+  console.log('cases:', state.data.cases);
 });


### PR DESCRIPTION
## Summary

Update `commcare` apis to `v1` and `v2`.

Fixes #1727 

## Details

Add support for CommCare's [Case Data API v2](https://commcare-hq.readthedocs.io/api/cases-v2.html) and make the API version configurable.

**Breaking change:** The URL pattern used by `get()`, `post()`, and `fetchReportData()` has changed from `/api/v0.5/<resource>` to `/api/<resource>/<apiVersion>`. Existing jobs are unaffected as long as the CommCare v1 API is still available — the default `apiVersion` is `"v1"`.

**`get()` now correctly handles individual resource fetches**, placing the ID after the API version in the URL (e.g. `get("case/12345")` resolves to `/api/case/v1/12345`).

**New: configurable API version**

Set `apiVersion` in `state.configuration` to target a specific CommCare API version (defaults to `"v1"`):

```json
{
  "configuration": {
    "hostUrl": "https://www.commcarehq.org",
    "username": "...",
    "password": "...",
    "domain": "my-domain",
    "apiVersion": "v2"
  }
}
```

**New: Case Data API v2 (`apiVersion: "v2"`)**

The v2 case API introduces JSON-based case creation and updates (no XForm construction required), filtering by project-specific case properties, bulk operations, and a new response envelope. See the [v2 docs](https://commcare-hq.readthedocs.io/api/cases-v2.html) for full details.

Note: auto-pagination is v1-only (uses `meta.next`). The v2 API uses cursor-based pagination via a top-level `next` field — follow it manually using `request()` if needed.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [x] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [ ] Have you ticked a box under AI Usage?
