### PR TITLE
Add fetchAttachments option to gmail adaptor

### DIFF
--- a/.changeset/calm-mails-list.md
+++ b/.changeset/calm-mails-list.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-gmail': minor
+---
+
+Add an option to retrieve Gmail message content without downloading attachments

--- a/packages/gmail/README.md
+++ b/packages/gmail/README.md
@@ -19,7 +19,8 @@ customize the output.
 ## Parameters
 
 An `options` object can configure the results of the function call. Optional
-parameters include: `contents`, `query`, `email`, `processedIds`, `maxResults`
+parameters include: `contents`, `query`, `email`, `processedIds`, `maxResults`,
+`fetchAttachments`
 
 ### options.contents
 
@@ -161,6 +162,24 @@ This works in conjuction with the `options.processedIds` parameter. For example:
 - `options.maxResults = 1;`
 - this will skip message #1 and resulting dataset will contain a single message
   #2
+
+### options.fetchAttachments
+
+Set `fetchAttachments` to `false` to return message IDs and non-attachment
+content without downloading requested file or archive attachments. Attachment
+fields are omitted from the output when downloading is disabled. The default is
+`true`.
+
+```js
+getContentsFromMessages({
+  query: 'after:2026/07/01',
+  contents: [
+    'body',
+    { type: 'file', name: 'report', file: /\.xlsx$/ },
+  ],
+  fetchAttachments: false,
+});
+```
 
 ## Example jobs
 

--- a/packages/gmail/ast.json
+++ b/packages/gmail/ast.json
@@ -52,6 +52,11 @@
             "title": "example",
             "description": "getContentsFromMessages(\n  {\n    query: 'after:15/01/2025',\n    contents: [\n      'subject',\n      { type: 'file', name: 'metadata', file: 'report.txt'}\n    ]\n  }\n)",
             "caption": "Get messages after a specific date, with subject and report.txt attachment"
+          },
+          {
+            "title": "example",
+            "description": "getContentsFromMessages(\n  {\n    query: 'after:2026/07/01',\n    contents: [\n      'body',\n      { type: 'file', name: 'report', file: /\\.xlsx$/ }\n    ],\n    fetchAttachments: false\n  }\n)",
+            "caption": "Get metadata without downloading requested attachments"
           }
         ]
       },

--- a/packages/gmail/src/Adaptor.js
+++ b/packages/gmail/src/Adaptor.js
@@ -41,6 +41,7 @@ import {
  * @property {Array<string>} [processedIds] - Ignore message ids which have already been processed.
  * @property {string?} [email] - The user account to retrieve messages from. Defaults to the authenticated user.
  * @property {int?} [maxResults] - Maximum number of messages to process per request. Default is 1000.
+ * @property {boolean} [fetchAttachments=true] - Whether to download file and archive attachments.
  */
 
 /**
@@ -67,6 +68,17 @@ import {
  *     ]
  *   }
  * )
+ * @example <caption>Get metadata without downloading requested attachments</caption>
+ * getContentsFromMessages(
+ *   {
+ *     query: 'after:2026/07/01',
+ *     contents: [
+ *       'body',
+ *       { type: 'file', name: 'report', file: /\.xlsx$/ }
+ *     ],
+ *     fetchAttachments: false
+ *   }
+ * )
  */
 export function getContentsFromMessages(options) {
   return async state => {
@@ -83,11 +95,19 @@ export function getContentsFromMessages(options) {
       query: resolvedOptions.query,
       processedIds: resolvedOptions.processedIds,
       maxResults: resolvedOptions.maxResults ?? defaultOptions.maxResults,
+      fetchAttachments: resolvedOptions.fetchAttachments !== false,
     };
 
+    const requestedContentIndicators = getContentIndicators(
+      [],
+      resolvedOptions.contents,
+    ).filter(
+      ({ type }) =>
+        opts.fetchAttachments || (type !== 'file' && type !== 'archive'),
+    );
     const contentIndicators = getContentIndicators(
       defaultOptions.contents,
-      resolvedOptions.contents,
+      requestedContentIndicators,
     );
 
     const contents = [];

--- a/packages/gmail/test/Adaptor.test.js
+++ b/packages/gmail/test/Adaptor.test.js
@@ -90,6 +90,7 @@ describe('sendMessage', () => {
 describe('getContentsFromMessages', () => {
   let originalGmail;
   let mockGmail;
+  let attachmentGetCalls;
 
   const bodyText = 'Hello';
 
@@ -106,6 +107,7 @@ describe('getContentsFromMessages', () => {
 
   beforeEach(() => {
     originalGmail = google.gmail;
+    attachmentGetCalls = 0;
 
     const listResponse = {
       data: {
@@ -163,7 +165,20 @@ describe('getContentsFromMessages', () => {
               ],
             },
           ],
-          headers: [],
+          headers: [
+            {
+              name: 'From',
+              value: 'sender@example.org',
+            },
+            {
+              name: 'Date',
+              value: 'Thu, 23 Jul 2026 08:55:46 +0000',
+            },
+            {
+              name: 'Subject',
+              value: 'Monthly report',
+            },
+          ],
         },
       },
     };
@@ -193,6 +208,7 @@ describe('getContentsFromMessages', () => {
           get: async () => getResponse,
           attachments: {
             get: async ({ id }) => {
+              attachmentGetCalls += 1;
               if (id === 'a') {
                 return attachmentA;
               }
@@ -229,6 +245,54 @@ describe('getContentsFromMessages', () => {
 
     expect(data[0].messageId).to.equal('test-message-id');
     expect(data[0].body).to.equal(bodyText);
+  });
+
+  it('should skip file and archive attachments when fetching is disabled', async () => {
+    const result = await getContentsFromMessages({
+      contents: [
+        'body',
+        {
+          type: 'file',
+          name: 'text',
+          file: /.txt$/,
+        },
+        {
+          type: 'archive',
+          name: 'archive',
+          archive: /.zip$/,
+          file: /.json$/,
+        },
+      ],
+      fetchAttachments: false,
+    })(state);
+
+    expect(result.data[0].messageId).to.equal('test-message-id');
+    expect(result.data[0].from).to.equal('sender@example.org');
+    expect(result.data[0].date).to.eql(
+      new Date('Thu, 23 Jul 2026 08:55:46 +0000'),
+    );
+    expect(result.data[0].subject).to.equal('Monthly report');
+    expect(result.data[0].body).to.equal(bodyText);
+    expect(result.data[0]).not.to.have.property('text');
+    expect(result.data[0]).not.to.have.property('archive');
+    expect(result.processedIds).to.eql(['test-message-id']);
+    expect(attachmentGetCalls).to.equal(0);
+  });
+
+  it('should fetch attachments when explicitly enabled', async () => {
+    const { data } = await getContentsFromMessages({
+      contents: [
+        {
+          type: 'file',
+          name: 'text',
+          file: /.txt$/,
+        },
+      ],
+      fetchAttachments: true,
+    })(state);
+
+    expect(data[0].text.content).to.equal('hello');
+    expect(attachmentGetCalls).to.equal(1);
   });
 
   it('should get an XLSX attachment', async () => {


### PR DESCRIPTION


Includes documentation updates and comprehensive tests verifying both disabled and enabled attachment fetching behavior.

Adds a new `fetchAttachments` option (default true) to `getContentsFromMessages` that allows skipping the download of file and archive attachments while still retrieving message metadata and body content. This improves performance when attachment content is not needed.
Add a high-level, single-sentence summary of what this PR changes.

Fixes #1731 

## Details

Add technical details of what you've changed (and why).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [x] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [ ] Have you ticked a box under AI Usage?
