### PR TITLE
Feature/1738 commcare http namespace

### DIFF
--- a/.changeset/slick-wombats-travel.md
+++ b/.changeset/slick-wombats-travel.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-commcare': minor
----
-
-Add `http` namespace with `http.get()`, `http.post()`, and `http.request()` for direct access to the CommCare REST API.

--- a/.changeset/slick-wombats-travel.md
+++ b/.changeset/slick-wombats-travel.md
@@ -1,0 +1,18 @@
+---
+'@openfn/language-commcare': minor
+---
+
+Add `http` namespace with `http.get()`, `http.post()`, and `http.request()` for direct access to the CommCare REST API.
+
+All functions support two URL conventions:
+
+- **Relative paths** are automatically prefixed with `/a/<domain>/api/`, so you only need to provide the resource and version.
+- **Absolute paths** (starting with `/`) are passed through unchanged, giving you full control over the URL.
+
+```js
+// Relative path — resolves to /a/my-project/api/case/v1
+http.get('case/v1');
+
+// Absolute path — used exactly as written
+http.get('/a/my-project/api/case/v1');
+```

--- a/.changeset/slick-wombats-travel.md
+++ b/.changeset/slick-wombats-travel.md
@@ -3,16 +3,3 @@
 ---
 
 Add `http` namespace with `http.get()`, `http.post()`, and `http.request()` for direct access to the CommCare REST API.
-
-All functions support two URL conventions:
-
-- **Relative paths** are automatically prefixed with `/a/<domain>/api/`, so you only need to provide the resource and version.
-- **Absolute paths** (starting with `/`) are passed through unchanged, giving you full control over the URL.
-
-```js
-// Relative path — resolves to /a/my-project/api/case/v1
-http.get('case/v1');
-
-// Absolute path — used exactly as written
-http.get('/a/my-project/api/case/v1');
-```

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-commcare
 
+## 4.2.0 - 11 August 2026
+
+### Minor Changes
+
+- 20fa4ec: Add `http` namespace with `http.get()`, `http.post()`, and
+  `http.request()` for direct access to the CommCare REST API.
+
 ## 4.1.2 - 30 June 2026
 
 ### Patch Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-commcare",
   "label": "CommCare",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "OpenFn adaptor for CommCare (Dimagi)",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -5,7 +5,7 @@ import {
   logResponse,
 } from '@openfn/language-common/util';
 
-export const stripUrlPath = (url, domain) => {
+export const buildUrl = (url, domain) => {
   let finalUrl = '';
 
   const absoluteUrl = url.startsWith('/');

--- a/packages/commcare/src/Utils.js
+++ b/packages/commcare/src/Utils.js
@@ -5,6 +5,19 @@ import {
   logResponse,
 } from '@openfn/language-common/util';
 
+export const stripUrlPath = (url, domain) => {
+  let finalUrl = '';
+
+  const absoluteUrl = url.startsWith('/');
+  if (absoluteUrl) {
+    finalUrl = url;
+  } else {
+    finalUrl = `/a/${domain}/api/${url}`;
+  }
+
+  return finalUrl;
+};
+
 export const configureAuth = (auth, headers = {}) => {
   if ('apiKey' in auth) {
     Object.assign(headers, {
@@ -14,7 +27,7 @@ export const configureAuth = (auth, headers = {}) => {
     Object.assign(headers, makeBasicAuthHeader(auth.username, auth.password));
   } else {
     throw new Error(
-      'Invalid authorization credentials. Include an apiKey or password in state.configuration'
+      'Invalid authorization credentials. Include an apiKey or password in state.configuration',
     );
   }
 

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -13,7 +13,7 @@ import * as util from './Utils.js';
 /**
  * Make a POST request to CommCare. Use this to send resources directly to Commcare REST API.
  * You can pass CommCare body data as a JSON object.
- * @example <caption>Create a case using a relative path (prefixed with /a/<domain>/api/)</caption>
+ * @example <caption>Post to the V2 case API with JSON data (prefixed with /a/<domain>/api/)</caption>
  * http.post('case/v2', {
  *   case_type: 'patient',
  *   case_name: 'Elizabeth Harmon',
@@ -34,7 +34,7 @@ export function post(path, data, params = {}) {
 
 /**
  * Make a GET request to CommCare. Use this to retrieve resources directly from the CommCare REST API.
- * @example <caption>Get cases using a relative path (prefixed with /a/<domain>/api/)</caption>
+ * @example <caption>Get cases using the v1 API (prefixed with /a/<domain>/api/)</caption>
  * http.get('case/v1');
  * @function
  * @public
@@ -49,7 +49,7 @@ export function get(path, params = {}) {
 
 /**
  * Make a general HTTP request against the CommCare server. Use this to make any request to CommCare REST API.
- * @example <caption>GET cases with a relative path (prefixed with /a/<domain>/api/)</caption>
+ * @example <caption>Get cases using the v1 API (prefixed with /a/<domain>/api/)</caption>
  * http.request('GET', 'case/v1');
  * @function
  * @public

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -1,0 +1,139 @@
+import { expandReferences } from '@openfn/language-common/util';
+import * as util from './Utils.js';
+
+/**
+ * State object
+ * @typedef {Object} CommcareHttpState
+ * @property data - The response body (as JSON)
+ * @property response - The HTTP response from the CommCare server (excluding the body)
+ * @property references - An array of all previous data objects used in the Job
+ * @private
+ */
+
+/**
+ * Make a POST request to CommCare. Use this to send resources directly to Commcare REST API.
+ * You can pass Commcare body data as a JSON object.
+ * @example <caption>Create a case using a relative path (prefixed with /a/<domain>/api/)</caption>
+ * http.post('case/v2', {
+ *   case_type: 'patient',
+ *   case_name: 'Elizabeth Harmon',
+ *   owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
+ *   properties: { dob: '1948-11-02' },
+ * });
+ * @example <caption>Create a case using an absolute path (used as-is, starting with /)</caption>
+ * http.post('/a/plan-global-hub-staging/api/case/v2', {
+ *   case_type: 'patient',
+ *   case_name: 'Elizabeth Harmon',
+ *   owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
+ *   properties: { dob: '1948-11-02' },
+ * });
+ * @function
+ * @public
+ * @param {string} path - Path to resource. Relative paths are prefixed with `/a/<domain>/api/`; paths starting with `/` are used as-is.
+ * @param {object} data - Object or JSON to create a resource
+ * @param {Object} [params] - Optional request params
+ * @returns {Operation}
+ * @state {CommcareHttpState}
+ */
+export function post(path, data, params = {}) {
+  return async state => {
+    const { domain } = state.configuration;
+    const [resolvedPath, resolvedData, resolvedParams] = expandReferences(
+      state,
+      path,
+      data,
+      params,
+    );
+
+    const url = util.stripUrlPath(resolvedPath, domain);
+
+    try {
+      const response = await util.request(state.configuration, url, {
+        method: 'POST',
+        data: resolvedData,
+        params: resolvedParams,
+        contentType: 'application/json',
+      });
+
+      return util.prepareNextState(state, response);
+    } catch (e) {
+      throw e.body.error ?? e;
+    }
+  };
+}
+
+/**
+ * Make a GET request to CommCare. Use this to retrieve resources directly from the Commcare REST API.
+ * @example <caption>Get cases using a relative path (prefixed with /a/<domain>/api/)</caption>
+ * http.get('case/v1');
+ * @example <caption>Get cases using an absolute path (used as-is, starting with /)</caption>
+ * http.get('/a/plan-global-hub-staging/api/case/v1/');
+ * @function
+ * @public
+ * @param {string} path - Path to resource. Relative paths are prefixed with `/a/<domain>/api/`; paths starting with `/` are used as-is.
+ * @param {Object} [params] - Optional request params
+ * @returns {Operation}
+ * @state {CommcareHttpState}
+ */
+export function get(path, params = {}) {
+  return async state => {
+    const { domain } = state.configuration;
+    const [resolvedPath, resolvedParams] = expandReferences(
+      state,
+      path,
+      params,
+    );
+
+    const url = util.stripUrlPath(resolvedPath, domain);
+
+    try {
+      const response = await util.request(state.configuration, url, {
+        method: 'GET',
+        params: resolvedParams,
+        contentType: 'application/json',
+      });
+
+      return util.prepareNextState(state, response);
+    } catch (e) {
+      throw e.body.error ?? e;
+    }
+  };
+}
+
+/**
+ * Make a general HTTP request against the Commcare server. Use this to make any request to Commcare REST API.
+ * @example <caption>GET cases with a relative path (prefixed with /a/<domain>/api/)</caption>
+ * http.request('GET', 'case/v1');
+ * @example <caption>POST a case with an absolute path (used as-is, starting with /)</caption>
+ * http.request('POST', '/a/plan-global-hub-staging/api/case/v2', {
+ *   case_type: 'patient',
+ *   case_name: 'Elizabeth Harmon',
+ *   owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
+ *   properties: { dob: '1948-11-02' },
+ * });
+ * @function
+ * @public
+ * @param {string} method - HTTP method to use
+ * @param {string} path - Path to resource
+ * @param {object} body - Object which will be attached to the body
+ * @param {object} params - An object of query parameters to be encoded into the URL
+ * @returns {Operation}
+ * @state {CommcareHttpState}
+ */
+export function request(method, path, body, params = {}) {
+  return async state => {
+    const { domain } = state.configuration;
+    const [resolvedMethod, resolvedPath, resolvedBody, resolvedParams] =
+      expandReferences(state, method, path, body, params);
+
+    const url = util.stripUrlPath(resolvedPath, domain);
+    const response = await util.request(state.configuration, url, {
+      method: resolvedMethod,
+      data: resolvedBody,
+      params: resolvedParams,
+      contentType: 'application/json',
+    });
+
+    return util.prepareNextState(state, response);
+  };
+}

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -66,7 +66,7 @@ export function request(method, path, body, params = {}) {
     const [resolvedMethod, resolvedPath, resolvedBody, resolvedParams] =
       expandReferences(state, method, path, body, params);
 
-    const url = util.stripUrlPath(resolvedPath, domain);
+    const url = util.buildUrl(resolvedPath, domain);
     const response = await util.request(state.configuration, url, {
       method: resolvedMethod,
       data: resolvedBody,

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -20,13 +20,6 @@ import * as util from './Utils.js';
  *   owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
  *   properties: { dob: '1948-11-02' },
  * });
- * @example <caption>Create a case using an absolute path (used as-is, starting with /)</caption>
- * http.post('/a/plan-global-hub-staging/api/case/v2', {
- *   case_type: 'patient',
- *   case_name: 'Elizabeth Harmon',
- *   owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
- *   properties: { dob: '1948-11-02' },
- * });
  * @function
  * @public
  * @param {string} path - Path to resource. Relative paths are prefixed with `/a/<domain>/api/`; paths starting with `/` are used as-is.
@@ -43,8 +36,6 @@ export function post(path, data, params = {}) {
  * Make a GET request to CommCare. Use this to retrieve resources directly from the Commcare REST API.
  * @example <caption>Get cases using a relative path (prefixed with /a/<domain>/api/)</caption>
  * http.get('case/v1');
- * @example <caption>Get cases using an absolute path (used as-is, starting with /)</caption>
- * http.get('/a/plan-global-hub-staging/api/case/v1/');
  * @function
  * @public
  * @param {string} path - Path to resource. Relative paths are prefixed with `/a/<domain>/api/`; paths starting with `/` are used as-is.
@@ -60,13 +51,6 @@ export function get(path, params = {}) {
  * Make a general HTTP request against the Commcare server. Use this to make any request to Commcare REST API.
  * @example <caption>GET cases with a relative path (prefixed with /a/<domain>/api/)</caption>
  * http.request('GET', 'case/v1');
- * @example <caption>POST a case with an absolute path (used as-is, starting with /)</caption>
- * http.request('POST', '/a/plan-global-hub-staging/api/case/v2', {
- *   case_type: 'patient',
- *   case_name: 'Elizabeth Harmon',
- *   owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
- *   properties: { dob: '1948-11-02' },
- * });
  * @function
  * @public
  * @param {string} method - HTTP method to use

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -36,7 +36,7 @@ import * as util from './Utils.js';
  * @state {CommcareHttpState}
  */
 export function post(path, data, params = {}) {
-   return request('POST', path, data, params);
+  return request('POST', path, data, params);
 }
 
 /**
@@ -53,7 +53,7 @@ export function post(path, data, params = {}) {
  * @state {CommcareHttpState}
  */
 export function get(path, params = {}) {
-   return request('GET', path, null, params);
+  return request('GET', path, null, params);
 }
 
 /**

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -3,7 +3,7 @@ import * as util from './Utils.js';
 
 /**
  * State object
- * @typedef {Object} CommCareHttpState
+ * @typedef {Object} CommCareState
  * @property data - The response body (as JSON)
  * @property response - The HTTP response from the CommCare server (excluding the body)
  * @property references - An array of all previous data objects used in the Job
@@ -26,7 +26,7 @@ import * as util from './Utils.js';
  * @param {object} data - Object or JSON to create a resource
  * @param {Object} [params] - Optional request params
  * @returns {Operation}
- * @state {CommCareHttpState}
+ * @state {CommCareState}
  */
 export function post(path, data, params = {}) {
   return request('POST', path, data, params);
@@ -41,7 +41,7 @@ export function post(path, data, params = {}) {
  * @param {string} path - Path to resource. Relative paths are prefixed with `/a/<domain>/api/`; paths starting with `/` are used as-is.
  * @param {Object} [params] - Optional request params
  * @returns {Operation}
- * @state {CommCareHttpState}
+ * @state {CommCareState}
  */
 export function get(path, params = {}) {
   return request('GET', path, null, params);
@@ -58,7 +58,7 @@ export function get(path, params = {}) {
  * @param {object} body - Object which will be attached to the body
  * @param {object} params - An object of query parameters to be encoded into the URL
  * @returns {Operation}
- * @state {CommCareHttpState}
+ * @state {CommCareState}
  */
 export function request(method, path, body, params = {}) {
   return async state => {

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -3,7 +3,7 @@ import * as util from './Utils.js';
 
 /**
  * State object
- * @typedef {Object} CommcareHttpState
+ * @typedef {Object} CommCareHttpState
  * @property data - The response body (as JSON)
  * @property response - The HTTP response from the CommCare server (excluding the body)
  * @property references - An array of all previous data objects used in the Job
@@ -12,7 +12,7 @@ import * as util from './Utils.js';
 
 /**
  * Make a POST request to CommCare. Use this to send resources directly to Commcare REST API.
- * You can pass Commcare body data as a JSON object.
+ * You can pass CommCare body data as a JSON object.
  * @example <caption>Create a case using a relative path (prefixed with /a/<domain>/api/)</caption>
  * http.post('case/v2', {
  *   case_type: 'patient',
@@ -26,14 +26,14 @@ import * as util from './Utils.js';
  * @param {object} data - Object or JSON to create a resource
  * @param {Object} [params] - Optional request params
  * @returns {Operation}
- * @state {CommcareHttpState}
+ * @state {CommCareHttpState}
  */
 export function post(path, data, params = {}) {
   return request('POST', path, data, params);
 }
 
 /**
- * Make a GET request to CommCare. Use this to retrieve resources directly from the Commcare REST API.
+ * Make a GET request to CommCare. Use this to retrieve resources directly from the CommCare REST API.
  * @example <caption>Get cases using a relative path (prefixed with /a/<domain>/api/)</caption>
  * http.get('case/v1');
  * @function
@@ -41,14 +41,14 @@ export function post(path, data, params = {}) {
  * @param {string} path - Path to resource. Relative paths are prefixed with `/a/<domain>/api/`; paths starting with `/` are used as-is.
  * @param {Object} [params] - Optional request params
  * @returns {Operation}
- * @state {CommcareHttpState}
+ * @state {CommCareHttpState}
  */
 export function get(path, params = {}) {
   return request('GET', path, null, params);
 }
 
 /**
- * Make a general HTTP request against the Commcare server. Use this to make any request to Commcare REST API.
+ * Make a general HTTP request against the CommCare server. Use this to make any request to CommCare REST API.
  * @example <caption>GET cases with a relative path (prefixed with /a/<domain>/api/)</caption>
  * http.request('GET', 'case/v1');
  * @function
@@ -58,7 +58,7 @@ export function get(path, params = {}) {
  * @param {object} body - Object which will be attached to the body
  * @param {object} params - An object of query parameters to be encoded into the URL
  * @returns {Operation}
- * @state {CommcareHttpState}
+ * @state {CommCareHttpState}
  */
 export function request(method, path, body, params = {}) {
   return async state => {

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -36,30 +36,7 @@ import * as util from './Utils.js';
  * @state {CommcareHttpState}
  */
 export function post(path, data, params = {}) {
-  return async state => {
-    const { domain } = state.configuration;
-    const [resolvedPath, resolvedData, resolvedParams] = expandReferences(
-      state,
-      path,
-      data,
-      params,
-    );
-
-    const url = util.stripUrlPath(resolvedPath, domain);
-
-    try {
-      const response = await util.request(state.configuration, url, {
-        method: 'POST',
-        data: resolvedData,
-        params: resolvedParams,
-        contentType: 'application/json',
-      });
-
-      return util.prepareNextState(state, response);
-    } catch (e) {
-      throw e.body.error ?? e;
-    }
-  };
+   return request('POST', path, data, params);
 }
 
 /**
@@ -76,28 +53,7 @@ export function post(path, data, params = {}) {
  * @state {CommcareHttpState}
  */
 export function get(path, params = {}) {
-  return async state => {
-    const { domain } = state.configuration;
-    const [resolvedPath, resolvedParams] = expandReferences(
-      state,
-      path,
-      params,
-    );
-
-    const url = util.stripUrlPath(resolvedPath, domain);
-
-    try {
-      const response = await util.request(state.configuration, url, {
-        method: 'GET',
-        params: resolvedParams,
-        contentType: 'application/json',
-      });
-
-      return util.prepareNextState(state, response);
-    } catch (e) {
-      throw e.body.error ?? e;
-    }
-  };
+   return request('GET', path, null, params);
 }
 
 /**

--- a/packages/commcare/src/index.js
+++ b/packages/commcare/src/index.js
@@ -2,3 +2,4 @@ import * as Adaptor from './Adaptor.js';
 export default Adaptor;
 
 export * from './Adaptor.js';
+export * as http from './http.js';

--- a/packages/commcare/test/http.test.js
+++ b/packages/commcare/test/http.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { enableMockClient } from '@openfn/language-common/util';
 import * as http from '../src/http.js';
+import { stripUrlPath } from '../src/Utils.js';
 
 const hostUrl = 'http://test-example.commcare.com';
 const domain = 'test-staging';
@@ -15,6 +16,27 @@ const configuration = {
 };
 
 const baseState = { configuration };
+
+
+describe('stripUrlPath', () => {
+  it('prefixes a relative path with /a/<domain>/api/', () => {
+    expect(stripUrlPath('case/v1', 'my-domain')).to.equal(
+      '/a/my-domain/api/case/v1'
+    );
+  });
+
+  it('passes an absolute path through unchanged', () => {
+    expect(stripUrlPath('/a/my-domain/api/case/v1', 'my-domain')).to.equal(
+      '/a/my-domain/api/case/v1'
+    );
+  });
+
+  it('treats any path starting with / as absolute', () => {
+    expect(stripUrlPath('/some/custom/path', 'my-domain')).to.equal(
+      '/some/custom/path'
+    );
+  });
+});
 
 
 describe('http.get', () => {

--- a/packages/commcare/test/http.test.js
+++ b/packages/commcare/test/http.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { enableMockClient } from '@openfn/language-common/util';
-import * as http from '../src/http.js';
+import { http } from '../src/index.js';
 import { stripUrlPath } from '../src/Utils.js';
 
 const hostUrl = 'http://test-example.commcare.com';

--- a/packages/commcare/test/http.test.js
+++ b/packages/commcare/test/http.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { enableMockClient } from '@openfn/language-common/util';
 import { http } from '../src/index.js';
-import { stripUrlPath } from '../src/Utils.js';
+import { buildUrl } from '../src/Utils.js';
 
 const hostUrl = 'http://test-example.commcare.com';
 const domain = 'test-staging';
@@ -18,21 +18,21 @@ const configuration = {
 const baseState = { configuration };
 
 
-describe('stripUrlPath', () => {
+describe('buildUrl', () => {
   it('prefixes a relative path with /a/<domain>/api/', () => {
-    expect(stripUrlPath('case/v1', 'my-domain')).to.equal(
+    expect(buildUrl('case/v1', 'my-domain')).to.equal(
       '/a/my-domain/api/case/v1'
     );
   });
 
   it('passes an absolute path through unchanged', () => {
-    expect(stripUrlPath('/a/my-domain/api/case/v1', 'my-domain')).to.equal(
+    expect(buildUrl('/a/my-domain/api/case/v1', 'my-domain')).to.equal(
       '/a/my-domain/api/case/v1'
     );
   });
 
   it('treats any path starting with / as absolute', () => {
-    expect(stripUrlPath('/some/custom/path', 'my-domain')).to.equal(
+    expect(buildUrl('/some/custom/path', 'my-domain')).to.equal(
       '/some/custom/path'
     );
   });

--- a/packages/commcare/test/http.test.js
+++ b/packages/commcare/test/http.test.js
@@ -1,0 +1,152 @@
+import { expect } from 'chai';
+import { enableMockClient } from '@openfn/language-common/util';
+import * as http from '../src/http.js';
+
+const hostUrl = 'http://test-example.commcare.com';
+const domain = 'test-staging';
+
+const testServer = enableMockClient(hostUrl, { maxRedirections: 1 });
+
+const configuration = {
+  hostUrl,
+  domain,
+  username: 'user',
+  apiKey: 'test-api-key',
+};
+
+const baseState = { configuration };
+
+
+describe('http.get', () => {
+  it('gets cases using a relative path', async () => {
+    testServer
+      .intercept({
+        path: '/a/test-staging/api/case/v1',
+        method: 'GET',
+      })
+      .reply(200, { objects: [{ case_id: 'abc-001' }], meta: {} });
+
+    const finalState = await http.get('case/v1')(baseState);
+
+    expect(finalState.data).to.eql([{ case_id: 'abc-001' }]);
+  });
+
+  it('gets cases using an absolute path', async () => {
+    testServer
+      .intercept({
+        path: '/a/test-staging/api/case/v1/',
+        method: 'GET',
+      })
+      .reply(200, { objects: [{ case_id: 'abc-002' }], meta: {} });
+
+    const finalState = await http.get(
+      '/a/test-staging/api/case/v1/'
+    )(baseState);
+
+    expect(finalState.data).to.eql([{ case_id: 'abc-002' }]);
+  });
+});
+
+
+describe('http.post', () => {
+  it('creates a case using a relative path', async () => {
+    testServer
+      .intercept({
+        path: '/a/test-staging/api/case/v2',
+        method: 'POST',
+      })
+      .reply(200, {
+        case_id: 'xyz-001',
+        case_type: 'patient',
+        case_name: 'Elizabeth Harmon',
+      });
+
+    const finalState = await http.post('case/v2', {
+      case_type: 'patient',
+      case_name: 'Elizabeth Harmon',
+      owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
+      properties: { dob: '1948-11-02' },
+    })(baseState);
+
+    expect(finalState.data.case_name).to.equal('Elizabeth Harmon');
+  });
+
+  it('creates a case using an absolute path', async () => {
+    testServer
+      .intercept({
+        path: '/a/test-staging/api/case/v2',
+        method: 'POST',
+      })
+      .reply(200, {
+        case_id: 'xyz-002',
+        case_type: 'patient',
+        case_name: 'Elizabeth Harmon',
+      });
+
+    const finalState = await http.post(
+      '/a/test-staging/api/case/v2',
+      {
+        case_type: 'patient',
+        case_name: 'Elizabeth Harmon',
+        owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
+        properties: { dob: '1948-11-02' },
+      }
+    )(baseState);
+
+    expect(finalState.data.case_name).to.equal('Elizabeth Harmon');
+  });
+});
+
+
+describe('http.request', () => {
+  it('GET cases with a relative path', async () => {
+    testServer
+      .intercept({
+        path: '/a/test-staging/api/case/v1',
+        method: 'GET',
+      })
+      .reply(200, { objects: [{ case_id: 'abc-003' }], meta: {} });
+
+    const finalState = await http.request('GET', 'case/v1')(baseState);
+
+    expect(finalState.data).to.eql([{ case_id: 'abc-003' }]);
+  });
+
+  it('GET cases using an absolute path', async () => {
+    testServer
+      .intercept({
+        path: '/a/test-staging/api/case/v1/',
+        method: 'GET',
+      })
+      .reply(200, { objects: [{ case_id: 'abc-004' }], meta: {} });
+
+    const finalState = await http.request(
+      'GET',
+      '/a/test-staging/api/case/v1/'
+    )(baseState);
+
+    expect(finalState.data).to.eql([{ case_id: 'abc-004' }]);
+  });
+
+  it('POST a case with a relative path', async () => {
+    testServer
+      .intercept({
+        path: '/a/test-staging/api/case/v2',
+        method: 'POST',
+      })
+      .reply(200, {
+        case_id: 'xyz-003',
+        case_type: 'patient',
+        case_name: 'Elizabeth Harmon',
+      });
+
+    const finalState = await http.request('POST', 'case/v2', {
+      case_type: 'patient',
+      case_name: 'Elizabeth Harmon',
+      owner_id: '20cc9dda-b90a-4af3-aa3d-fc67184e73ef',
+      properties: { dob: '1948-11-02' },
+    })(baseState);
+
+    expect(finalState.data.case_id).to.equal('xyz-003');
+  });
+});

--- a/packages/fhir-opensrp/CHANGELOG.md
+++ b/packages/fhir-opensrp/CHANGELOG.md
@@ -1,8 +1,7 @@
 # @openfn/language-fhir-opensrp
 
-## 1.0.0
+## 1.0.0 - 11 August 2026
 
 Implemented the `fhir-opensrp` adaptor with `create()`, `read()`, `delete()`, `update()` and `request()` methods.
 
 Exported `fhir-4` builder helper functions for the fhir resources
-


### PR DESCRIPTION
## Summary


Added `http` namespace with `http.get()`, `http.post()`, and `http.request()` for direct access to the CommCare REST API.

All functions support two URL conventions:

- **Relative paths** are automatically prefixed with `/a/<domain>/api/`, so you only need to provide the resource and version.
- **Absolute paths** (starting with `/`) are passed through unchanged, giving you full control over the URL.

```js
// Relative path — resolves to /a/my-project/api/case/v1
http.get('case/v1');

// Absolute path — used exactly as written
http.get('/a/my-project/api/case/v1');
```

- Used `/code-review` for initial code review

Fixes #1738 


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [x] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [x] Have you ticked a box under AI Usage?
