### PR TITLE
 msgraph: wrap `uploadFile` upload-session metadata in an `item` property

### DIFF
--- a/.changeset/eighty-pugs-tickle.md
+++ b/.changeset/eighty-pugs-tickle.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-msgraph': patch
----
-
-Fix `uploadFile` to wrap upload session metadata in an `item` property, as required by the Microsoft Graph createUploadSession API

--- a/.changeset/eighty-pugs-tickle.md
+++ b/.changeset/eighty-pugs-tickle.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-msgraph': patch
+---
+
+Fix `uploadFile` to wrap upload session metadata in an `item` property, as required by the Microsoft Graph createUploadSession API

--- a/.changeset/public-planes-dig.md
+++ b/.changeset/public-planes-dig.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-commcare': patch
----
-
-Fix an issue in docs which caused mdx parsers to fail

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dist
 .idea
 
 /pnpm-publish-summary.json
+
+# graphify knowledge graph output
+graphify-out/

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/language-commcare
 
+## 4.2.1 - 17 August 2026
+
+### Patch Changes
+
+- 52d6a74: Fix an issue in docs which caused mdx parsers to fail
+
 ## 4.2.0 - 11 August 2026
 
 ### Minor Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-commcare",
   "label": "CommCare",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "OpenFn adaptor for CommCare (Dimagi)",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/msgraph/CHANGELOG.md
+++ b/packages/msgraph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/language-msgraph
 
+## 0.10.1 - 17 August 2026
+
+### Patch Changes
+
+- c29cc83: Fix `uploadFile` to wrap upload session metadata in an `item`
+  property, as required by the Microsoft Graph createUploadSession API
+
 ## 0.10.0 - 06 August 2026
 
 ### Minor Changes

--- a/packages/msgraph/package.json
+++ b/packages/msgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-msgraph",
   "label": "Microsoft Graph",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Microsoft Graph Language Pack for OpenFn",
   "type": "module",
   "exports": {

--- a/packages/msgraph/src/Adaptor.js
+++ b/packages/msgraph/src/Adaptor.js
@@ -350,8 +350,10 @@ export function uploadFile(resource, data, callback) {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        '@microsoft.graph.conflictBehavior': onConflict,
-        name: fileName,
+        item: {
+          '@microsoft.graph.conflictBehavior': onConflict,
+          name: fileName,
+        },
       }),
     });
 

--- a/packages/msgraph/test/Adaptor.test.js
+++ b/packages/msgraph/test/Adaptor.test.js
@@ -91,7 +91,7 @@ describe('getDrive', () => {
         // write the drives object back to state before it gets cleaned up
         state.result = state.drives;
         return state;
-      })
+      }),
     )(state);
 
     expect(finalState.result.default).to.eql(fixtures.driveResponse);
@@ -109,7 +109,7 @@ describe('getDrive', () => {
         // write the drives object back to state before it gets cleaned up
         state.result = state.drives;
         return state;
-      })
+      }),
     )(state);
 
     expect(finalState.result.mydrive).to.eql(fixtures.driveResponse);
@@ -130,8 +130,8 @@ describe('getDrive', () => {
           // write the drives object back to state before it gets cleaned up
           state.result = state.drives;
           return state;
-        }
-      )
+        },
+      ),
     )(state);
 
     expect(finalState.result.default).to.eql(fixtures.driveResponse);
@@ -146,9 +146,9 @@ describe('getDrive', () => {
     await execute(
       getDrive({ id: 'noAccess', owner: 'sites' })(state).catch(e => {
         expect(e.message).to.contain(
-          fixtures.invalidRequestResponse.error.message
+          fixtures.invalidRequestResponse.error.message,
         );
-      })
+      }),
     )(state);
   });
 
@@ -163,10 +163,10 @@ describe('getDrive', () => {
       getDrive({ id: 'openfn.sharepoint.com', owner: 'sites' })(state).catch(
         e => {
           expect(e.message).to.contain(
-            fixtures.invalidTokenResponse.error.message
+            fixtures.invalidTokenResponse.error.message,
           );
-        }
-      )
+        },
+      ),
     )(state);
   });
 
@@ -181,10 +181,10 @@ describe('getDrive', () => {
       getDrive({ id: 'openfn.sharepoint.com', owner: 'sites' })(state).catch(
         e => {
           expect(e.message).to.contain(
-            fixtures.expiredTokenResponse.error.message
+            fixtures.expiredTokenResponse.error.message,
           );
-        }
-      )
+        },
+      ),
     )(state);
   });
 });
@@ -203,7 +203,7 @@ describe('getFolder', () => {
     };
 
     const finalState = await execute(
-      getFolder('01LUM6XOCKDTZKQC7AVZF2VMHE2I3O6OY3', { metadata: true })
+      getFolder('01LUM6XOCKDTZKQC7AVZF2VMHE2I3O6OY3', { metadata: true }),
     )(state);
 
     expect(finalState.data).to.eql(fixtures.itemResponse);
@@ -222,7 +222,7 @@ describe('getFolder', () => {
     };
 
     const finalState = await execute(
-      getFolder('01LUM6XOCKDTZKQC7AVZF2VMHE2I3O6OY3')
+      getFolder('01LUM6XOCKDTZKQC7AVZF2VMHE2I3O6OY3'),
     )(state);
 
     expect(finalState.data).to.eql(fixtures.itemsResponse);
@@ -244,7 +244,7 @@ describe('getFolder', () => {
       getFolder('01LUM6XOCKDTZKQC7AVZF2VMHE2I3O6OY3', {
         driveName: 'mydrive',
         metadata: true,
-      })
+      }),
     )(state);
 
     expect(finalState.data).to.eql(fixtures.itemResponse);
@@ -263,7 +263,7 @@ describe('getFolder', () => {
     };
 
     const finalState = await execute(
-      getFolder('01LUM6XOCKDTZKQC7AVZF2VMHE2I3O6OY3', { driveName: 'mydrive' })
+      getFolder('01LUM6XOCKDTZKQC7AVZF2VMHE2I3O6OY3', { driveName: 'mydrive' }),
     )(state);
 
     expect(finalState.data).to.eql(fixtures.itemsResponse);
@@ -282,7 +282,7 @@ describe('getFolder', () => {
     };
 
     const finalState = await execute(
-      getFolder('/Sample Data', { metadata: true })
+      getFolder('/Sample Data', { metadata: true }),
     )(state);
 
     expect(finalState.data).to.eql(fixtures.itemResponse);
@@ -317,7 +317,7 @@ describe('getFolder', () => {
       },
     };
     const finalState = await execute(
-      getFolder('/Sample Data', { driveName: 'mydrive', metadata: true })
+      getFolder('/Sample Data', { driveName: 'mydrive', metadata: true }),
     )(state);
     expect(finalState.data).to.eql(fixtures.itemResponse);
   });
@@ -334,7 +334,7 @@ describe('getFolder', () => {
       },
     };
     const finalState = await execute(
-      getFolder('/Sample Data', { driveName: 'mydrive' })
+      getFolder('/Sample Data', { driveName: 'mydrive' }),
     )(state);
     expect(finalState.data).to.eql(fixtures.itemsResponse);
   });
@@ -367,7 +367,7 @@ describe('getFile', () => {
     };
 
     const finalState = await execute(
-      getFile('01LUM6XOGRONYNTZ26DBBJPTN5IFTQPBIW')
+      getFile('01LUM6XOGRONYNTZ26DBBJPTN5IFTQPBIW'),
     )(state);
 
     expect(finalState.data).to.eql(fixtures.itemContent);
@@ -388,7 +388,7 @@ describe('getFile', () => {
     const finalState = await execute(
       getFile('01LUM6XOGRONYNTZ26DBBJPTN5IFTQPBIW', {
         metadata: true,
-      })
+      }),
     )(state);
 
     expect(finalState.data).to.eql(fixtures.itemWithDownloadUrl);
@@ -409,7 +409,7 @@ describe('getFile', () => {
     const finalState = await execute(
       getFile('01LUM6XOGRONYNTZ26DBBJPTN5IFTQPBIW', {
         driveName: 'mydrive',
-      })
+      }),
     )(state);
 
     expect(finalState.data).to.eql(fixtures.itemContent);
@@ -445,7 +445,7 @@ describe('getFile', () => {
     };
 
     const finalState = await execute(
-      getFile('/Sample Data/test.csv', { metadata: true })
+      getFile('/Sample Data/test.csv', { metadata: true }),
     )(state);
 
     expect(finalState.data).to.eql(fixtures.itemWithDownloadUrl);
@@ -485,7 +485,7 @@ describe('uploadFile', () => {
         fileName: 'Tracker.xlsx',
         ...resource,
       }),
-      state => state.buffer
+      state => state.buffer,
     )(state);
 
   const conflictBehaviour = () =>
@@ -501,13 +501,11 @@ describe('uploadFile', () => {
   });
 
   it('should wrap the file metadata in an item property', async () => {
-    // onConflict is passed explicitly so this test describes the envelope
-    // only, and doesn't also fail if the default conflict behaviour changes
-    await upload(uploadState(), { onConflict: 'replace' });
+    await upload(uploadState(), { onConflict: 'fail' });
 
     expect(JSON.parse(captured.createUploadSession.body)).to.eql({
       item: {
-        '@microsoft.graph.conflictBehavior': 'replace',
+        '@microsoft.graph.conflictBehavior': 'fail',
         name: 'Tracker.xlsx',
       },
     });
@@ -541,7 +539,7 @@ describe('uploadFile', () => {
     expect(headers['Content-Type']).to.eql('application/octet-stream');
     expect(headers['Content-Length']).to.eql(`${buffer.length}`);
     expect(headers['Content-Range']).to.eql(
-      `bytes 0-${buffer.length - 1}/${buffer.length}`
+      `bytes 0-${buffer.length - 1}/${buffer.length}`,
     );
   });
 });
@@ -582,7 +580,7 @@ describe('zip', () => {
     const state = {};
 
     expect(() =>
-      zip([{ name: 'empty.txt', content: undefined }])(state)
+      zip([{ name: 'empty.txt', content: undefined }])(state),
     ).to.throw('no content provided for file "empty.txt"');
   });
 

--- a/packages/msgraph/test/Adaptor.test.js
+++ b/packages/msgraph/test/Adaptor.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { setGlobalDispatcher } from 'undici';
 
-import MockAgent from './mockAgent.js';
+import MockAgent, { captured } from './mockAgent.js';
 import { fixtures } from './fixtures.js';
 import AdmZip from 'adm-zip';
 
@@ -466,41 +466,83 @@ describe('getFile', () => {
 });
 
 describe('uploadFile', () => {
-  it.skip('should convert array of object to excel and post to specified path', async () => {
-    const state = {
-      configuration: {
-        accessToken: fixtures.accessToken,
-      },
-      siteId: 'openfn.sharepoint.com',
-      folderId: '01LUM6XOGVJ2OK2Z5RJRAKU3WAK2MTC5XD',
-      drives: {},
-      rows: [
-        [
-          {
-            name: 'Mtuchi',
-            birthday: '1/1/1973',
-          },
-          {
-            name: 'Aleksa',
-            birthday: '1/1/2023',
-          },
-        ],
-      ],
-    };
+  const buffer = Buffer.from('a,b,c\n1,2,3');
 
-    const finalState = await uploadFile(
+  const uploadState = () => ({
+    configuration: {
+      accessToken: fixtures.accessToken,
+    },
+    driveId: 'b!YXzpkoLwR06bxC8tNdg71m_',
+    folderId: '01LUM6XOGVJ2OK2Z5RJRAKU3WAK2MTC5XD',
+    buffer,
+  });
+
+  const upload = (state, resource = {}) =>
+    uploadFile(
       state => ({
-        siteId: state.siteId,
-        parentItemId: state.folderId,
-        fileName: `invalidGrantCodeRows_${new Date()
-          .toISOString()
-          .replace(/[-:.]/g, '_')}.csv`,
+        driveId: state.driveId,
+        folderId: state.folderId,
+        fileName: 'Tracker.xlsx',
+        ...resource,
       }),
       state => state.buffer
     )(state);
 
-    console.log(finalState.buffer);
-    expect(data).to.eql(fixtures.uploadFileResponse);
+  const conflictBehaviour = () =>
+    JSON.parse(captured.createUploadSession.body).item[
+      '@microsoft.graph.conflictBehavior'
+    ];
+
+  it('should upload a file and return the created drive item', async () => {
+    const finalState = await upload(uploadState());
+
+    expect(finalState.data).to.eql(fixtures.submitXlsResponse);
+    expect(finalState.response).to.eql(fixtures.submitXlsResponse);
+  });
+
+  it('should wrap the file metadata in an item property', async () => {
+    // onConflict is passed explicitly so this test describes the envelope
+    // only, and doesn't also fail if the default conflict behaviour changes
+    await upload(uploadState(), { onConflict: 'replace' });
+
+    expect(JSON.parse(captured.createUploadSession.body)).to.eql({
+      item: {
+        '@microsoft.graph.conflictBehavior': 'replace',
+        name: 'Tracker.xlsx',
+      },
+    });
+  });
+
+  it('should default onConflict to replace', async () => {
+    await upload(uploadState());
+
+    expect(conflictBehaviour()).to.eql('replace');
+  });
+
+  it('should send the given onConflict behaviour', async () => {
+    await upload(uploadState(), { onConflict: 'rename' });
+
+    expect(conflictBehaviour()).to.eql('rename');
+  });
+
+  it('should send onConflict from state', async () => {
+    const state = { ...uploadState(), conflictMode: 'fail' };
+
+    await upload(state, { onConflict: state.conflictMode });
+
+    expect(conflictBehaviour()).to.eql('fail');
+  });
+
+  it('should send the file with content headers describing the whole buffer', async () => {
+    await upload(uploadState());
+
+    const { headers } = captured.upload;
+
+    expect(headers['Content-Type']).to.eql('application/octet-stream');
+    expect(headers['Content-Length']).to.eql(`${buffer.length}`);
+    expect(headers['Content-Range']).to.eql(
+      `bytes 0-${buffer.length - 1}/${buffer.length}`
+    );
   });
 });
 

--- a/packages/msgraph/test/fixtures.js
+++ b/packages/msgraph/test/fixtures.js
@@ -180,10 +180,22 @@ const itemsResponse = {
   ],
 };
 
+// The upload session is created on graph.microsoft.com, but the uploadUrl it
+// returns points at a different host, which the PUT then goes to directly.
+const uploadSessionUrl =
+  'https://openfn.sharepoint.com/_api/v2.0/drives/b!YXzpkoLwR06bxC8tNdg71m_/items/01LUM6XOGVJ2OK2Z5RJRAKU3WAK2MTC5XD/uploadSession';
+
 const fixtures = {
   accessToken: 'validAccessToken=',
   expiredToken: 'expiredAccessToken',
   invalidToken: 'invalidAccessToken',
+  uploadSessionUrl: uploadSessionUrl,
+  uploadSessionResponse: {
+    '@odata.context':
+      'https://graph.microsoft.com/v1.0/$metadata#microsoft.graph.uploadSession',
+    expirationDateTime: '2023-09-19T07:34:09.369Z',
+    uploadUrl: uploadSessionUrl,
+  },
   driveResponse: driveResponse,
   invalidRequestResponse: {
     // 400

--- a/packages/msgraph/test/fixtures.js
+++ b/packages/msgraph/test/fixtures.js
@@ -180,8 +180,6 @@ const itemsResponse = {
   ],
 };
 
-// The upload session is created on graph.microsoft.com, but the uploadUrl it
-// returns points at a different host, which the PUT then goes to directly.
 const uploadSessionUrl =
   'https://openfn.sharepoint.com/_api/v2.0/drives/b!YXzpkoLwR06bxC8tNdg71m_/items/01LUM6XOGVJ2OK2Z5RJRAKU3WAK2MTC5XD/uploadSession';
 

--- a/packages/msgraph/test/mockAgent.js
+++ b/packages/msgraph/test/mockAgent.js
@@ -3,6 +3,9 @@ import { fixtures } from './fixtures.js';
 
 const mockAgent = new MockAgent();
 
+// Any request without a matching intercept must throw, not reach the network.
+mockAgent.disableNetConnect();
+
 const mockPool = mockAgent.get('https://graph.microsoft.com');
 
 const jsonResponse = {
@@ -135,12 +138,39 @@ mockPool
   .reply(200, fixtures.itemContent)
   .persist();
 
+export const captured = {};
+
 mockPool
   .intercept({
-    path: '/v1.0/sites/openfn.sharepoint.com/drive/items/01LUM6XOGVJ2OK2Z5RJRAKU3WAK2MTC5XD:/2023_09_19T07_29_09_369Z.xls:/content',
-    method: 'PUT',
+    path: '/v1.0/drives/b!YXzpkoLwR06bxC8tNdg71m_/items/01LUM6XOGVJ2OK2Z5RJRAKU3WAK2MTC5XD:/Tracker.xlsx:/createUploadSession',
+    method: 'POST',
     headers: headers,
   })
-  .reply(200, fixtures.submitXlsResponse);
+  .reply(
+    200,
+    opts => {
+      captured.createUploadSession = opts;
+      return fixtures.uploadSessionResponse;
+    },
+    jsonResponse,
+  )
+  .persist();
+
+const uploadPool = mockAgent.get('https://openfn.sharepoint.com');
+
+uploadPool
+  .intercept({
+    path: '/_api/v2.0/drives/b!YXzpkoLwR06bxC8tNdg71m_/items/01LUM6XOGVJ2OK2Z5RJRAKU3WAK2MTC5XD/uploadSession',
+    method: 'PUT',
+  })
+  .reply(
+    200,
+    opts => {
+      captured.upload = opts;
+      return fixtures.submitXlsResponse;
+    },
+    jsonResponse,
+  )
+  .persist();
 
 export default mockAgent;

--- a/packages/msgraph/test/mockAgent.js
+++ b/packages/msgraph/test/mockAgent.js
@@ -3,7 +3,6 @@ import { fixtures } from './fixtures.js';
 
 const mockAgent = new MockAgent();
 
-// Any request without a matching intercept must throw, not reach the network.
 mockAgent.disableNetConnect();
 
 const mockPool = mockAgent.get('https://graph.microsoft.com');


### PR DESCRIPTION
## Summary

Fix `onConflict` option in `uploadFile()` function 

Fixes #1761

## Details

The `createUploadSession` request body was sending the file metadata
flat:

```js
body: JSON.stringify({
  '@microsoft.graph.conflictBehavior': onConflict,
  name: fileName,
})
```

MSGraph expects that metadata nested under a single `item` key of type `driveItemUploadableProperties`. Sent flat, the conflict behaviour and filename were ignored. This PR wraps them:

```js
body: JSON.stringify({
  item: {
    '@microsoft.graph.conflictBehavior': onConflict,
    name: fileName,
  },
})
```

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [x] Are there any unit tests?
- [x] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [x] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [x] Have you ticked a box under AI Usage?
