### PR TITLE
feat(chatgpt,claude): allow users to specify `baseUrl`

### DIFF
--- a/packages/chatgpt/configuration-schema.json
+++ b/packages/chatgpt/configuration-schema.json
@@ -15,6 +15,21 @@
       "type": "string",
       "minLength": 1,
       "examples": ["sk-proj-api03-YOUR_SECRET_KEY"]
+    },
+    "baseUrl": {
+      "title": "Base URL",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The URL for the OpenAI-compatible endpoint of the LLM provider",
+      "type": "string",
+      "minLength": 1,
+      "examples": ["https://api.openai.com/v1"]
     }
   },
   "type": "object",

--- a/packages/chatgpt/src/Adaptor.js
+++ b/packages/chatgpt/src/Adaptor.js
@@ -28,11 +28,10 @@ let client;
  * @returns {state}
  */
 export function createClient(state) {
-  const { apiKey } = state.configuration;
+  const { apiKey, baseUrl } = state.configuration;
 
-  client = new OpenAI({
-    apiKey,
-  });
+  const clientOptions = baseUrl ? { apiKey, baseUrl } : { apiKey };
+  client = new OpenAI(clientOptions);
 
   return state;
 }

--- a/packages/chatgpt/src/Adaptor.js
+++ b/packages/chatgpt/src/Adaptor.js
@@ -30,8 +30,10 @@ let client;
 export function createClient(state) {
   const { apiKey, baseUrl } = state.configuration;
 
-  const clientOptions = baseUrl ? { apiKey, baseUrl } : { apiKey };
-  client = new OpenAI(clientOptions);
+  client = new OpenAI({
+    apiKey,
+    baseUrl,
+  });
 
   return state;
 }

--- a/packages/claude/configuration-schema.json
+++ b/packages/claude/configuration-schema.json
@@ -15,6 +15,21 @@
       "type": "string",
       "minLength": 1,
       "examples": ["sk-ant-api03-YOUR_SECRET_KEY"]
+    },
+    "baseUrl": {
+      "title": "Base URL",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The URL for the endpoint of the LLM provider compatible with the Messages API for Claude",
+      "type": "string",
+      "minLength": 1,
+      "examples": ["https://api.anthropic.com"]
     }
   },
   "type": "object",

--- a/packages/claude/src/Adaptor.js
+++ b/packages/claude/src/Adaptor.js
@@ -24,8 +24,10 @@ let client;
 export function createClient(state) {
   const { apiKey, baseUrl } = state.configuration;
 
-  const clientOptions = baseUrl ? { apiKey, baseUrl } : { apiKey };
-  client = new Anthropic(clientOptions);
+  client = new Anthropic({
+    apiKey,
+    baseUrl,
+  });
 
   return state;
 }

--- a/packages/claude/src/Adaptor.js
+++ b/packages/claude/src/Adaptor.js
@@ -22,11 +22,10 @@ let client;
  * @returns {state}
  */
 export function createClient(state) {
-  const { apiKey } = state.configuration;
+  const { apiKey, baseUrl } = state.configuration;
 
-  client = new Anthropic({
-    apiKey,
-  });
+  const clientOptions = baseUrl ? { apiKey, baseUrl } : { apiKey };
+  client = new Anthropic(clientOptions);
 
   return state;
 }


### PR DESCRIPTION
## Summary

Allow users to specify an OpenAI-compatible (for `chatgpt`) or Claude-compatible (for `claude`) endpoint
to the corresponding adaptors, for the following use cases:

- Routing requests through a reverse proxy
- Sending requests to self-hosted infrastructure, eg: Ollama, vLLM
- Replacing OpenAI or Claude with alternatives, eg:
  - [Mistral](https://docs.mistral.ai/resources/migration-guides), [Groq](https://console.groq.com/docs/openai) (OpenAI-compatible)
  - [DeepSeek](https://api-docs.deepseek.com/guides/anthropic_api/) (Claude-compatible)

## Details

- Add `baseUrl` as an optional property in both `chatgpt` and `claude` config schemas
- When present, pass `baseUrl` along with `apiKey` to the OpenAI or Anthropic client constructor

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [x] Have you ticked a box under AI Usage?
