### PR TITLE
Commcare: implement pagination in http.get

### DIFF
--- a/.changeset/quiet-eggs-yawn.md
+++ b/.changeset/quiet-eggs-yawn.md
@@ -1,0 +1,24 @@
+---
+'@openfn/language-commcare': minor
+---
+
+Add opt-in pagination to `http.get`
+
+`http.get` now supports two pagination modes, both disabled by default:
+
+- **Accumulate** — pass `paginate: true` to fetch all pages and return them
+  as a single array in `state.data`:
+  ```js
+  http.get('case/v1', { paginate: true });
+  ```
+- **Stream** — pass a callback as the third argument to process each page
+  individually without accumulating the full result in `state.data`:
+  ```js
+  http.get('case/v1', { paginate: true }, state => {
+    // state.data is the current page's records only
+    return state;
+  });
+  ```
+
+Both modes support the v1 (offset/limit) and v2 (cursor) CommCare APIs.
+In stream mode `state.data` is `{}` after the operation completes.

--- a/.changeset/quiet-eggs-yawn.md
+++ b/.changeset/quiet-eggs-yawn.md
@@ -1,5 +1,0 @@
----
-'@openfn/language-commcare': minor
----
-
-Add opt-in pagination to `http.get`. Pass `params.paginate: true` to accumulate all pages into `state.data`, or also provide a callback to stream each page without accumulating.

--- a/.changeset/quiet-eggs-yawn.md
+++ b/.changeset/quiet-eggs-yawn.md
@@ -2,23 +2,4 @@
 '@openfn/language-commcare': minor
 ---
 
-Add opt-in pagination to `http.get`
-
-`http.get` now supports two pagination modes, both disabled by default:
-
-- **Accumulate** — pass `paginate: true` to fetch all pages and return them
-  as a single array in `state.data`:
-  ```js
-  http.get('case/v1', { paginate: true });
-  ```
-- **Stream** — pass a callback as the third argument to process each page
-  individually without accumulating the full result in `state.data`:
-  ```js
-  http.get('case/v1', { paginate: true }, state => {
-    // state.data is the current page's records only
-    return state;
-  });
-  ```
-
-Both modes support the v1 (offset/limit) and v2 (cursor) CommCare APIs.
-In stream mode `state.data` is `{}` after the operation completes.
+Add opt-in pagination to `http.get`. Pass `params.paginate: true` to accumulate all pages into `state.data`, or also provide a callback to stream each page without accumulating.

--- a/packages/commcare/CHANGELOG.md
+++ b/packages/commcare/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/language-commcare
 
+## 4.3.0 - 28 August 2026
+
+### Minor Changes
+
+- 7bf9586: Add opt-in pagination to `http.get`. Pass `params.paginate: true` to
+  accumulate all pages into `state.data`, or also provide a callback to stream
+  each page without accumulating.
+
 ## 4.2.1 - 17 August 2026
 
 ### Patch Changes

--- a/packages/commcare/package.json
+++ b/packages/commcare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/language-commcare",
   "label": "CommCare",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "OpenFn adaptor for CommCare (Dimagi)",
   "homepage": "https://docs.openfn.org",
   "repository": {

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -36,15 +36,92 @@ export function post(path, data, params = {}) {
  * Make a GET request to CommCare. Use this to retrieve resources directly from the CommCare REST API.
  * @example <caption>Get cases using the v1 API (prefixed with /a/[domain]/api/)</caption>
  * http.get('case/v1');
+ * @example <caption>Get all cases paginated into state.data </caption>
+ * http.get('case/v2', { paginate: true });
+ * @example <caption>Get all cases paginated and return each response to a callback</caption>
+ * http.get('case/v2', { paginate: true }, (state) => {
+ *   console.log(state.data); // one page at a time
+ *   return state;
+ * });
  * @function
  * @public
  * @param {string} path - Path to resource. Relative paths are prefixed with `/a/[domain]/api/`; paths starting with `/` are used as-is.
- * @param {Object} [params] - Optional request params
+ * @param {Object} [params] - Optional request params. Set `paginate: true` to enable automatic pagination.
+ * @param {Function} [callback] - Optional per-page callback. When provided with `paginate: true`, each page is passed to the callback and NOT accumulated into state.data.
  * @returns {Operation}
  * @state {CommCareState}
  */
-export function get(path, params = {}) {
-  return request('GET', path, null, params);
+export function get(path, params = {}, callback) {
+  return async state => {
+    const { domain } = state.configuration;
+    const [resolvedPath, resolvedParams] = expandReferences(
+      state,
+      path,
+      params,
+    );
+
+    const { paginate, ...requestParams } = resolvedParams;
+    const shouldPaginate = paginate === true;
+    // Return response data to callback if provided
+    const callbackFn = typeof callback === 'function';
+
+    const url = util.buildUrl(resolvedPath, domain);
+
+    try {
+      let currentParams = { ...requestParams };
+      let results = null;
+      let nextState = state;
+
+      do {
+        const response = await util.request(state.configuration, url, {
+          method: 'GET',
+          params: currentParams,
+          contentType: 'application/json',
+        });
+
+        const body = response.body;
+        // Only return response array data
+        const items = Object.values(body).find(Array.isArray) ?? [];
+
+        if (callbackFn) {
+
+          const pageState = util.prepareNextState(state, response);
+          nextState = await callback({ ...pageState, data: items });
+        } else {
+          nextState = util.prepareNextState(state, response);
+          if (!results) results = [];
+          results.push(...items);
+        }
+
+        const v1Next = body?.meta?.next;
+        const v2Next = !body?.meta && body?.next;
+        const hasMore = shouldPaginate && (v1Next || v2Next);
+
+        if (hasMore) {
+          if (v1Next) {
+            currentParams = {
+              ...requestParams,
+              offset: body.meta.offset + body.meta.limit,
+              limit: body.meta.limit,
+            };
+          } else {
+            // extract cursor from the absolute next URL
+            const cursor = new URL(v2Next).searchParams.get('cursor');
+            currentParams = { ...requestParams, cursor };
+          }
+        } else {
+          break;
+        }
+      } while (true);
+
+      return {
+        ...nextState,
+        data: callbackFn ? {} : results ?? nextState.data,
+      };
+    } catch (error) {
+      throw error;
+    }
+  };
 }
 
 /**

--- a/packages/commcare/src/http.js
+++ b/packages/commcare/src/http.js
@@ -36,18 +36,20 @@ export function post(path, data, params = {}) {
  * Make a GET request to CommCare. Use this to retrieve resources directly from the CommCare REST API.
  * @example <caption>Get cases using the v1 API (prefixed with /a/[domain]/api/)</caption>
  * http.get('case/v1');
- * @example <caption>Get all cases paginated into state.data </caption>
+ * @example <caption>Filter cases by type using query parameters</caption>
+ * http.get('case/v1', { case_type: 'patient', limit: 100 });
+ * @example <caption>Paginate all results into state.data</caption>
  * http.get('case/v2', { paginate: true });
- * @example <caption>Get all cases paginated and return each response to a callback</caption>
- * http.get('case/v2', { paginate: true }, (state) => {
+ * @example <caption>Stream each page to a callback without accumulating in memory</caption>
+ * http.get('case/v2', { paginate: true }, state => {
  *   console.log(state.data); // one page at a time
  *   return state;
  * });
  * @function
  * @public
  * @param {string} path - Path to resource. Relative paths are prefixed with `/a/[domain]/api/`; paths starting with `/` are used as-is.
- * @param {Object} [params] - Optional request params. Set `paginate: true` to enable automatic pagination.
- * @param {Function} [callback] - Optional per-page callback. When provided with `paginate: true`, each page is passed to the callback and NOT accumulated into state.data.
+ * @param {Object} [params] - Query parameters to append to the URL. All keys except `params.paginate` are sent as query strings (e.g. `{ case_type: 'patient' }` becomes `?case_type=patient`). Set `params.paginate` to `true` to enable automatic pagination.
+ * @param {Function} [callback] - Optional per-page callback. When provided alongside `params.paginate`, each page's records are passed as `state.data` and the full dataset is NOT accumulated. `state.data` will be `{}` when the operation completes.
  * @returns {Operation}
  * @state {CommCareState}
  */
@@ -61,9 +63,9 @@ export function get(path, params = {}, callback) {
     );
 
     const { paginate, ...requestParams } = resolvedParams;
-    const shouldPaginate = paginate === true;
+
     // Return response data to callback if provided
-    const callbackFn = typeof callback === 'function';
+    const callbackMode = typeof callback === 'function';
 
     const url = util.buildUrl(resolvedPath, domain);
 
@@ -83,7 +85,7 @@ export function get(path, params = {}, callback) {
         // Only return response array data
         const items = Object.values(body).find(Array.isArray) ?? [];
 
-        if (callbackFn) {
+        if (callbackMode) {
 
           const pageState = util.prepareNextState(state, response);
           nextState = await callback({ ...pageState, data: items });
@@ -93,21 +95,20 @@ export function get(path, params = {}, callback) {
           results.push(...items);
         }
 
-        const v1Next = body?.meta?.next;
-        const v2Next = !body?.meta && body?.next;
-        const hasMore = shouldPaginate && (v1Next || v2Next);
+        // cursor API (body.next) takes precedence over paging API (body.meta.next)
+        const next = body?.next ?? body?.meta?.next;
+        const hasMore = paginate === true && next;
 
         if (hasMore) {
-          if (v1Next) {
+          if (body?.next) {
+            const cursor = new URL(body.next).searchParams.get('cursor');
+            currentParams = { ...requestParams, cursor };
+          } else {
             currentParams = {
               ...requestParams,
               offset: body.meta.offset + body.meta.limit,
               limit: body.meta.limit,
             };
-          } else {
-            // extract cursor from the absolute next URL
-            const cursor = new URL(v2Next).searchParams.get('cursor');
-            currentParams = { ...requestParams, cursor };
           }
         } else {
           break;
@@ -116,7 +117,7 @@ export function get(path, params = {}, callback) {
 
       return {
         ...nextState,
-        data: callbackFn ? {} : results ?? nextState.data,
+        data: callbackMode ? {} : results ?? nextState.data,
       };
     } catch (error) {
       throw error;

--- a/packages/commcare/test/http.test.js
+++ b/packages/commcare/test/http.test.js
@@ -84,7 +84,7 @@ describe('http.get', () => {
     expect(finalState.data).to.eql([{ case_id: 'abc-002' }]);
   });
 
-  describe('no pagination (default)', () => {
+  describe('no pagination', () => {
     it('does not paginate even when meta.next is present (v1)', async () => {
       testServer
         .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })

--- a/packages/commcare/test/http.test.js
+++ b/packages/commcare/test/http.test.js
@@ -17,6 +17,30 @@ const configuration = {
 
 const baseState = { configuration };
 
+// Builds a v1 (offset/limit) paginated responder for use with .reply(200, fn)
+const v1Responder = (objects, pageSize = 1) => req => {
+  const offset = Number(req.query.offset ?? 0);
+  const limit = Number(req.query.limit ?? pageSize);
+  const nextOffset = offset + limit;
+  const next =
+    nextOffset < objects.length ? `?limit=${limit}&offset=${nextOffset}` : null;
+  return {
+    objects: objects.slice(offset, offset + limit),
+    meta: { limit, offset, next, total_count: objects.length },
+  };
+};
+
+// Builds a v2 (cursor) paginated responder. The cursor encodes the next index.
+const v2Responder = (objects, pageSize = 1) => req => {
+  const cursor = req.query.cursor ? Number(req.query.cursor) : 0;
+  const nextCursor = cursor + pageSize;
+  const next =
+    nextCursor < objects.length
+      ? `${hostUrl}/a/test-staging/api/case/v2?cursor=${nextCursor}`
+      : null;
+  return { cases: objects.slice(cursor, cursor + pageSize), next };
+};
+
 
 describe('buildUrl', () => {
   it('prefixes a relative path with /a/<domain>/api/', () => {
@@ -42,10 +66,7 @@ describe('buildUrl', () => {
 describe('http.get', () => {
   it('gets cases using a relative path', async () => {
     testServer
-      .intercept({
-        path: '/a/test-staging/api/case/v1',
-        method: 'GET',
-      })
+      .intercept({ path: '/a/test-staging/api/case/v1', method: 'GET' })
       .reply(200, { objects: [{ case_id: 'abc-001' }], meta: {} });
 
     const finalState = await http.get('case/v1')(baseState);
@@ -55,17 +76,278 @@ describe('http.get', () => {
 
   it('gets cases using an absolute path', async () => {
     testServer
-      .intercept({
-        path: '/a/test-staging/api/case/v1/',
-        method: 'GET',
-      })
+      .intercept({ path: '/a/test-staging/api/case/v1/', method: 'GET' })
       .reply(200, { objects: [{ case_id: 'abc-002' }], meta: {} });
 
-    const finalState = await http.get(
-      '/a/test-staging/api/case/v1/'
-    )(baseState);
+    const finalState = await http.get('/a/test-staging/api/case/v1/')(baseState);
 
     expect(finalState.data).to.eql([{ case_id: 'abc-002' }]);
+  });
+
+  describe('no pagination (default)', () => {
+    it('does not paginate even when meta.next is present (v1)', async () => {
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, v1Responder([{ case_id: 'a1' }, { case_id: 'a2' }], 1));
+
+      const finalState = await http.get('case/v1')(baseState);
+
+      expect(finalState.data).to.eql([{ case_id: 'a1' }]);
+    });
+
+    it('does not paginate even when body.next is present (v2)', async () => {
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v2/, method: 'GET' })
+        .reply(200, v2Responder([{ case_id: 'b1' }, { case_id: 'b2' }], 1));
+
+      const finalState = await http.get('case/v2')(baseState);
+
+
+      expect(finalState.data).to.eql([{ case_id: 'b1' }]);
+    });
+
+    it('ignores paginate: false', async () => {
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, v1Responder([{ case_id: 'a1' }, { case_id: 'a2' }], 1));
+
+      const finalState = await http.get('case/v1', { paginate: false })(
+        baseState
+      );
+
+      expect(finalState.data).to.eql([{ case_id: 'a1' }]);
+    });
+
+    it('does not send paginate as a query param', async () => {
+      let sentQuery;
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, req => {
+          sentQuery = req.query;
+          return { objects: [{ case_id: 'a1' }], meta: {} };
+        });
+
+      await http.get('case/v1', { paginate: false, limit: 5 })(baseState);
+
+      expect(sentQuery).to.not.have.property('paginate');
+      expect(sentQuery.limit).to.eql(5);
+    });
+  });
+
+  describe('pagination with paginate: true', () => {
+    it('accumulates all results into state.data', async () => {
+      const objects = [{ case_id: '1' }, { case_id: '2' }, { case_id: '3' }];
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, v1Responder(objects, 1))
+        .times(3);
+
+      const finalState = await http.get('case/v1', { paginate: true })(
+        baseState
+      );
+
+      expect(finalState.data).to.eql(objects);
+    });
+
+    it('sends the computed offset/limit on subsequent v1 requests', async () => {
+      const queries = [];
+      const objects = [{ case_id: '1' }, { case_id: '2' }, { case_id: '3' }];
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, req => {
+          queries.push(req.query);
+          return v1Responder(objects, 1)(req);
+        })
+        .times(3);
+
+      await http.get('case/v1', { paginate: true })(baseState);
+
+      expect(queries[0].offset).to.be.undefined;
+      expect(queries[1].offset).to.eql(1);
+      expect(queries[2].offset).to.eql(2);
+    });
+
+    it('accumulates all v2 pages using the cursor', async () => {
+      const objects = [{ case_id: '1' }, { case_id: '2' }, { case_id: '3' }];
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v2/, method: 'GET' })
+        .reply(200, v2Responder(objects, 1))
+        .times(3);
+
+      const finalState = await http.get('case/v2', { paginate: true })(
+        baseState
+      );
+
+      expect(finalState.data).to.eql(objects);
+    });
+
+    it('extracts the cursor from  v2 next URL', async () => {
+      const queries = [];
+      const objects = [{ case_id: '1' }, { case_id: '2' }];
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v2/, method: 'GET' })
+        .reply(200, req => {
+          queries.push(req.query);
+          return v2Responder(objects, 1)(req);
+        })
+        .times(2);
+
+      await http.get('case/v2', { paginate: true })(baseState);
+
+      expect(queries[0].cursor).to.be.undefined;
+      expect(queries[1].cursor).to.eql('1');
+    });
+
+    it('returns a single page when there is no next page', async () => {
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, v1Responder([{ case_id: 'only' }], 1));
+
+      const finalState = await http.get('case/v1', { paginate: true })(
+        baseState
+      );
+
+      expect(finalState.data).to.eql([{ case_id: 'only' }]);
+    });
+
+    it('does not send paginate as a query param', async () => {
+      let sentQuery;
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, req => {
+          sentQuery = req.query;
+          return { objects: [{ case_id: '1' }], meta: { next: null } };
+        });
+
+      await http.get('case/v1', { paginate: true })(baseState);
+
+      expect(sentQuery).to.not.have.property('paginate');
+    });
+
+    it("respects the user's limit while paginating (v1)", async () => {
+      const objects = [
+        { case_id: '1' },
+        { case_id: '2' },
+        { case_id: '3' },
+        { case_id: '4' },
+      ];
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, req => v1Responder(objects, 2)(req))
+        .times(2);
+
+      const finalState = await http.get('case/v1', {
+        paginate: true,
+        limit: 2,
+      })(baseState);
+
+      expect(finalState.data).to.eql(objects);
+    });
+  });
+
+  describe('pagination with a streaming callback', () => {
+    it('invokes the callback once per v1 page', async () => {
+      const objects = [{ case_id: '1' }, { case_id: '2' }, { case_id: '3' }];
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, v1Responder(objects, 1))
+        .times(3);
+
+      const pages = [];
+      await http.get('case/v1', { paginate: true }, state => {
+        pages.push(state.data);
+        return state;
+      })(baseState);
+
+      expect(pages).to.eql([
+        [{ case_id: '1' }],
+        [{ case_id: '2' }],
+        [{ case_id: '3' }],
+      ]);
+    });
+
+    it('invokes the callback once per v2 page', async () => {
+      const objects = [{ case_id: '1' }, { case_id: '2' }, { case_id: '3' }];
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v2/, method: 'GET' })
+        .reply(200, v2Responder(objects, 1))
+        .times(3);
+
+      const pages = [];
+      await http.get('case/v2', { paginate: true }, state => {
+        pages.push(state.data);
+        return state;
+      })(baseState);
+
+      expect(pages).to.eql([
+        [{ case_id: '1' }],
+        [{ case_id: '2' }],
+        [{ case_id: '3' }],
+      ]);
+    });
+
+    it('does not append results into state.data when callback is provided', async () => {
+      const objects = [{ case_id: '1' }, { case_id: '2' }];
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, v1Responder(objects, 1))
+        .times(2);
+
+      const finalState = await http.get('case/v1', { paginate: true }, s => s)(
+        baseState
+      );
+
+      expect(finalState.data).to.eql({});
+    });
+
+    it('calls the callback once when there is no next page', async () => {
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, v1Responder([{ case_id: 'only' }], 1));
+
+      let calls = 0;
+      const finalState = await http.get('case/v1', { paginate: true }, state => {
+        calls++;
+        return state;
+      })(baseState);
+
+      expect(calls).to.equal(1);
+      expect(finalState.data).to.eql({});
+    });
+
+    it('streams a single page when paginate is not set', async () => {
+      const objects = [{ case_id: '1' }, { case_id: '2' }];
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(200, v1Responder(objects, 1));
+
+      const pages = [];
+      const finalState = await http.get('case/v1', {}, state => {
+        pages.push(state.data);
+        return state;
+      })(baseState);
+
+      expect(pages).to.eql([[{ case_id: '1' }]]);
+      expect(finalState.data).to.eql({});
+    });
+  });
+
+  describe('errors', () => {
+    it('throws when the server responds with an error', async () => {
+      testServer
+        .intercept({ path: /\/a\/test-staging\/api\/case\/v1/, method: 'GET' })
+        .reply(500, { error: 'boom' });
+
+      let caught;
+      try {
+        await http.get('case/v1')(baseState);
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).to.not.be.undefined;
+      expect(caught.statusCode).to.eql(500);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Implement pagination in `http.get()`.

Fixes #1739 

## Details


Add opt-in pagination to `http.get`

`http.get` now supports two pagination modes, both disabled by default:

- **Accumulate** — pass `paginate: true` to fetch all pages and return them
  as a single array in `state.data`:
  ```js
  http.get('case/v1', { paginate: true });
  ```
- **Stream** — pass a callback as the third argument to process each page
  individually without accumulating the full result in `state.data`:
  ```js
  http.get('case/v1', { paginate: true }, state => {
    // state.data is the current page's records only
    return state;
  });
  ```

Both modes support the v1 (offset/limit) and v2 (cursor) CommCare APIs.
In stream mode `state.data` is `{}` after the operation completes.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [x] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [x] Have you ticked a box under AI Usage?
