### PR TITLE
Commcare: deprecate `get`, `post`, and `request` functions

### DIFF
--- a/.changeset/thirty-seas-juggle.md
+++ b/.changeset/thirty-seas-juggle.md
@@ -3,3 +3,22 @@
 ---
 
 Deprecate `get`, `post`, and `request`. These functions only work with CommCare's legacy v0.5 API. Use `http.get`, `http.post`, and `http.request` instead.
+
+Note that the URL structure changes: the version segment moves from before the resource (`v0.5/case`) to after it (`case/v2`). Update the path itself, not just the function name.
+
+```js
+// before
+get('/case/12345');
+// after
+http.get('case/v2/12345');
+
+// before
+post('/user', { username: 'test', password: 'somepassword' });
+// after
+http.post('user/v2', { username: 'test', password: 'somepassword' });
+
+// before
+request('GET', '/a/asri/api/v0.5/case');
+// after
+http.request('GET', 'case/v2');
+```

--- a/.changeset/thirty-seas-juggle.md
+++ b/.changeset/thirty-seas-juggle.md
@@ -8,12 +8,12 @@ Note that the URL structure changes: the version segment moves from before the r
 
 ```js
 // before
-get('/case/12345');
+get('v0.5/case/12345');
 // after
 http.get('case/v2/12345');
 
 // before
-post('/user', { username: 'test', password: 'somepassword' });
+post('v0.5/user', { username: 'test', password: 'somepassword' });
 // after
 http.post('user/v2', { username: 'test', password: 'somepassword' });
 

--- a/.changeset/thirty-seas-juggle.md
+++ b/.changeset/thirty-seas-juggle.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-commcare': patch
+---
+
+Deprecate `get`, `post`, and `request`. These functions only work with CommCare's legacy v0.5 API. Use `http.get`, `http.post`, and `http.request` instead.

--- a/.changeset/thirty-seas-juggle.md
+++ b/.changeset/thirty-seas-juggle.md
@@ -4,21 +4,21 @@
 
 Deprecate `get`, `post`, and `request`. These functions only work with CommCare's legacy v0.5 API. Use `http.get`, `http.post`, and `http.request` instead.
 
-Note that the URL structure changes: the version segment moves from before the resource (`v0.5/case`) to after it (`case/v2`). Update the path itself, not just the function name.
+Note that `get`/`post`/`request` hard-code the `v0.5` version segment into the URL, but the `http.*` functions do not add a version automatically — you must include `v0.5` yourself in the path to get the same behaviour.
 
 ```js
 // before
-get('v0.5/case/12345');
+get('/case/12345');
 // after
-http.get('case/v2/12345');
+http.get('v0.5/case/12345');
 
 // before
-post('v0.5/user', { username: 'test', password: 'somepassword' });
+post('/user', { username: 'test', password: 'somepassword' });
 // after
-http.post('user/v2', { username: 'test', password: 'somepassword' });
+http.post('v0.5/user', { username: 'test', password: 'somepassword' });
 
 // before
 request('GET', '/a/asri/api/v0.5/case');
 // after
-http.request('GET', 'case/v2');
+http.request('GET', 'v0.5/case');
 ```

--- a/packages/commcare/ast.json
+++ b/packages/commcare/ast.json
@@ -8,8 +8,12 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a GET request to CommCare. Use this to fetch resources directly from Commcare REST API.\nYou can pass Commcare query parameters as an object of key value pairs, which will map to parameters\nin the URL.\nThe response body will be returned to `state.data` as JSON.\nPaginated responses will be fully downloaded and returned as a single array, _unless_ an `offset` is passed.",
+        "description": "Make a GET request to CommCare's legacy v0.5 API.\nYou can pass Commcare query parameters as an object of key value pairs, which will map to parameters\nin the URL.\nThe response body will be returned to `state.data` as JSON.\nPaginated responses will be fully downloaded and returned as a single array, _unless_ an `offset` is passed.",
         "tags": [
+          {
+            "title": "deprecated",
+            "description": "This function only works against CommCare's legacy v0.5 API (path: `/a/domain/api/v0.5/...`).\nFor current CommCare APIs, use {@link http.get} instead."
+          },
           {
             "title": "public",
             "description": null,
@@ -23,21 +27,21 @@
           {
             "title": "example",
             "description": "get(\"/case/12345\")",
-            "caption": "Get a resource by Id. Equivalent to GET `<baseUrl>/case/12345`"
+            "caption": "Get a resource by Id. Equivalent to GET `/a/domain/api/v0.5/case/12345`"
           },
           {
             "title": "example",
             "description": "get(\"/case\", { offset:0, limit: 20 })",
-            "caption": "Get a resource with exactly 20 items. Equivalent to `<baseUrl>/case?offset=0&limit=20`"
+            "caption": "Get a resource with exactly 20 items. Equivalent to `/a/domain/api/v0.5/case?offset=0&limit=20`"
           },
           {
             "title": "example",
             "description": "get(\"/case\", {}, (state) => {\n  state.cases.push(...state.data) // adds all cases to the cases array\n  return state;\n})",
-            "caption": "Get all items in a resource, and add them to state. Equivalent to `<baseUrl>/case`"
+            "caption": "Get all items in a resource, and add them to state. Equivalent to `/a/domain/api/v0.5/case`"
           },
           {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Path to a v0.5 resource (e.g. `case`, `form`)",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -46,7 +50,7 @@
           },
           {
             "title": "param",
-            "description": "Input parameters for the request. These vary by endpoint,  see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957366/Data+APIs CommCare docs}.",
+            "description": "Input parameters for the request. These vary by endpoint, see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957366/Data+APIs CommCare v0.5 docs}.",
             "type": {
               "type": "OptionalType",
               "expression": {
@@ -93,12 +97,16 @@
         "callback"
       ],
       "docs": {
-        "description": "Make a POST request to CommCare. Use this to send resources directly to Commcare REST API.\nYou can pass Commcare body data as a JSON object.",
+        "description": "Make a POST request to CommCare's legacy v0.5 API.\nYou can pass Commcare body data as a JSON object.",
         "tags": [
+          {
+            "title": "deprecated",
+            "description": "This function only works against CommCare's legacy v0.5 API (path: `/a/domain/api/v0.5/...`).\nFor current CommCare APIs, use {@link http.post} instead."
+          },
           {
             "title": "example",
             "description": "post(\"/user\", { \"username\":\"test\", \"password\":\"somepassword\" })",
-            "caption": "Create a user resource.Equivalent to `<baseUrl>/user`"
+            "caption": "Create a user resource. Equivalent to `/a/domain/api/v0.5/user`"
           },
           {
             "title": "function",
@@ -112,7 +120,7 @@
           },
           {
             "title": "param",
-            "description": "Path to resource",
+            "description": "Path to a v0.5 resource (e.g. `user`, `case`)",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -282,7 +290,7 @@
         "postUrl"
       ],
       "docs": {
-        "description": "Make a GET request to CommCare's Reports API\nand POST the response somewhere else.",
+        "description": "Make a GET request to CommCare's Reports API (v0.5) and POST the response somewhere else.",
         "tags": [
           {
             "title": "public",
@@ -292,7 +300,7 @@
           {
             "title": "example",
             "description": "fetchReportData(\n  \"abcde\",\n  { limit: 10 },\n  \"https://www.example.com/api/\"\n)",
-            "caption": "Get 10 records from a report and post them to example.com. Equivalent to `<baseUrl>/configurablereportdata/abcde?limit=10`"
+            "caption": "Get 10 records from a report and post them to example.com. Equivalent to `/a/domain/api/v0.5/configurablereportdata/abcde?limit=10`"
           },
           {
             "title": "function",
@@ -310,7 +318,7 @@
           },
           {
             "title": "param",
-            "description": "Input parameters for the request, see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957341/Download+Report+Data Commcare docs}.",
+            "description": "Input parameters for the request, see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957341/Download+Report+Data CommCare v0.5 docs}.",
             "type": {
               "type": "NameExpression",
               "name": "Object"
@@ -351,17 +359,21 @@
         "params"
       ],
       "docs": {
-        "description": "Make a general HTTP request against the Commcare server. Use this to make any request to Commcare REST API.",
+        "description": "Make a general HTTP request against the CommCare server.",
         "tags": [
           {
-            "title": "example",
-            "description": "request(\"GET\", \"/a/asri/api/v0.5/case\");",
-            "caption": "Get a resource. Equivalent to `<baseUrl>/a/asri/api/v0.5/case`"
+            "title": "deprecated",
+            "description": "Use {@link http.request} instead."
           },
           {
             "title": "example",
-            "description": "request(\"GET\", \"/case\", {}, { offset:0, limit: 20 })",
-            "caption": "Get a resource using query parameters. Equivalent to `<baseUrl>/case?offset=0&limit=20`"
+            "description": "request(\"GET\", \"/a/asri/api/v0.5/case\");",
+            "caption": "Get a resource at a v0.5 path"
+          },
+          {
+            "title": "example",
+            "description": "request(\"GET\", \"/a/asri/api/v0.5/case\", {}, { offset:0, limit: 20 })",
+            "caption": "Get a resource using query parameters"
           },
           {
             "title": "function",

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -38,29 +38,36 @@ export function execute(...operations) {
 }
 
 /**
- * Make a GET request to CommCare. Use this to fetch resources directly from Commcare REST API.
+ * Make a GET request to CommCare's legacy v0.5 API.
  * You can pass Commcare query parameters as an object of key value pairs, which will map to parameters
  * in the URL.
  * The response body will be returned to `state.data` as JSON.
  * Paginated responses will be fully downloaded and returned as a single array, _unless_ an `offset` is passed.
+ * @deprecated This function only works against CommCare's legacy v0.5 API (path: `/a/domain/api/v0.5/...`).
+ * For current CommCare APIs, use {@link http.get} instead.
  * @public
  * @function
- * @example <caption>Get a resource by Id. Equivalent to GET `<baseUrl>/case/12345`</caption>
+ * @example <caption>Get a resource by Id. Equivalent to GET `/a/domain/api/v0.5/case/12345`</caption>
  * get("/case/12345")
- * @example <caption>Get a resource with exactly 20 items. Equivalent to `<baseUrl>/case?offset=0&limit=20`</caption>
+ * @example <caption>Get a resource with exactly 20 items. Equivalent to `/a/domain/api/v0.5/case?offset=0&limit=20`</caption>
  * get("/case", { offset:0, limit: 20 })
- * @example <caption>Get all items in a resource, and add them to state. Equivalent to `<baseUrl>/case`</caption>
+ * @example <caption>Get all items in a resource, and add them to state. Equivalent to `/a/domain/api/v0.5/case`</caption>
  * get("/case", {}, (state) => {
  *   state.cases.push(...state.data) // adds all cases to the cases array
  *   return state;
  * })
- * @param {string} path - Path to resource
- * @param {Object} [params] - Input parameters for the request. These vary by endpoint,  see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957366/Data+APIs CommCare docs}.
+ * @param {string} path - Path to a v0.5 resource (e.g. `case`, `form`)
+ * @param {Object} [params] - Input parameters for the request. These vary by endpoint, see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957366/Data+APIs CommCare v0.5 docs}.
  * @param {function} [callback] - Optional callback function. Invoked once per page of data retrieved.
  * @state {CommcareHttpState}
  * @returns {Operation}
  */
 export function get(path, params = {}, callback = s => s) {
+  console.warn(
+    'DEPRECATION WARNING: get() only works with CommCare\'s legacy v0.5 API ' +
+      '(/a/domain/api/v0.5/...). Use http.get() for current CommCare APIs. ' +
+      'get() will be removed in a future major version.'
+  );
   return async state => {
     const { domain } = state.configuration;
     const [resolvedPath, resolvedParams] = expandReferences(
@@ -135,13 +142,15 @@ export function get(path, params = {}, callback = s => s) {
 }
 
 /**
- * Make a POST request to CommCare. Use this to send resources directly to Commcare REST API.
+ * Make a POST request to CommCare's legacy v0.5 API.
  * You can pass Commcare body data as a JSON object.
- * @example <caption>Create a user resource.Equivalent to `<baseUrl>/user`</caption>
+ * @deprecated This function only works against CommCare's legacy v0.5 API (path: `/a/domain/api/v0.5/...`).
+ * For current CommCare APIs, use {@link http.post} instead.
+ * @example <caption>Create a user resource. Equivalent to `/a/domain/api/v0.5/user`</caption>
  * post("/user", { "username":"test", "password":"somepassword" })
  * @function
  * @public
- * @param {string} path - Path to resource
+ * @param {string} path - Path to a v0.5 resource (e.g. `user`, `case`)
  * @param {object} data - Object or JSON to create a resource
  * @param {Object} [params] - Optional request params
  * @param {function} [callback] - Optional callback to handle the response
@@ -149,6 +158,11 @@ export function get(path, params = {}, callback = s => s) {
  * @state {CommcareHttpState}
  */
 export function post(path, data, params = {}, callback = s => s) {
+  console.warn(
+    'DEPRECATION WARNING: post() only works with CommCare\'s legacy v0.5 API ' +
+      '(/a/domain/api/v0.5/...). Use http.post() for current CommCare APIs. ' +
+      'post() will be removed in a future major version.'
+  );
   return async state => {
     const { domain } = state.configuration;
     const [resolvedPath, resolvedData, resolvedParams] = expandReferences(
@@ -275,10 +289,9 @@ export function submit(data) {
 }
 
 /**
- * Make a GET request to CommCare's Reports API
- * and POST the response somewhere else.
+ * Make a GET request to CommCare's Reports API (v0.5) and POST the response somewhere else.
  * @public
- * @example <caption>Get 10 records from a report and post them to example.com. Equivalent to `<baseUrl>/configurablereportdata/abcde?limit=10`</caption>
+ * @example <caption>Get 10 records from a report and post them to example.com. Equivalent to `/a/domain/api/v0.5/configurablereportdata/abcde?limit=10`</caption>
  * fetchReportData(
  *   "abcde",
  *   { limit: 10 },
@@ -286,7 +299,7 @@ export function submit(data) {
  * )
  * @function
  * @param {String} reportId - API name of the report.
- * @param {Object} params - Input parameters for the request, see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957341/Download+Report+Data Commcare docs}.
+ * @param {Object} params - Input parameters for the request, see {@link https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957341/Download+Report+Data CommCare v0.5 docs}.
  * @param {String} postUrl - URL to which the response object will be posted.
  * @state {CommcareHttpState}
  * @returns {Operation}
@@ -316,11 +329,12 @@ export function fetchReportData(reportId, params, postUrl) {
 }
 
 /**
- * Make a general HTTP request against the Commcare server. Use this to make any request to Commcare REST API.
- * @example <caption>Get a resource. Equivalent to `<baseUrl>/a/asri/api/v0.5/case`</caption>
+ * Make a general HTTP request against the CommCare server.
+ * @deprecated Use {@link http.request} instead.
+ * @example <caption>Get a resource at a v0.5 path</caption>
  * request("GET", "/a/asri/api/v0.5/case");
- * @example <caption>Get a resource using query parameters. Equivalent to `<baseUrl>/case?offset=0&limit=20`</caption>
- * request("GET", "/case", {}, { offset:0, limit: 20 })
+ * @example <caption>Get a resource using query parameters</caption>
+ * request("GET", "/a/asri/api/v0.5/case", {}, { offset:0, limit: 20 })
  * @function
  * @public
  * @param {string} method - HTTP method to use
@@ -331,6 +345,11 @@ export function fetchReportData(reportId, params, postUrl) {
  * @state {CommcareHttpState}
  */
 export function request(method, path, body, params = {}) {
+  console.warn(
+    'DEPRECATION WARNING: request() is designed around the legacy v0.5 API. ' +
+      'Use http.request() instead. ' +
+      'request() will be removed in a future major version.'
+  );
   return async state => {
     const [resolvedMethod, resolvedPath, resolvedBody, resolvedParams] =
       expandReferences(state, method, path, body, params);

--- a/packages/commcare/src/Adaptor.js
+++ b/packages/commcare/src/Adaptor.js
@@ -5,6 +5,15 @@ import js2xmlparser from 'js2xmlparser';
 import xlsx from 'xlsx';
 
 import * as util from './Utils.js';
+
+let hasWarnedDeprecated = false;
+function warnDeprecated(message) {
+  if (!hasWarnedDeprecated) {
+    hasWarnedDeprecated = true;
+    console.warn(message);
+  }
+}
+
 /**
  * State object
  * @typedef {Object} CommcareHttpState
@@ -63,17 +72,17 @@ export function execute(...operations) {
  * @returns {Operation}
  */
 export function get(path, params = {}, callback = s => s) {
-  console.warn(
-    'DEPRECATION WARNING: get() only works with CommCare\'s legacy v0.5 API ' +
+  warnDeprecated(
+    "DEPRECATION WARNING: get() only works with CommCare's legacy v0.5 API " +
       '(/a/domain/api/v0.5/...). Use http.get() for current CommCare APIs. ' +
-      'get() will be removed in a future major version.'
+      'get() will be removed in a future major version.',
   );
   return async state => {
     const { domain } = state.configuration;
     const [resolvedPath, resolvedParams] = expandReferences(
       state,
       path,
-      params
+      params,
     );
 
     let offset, limit;
@@ -98,7 +107,7 @@ export function get(path, params = {}, callback = s => s) {
             method: 'GET',
             params: requestParams,
             contentType: 'application/json',
-          }
+          },
         );
 
         nextState = util.prepareNextState(state, response, callback);
@@ -158,10 +167,10 @@ export function get(path, params = {}, callback = s => s) {
  * @state {CommcareHttpState}
  */
 export function post(path, data, params = {}, callback = s => s) {
-  console.warn(
-    'DEPRECATION WARNING: post() only works with CommCare\'s legacy v0.5 API ' +
+  warnDeprecated(
+    "DEPRECATION WARNING: post() only works with CommCare's legacy v0.5 API " +
       '(/a/domain/api/v0.5/...). Use http.post() for current CommCare APIs. ' +
-      'post() will be removed in a future major version.'
+      'post() will be removed in a future major version.',
   );
   return async state => {
     const { domain } = state.configuration;
@@ -169,7 +178,7 @@ export function post(path, data, params = {}, callback = s => s) {
       state,
       path,
       data,
-      params
+      params,
     );
 
     try {
@@ -181,7 +190,7 @@ export function post(path, data, params = {}, callback = s => s) {
           data: resolvedData,
           params: resolvedParams,
           contentType: 'application/json',
-        }
+        },
       );
 
       return util.prepareNextState(state, response, callback);
@@ -345,10 +354,10 @@ export function fetchReportData(reportId, params, postUrl) {
  * @state {CommcareHttpState}
  */
 export function request(method, path, body, params = {}) {
-  console.warn(
+  warnDeprecated(
     'DEPRECATION WARNING: request() is designed around the legacy v0.5 API. ' +
       'Use http.request() instead. ' +
-      'request() will be removed in a future major version.'
+      'request() will be removed in a future major version.',
   );
   return async state => {
     const [resolvedMethod, resolvedPath, resolvedBody, resolvedParams] =
@@ -414,7 +423,7 @@ export function bulk(type, data, params) {
     const [resolvedData, resolvedParams] = expandReferences(
       state,
       data,
-      params
+      params,
     );
     let path, file;
 


### PR DESCRIPTION
## Summary

Deprecate `get`, `post`, and `request`. These functions only work with CommCare's legacy v0.5 API. Use `http.get`, `http.post`, and `http.request` instead.

Fixes #1741 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [ ] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [ ] Have you ticked a box under AI Usage?
