### PR TITLE
Primero: add  a`get` function with  auto  pagination

### DIFF
--- a/.changeset/wacky-words-enjoy.md
+++ b/.changeset/wacky-words-enjoy.md
@@ -2,4 +2,4 @@
 '@openfn/language-primero': minor
 ---
 
-Add `get('cases', { per: 2 })` for making paginated GET requests to any Primero endpoint. 
+Add `get('cases', { per: 2 })` for making paginated GET requests to any Primero resource 

--- a/.changeset/wacky-words-enjoy.md
+++ b/.changeset/wacky-words-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-primero': minor
+---
+
+Add `get('cases', { per: 2 })` for making paginated GET requests to any Primero endpoint. 

--- a/.changeset/wacky-words-enjoy.md
+++ b/.changeset/wacky-words-enjoy.md
@@ -2,4 +2,4 @@
 '@openfn/language-primero': minor
 ---
 
-Add `get('cases', { per: 2 })` for making paginated GET requests to any Primero resource 
+Add `get` helper, which fetches resources with automatic pagination.

--- a/packages/primero/ast.json
+++ b/packages/primero/ast.json
@@ -601,7 +601,7 @@
         "query"
       ],
       "docs": {
-        "description": "GET resources from Primero. Automatically paginates through all pages.",
+        "description": "Get resources from Primero. Automatically paginates through all pages.",
         "tags": [
           {
             "title": "public",
@@ -624,8 +624,18 @@
             "caption": "Fetch with a fixed page size of 50"
           },
           {
+            "title": "example",
+            "description": "get('registry_records', { limit: 5000 });",
+            "caption": "Fetch at most 5000 records"
+          },
+          {
+            "title": "example",
+            "description": "get('registry_records/fc686dff-b1ee-4206-9be6-066dbf4e3a54');",
+            "caption": "Fetch a single registry record by ID"
+          },
+          {
             "title": "param",
-            "description": "Path to the resource",
+            "description": "Path to a resource",
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -634,7 +644,7 @@
           },
           {
             "title": "param",
-            "description": "Query parameters to append to the URL. Use `per` to control the page size..",
+            "description": "Query parameters to append to the URL. Use `per` to control the page size. Use `limit` to cap the total number of records fetched.",
             "type": {
               "type": "NameExpression",
               "name": "object"

--- a/packages/primero/ast.json
+++ b/packages/primero/ast.json
@@ -593,6 +593,65 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "get",
+      "params": [
+        "path",
+        "query"
+      ],
+      "docs": {
+        "description": "Make a GET request to any Primero endpoint. Automatically paginates through all pages.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "example",
+            "description": "get('registry_records');",
+            "caption": "Fetch all registry records"
+          },
+          {
+            "title": "example",
+            "description": "get('registry_records', { count: 50 });",
+            "caption": "Fetch with a fixed page size of 50"
+          },
+          {
+            "title": "param",
+            "description": "Path to the resource",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "path"
+          },
+          {
+            "title": "param",
+            "description": "Query parameters to append to the URL. Use `count` (or `per`) to control the page size.",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "query"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
     }
   ],
   "exports": [],

--- a/packages/primero/ast.json
+++ b/packages/primero/ast.json
@@ -621,7 +621,7 @@
           {
             "title": "example",
             "description": "get('registry_records', { per: 50 });",
-            "caption": "Fetch with a fixed page size of 50"
+            "caption": "fetch all records in pages of 50 at a time"
           },
           {
             "title": "example",

--- a/packages/primero/ast.json
+++ b/packages/primero/ast.json
@@ -601,7 +601,7 @@
         "query"
       ],
       "docs": {
-        "description": "Make a GET request to any Primero endpoint. Automatically paginates through all pages.",
+        "description": "GET resources from Primero. Automatically paginates through all pages.",
         "tags": [
           {
             "title": "public",
@@ -620,7 +620,7 @@
           },
           {
             "title": "example",
-            "description": "get('registry_records', { count: 50 });",
+            "description": "get('registry_records', { per: 50 });",
             "caption": "Fetch with a fixed page size of 50"
           },
           {
@@ -634,7 +634,7 @@
           },
           {
             "title": "param",
-            "description": "Query parameters to append to the URL. Use `count` (or `per`) to control the page size.",
+            "description": "Query parameters to append to the URL. Use `per` to control the page size..",
             "type": {
               "type": "NameExpression",
               "name": "object"

--- a/packages/primero/src/Adaptor.js
+++ b/packages/primero/src/Adaptor.js
@@ -1,6 +1,6 @@
 import { execute as commonExecute } from '@openfn/language-common';
 import { expandReferences } from '@openfn/language-common/util';
-import { assembleError, scrubResponse, tryJson } from './Utils.js';
+import { assembleError, scrubResponse, tryJson, getNextPageParams, request as utilRequest } from './Utils.js';
 import request from 'request';
 
 export const composeNextState = (state, data, meta) => {
@@ -898,6 +898,47 @@ export function getLocations(query, callback) {
         }
       });
     });
+  };
+}
+
+/**
+ * Make a GET request to any Primero endpoint. Automatically paginates through all pages.
+ * @public
+ * @function
+ * @example <caption>Fetch all registry records</caption>
+ * get('registry_records');
+ * @example <caption>Fetch with a fixed page size of 50</caption>
+ * get('registry_records', { count: 50 });
+ * @param {string} path - Path to the resource
+ * @param {object} query - Query parameters to append to the URL. Use `count` (or `per`) to control the page size.
+ * @returns {Operation}
+ */
+export function get(path, query = {}) {
+  return async state => {
+    const [resolvedPath, resolvedQuery] = expandReferences(state, path, query);
+    const { count, per, ...queryParams } = resolvedQuery;
+
+    let currentQuery = { ...queryParams };
+    if (count ?? per) currentQuery.per = count ?? per;
+
+    let results = [];
+
+    do {
+      const response = await utilRequest(state, 'GET', resolvedPath, {
+        query: currentQuery,
+      });
+
+      results.push(...(response.body.data ?? []));
+
+      const next = getNextPageParams(response.body.metadata, resolvedQuery);
+      if (next) {
+        currentQuery = { ...queryParams, page: next.page, per: next.per };
+      } else {
+        break;
+      }
+    } while (true);
+
+    return composeNextState(state, results);
   };
 }
 

--- a/packages/primero/src/Adaptor.js
+++ b/packages/primero/src/Adaptor.js
@@ -907,7 +907,7 @@ export function getLocations(query, callback) {
  * @function
  * @example <caption>Fetch all registry records</caption>
  * get('registry_records');
- * @example <caption>Fetch with a fixed page size of 50</caption>
+ * @example <caption>fetch all records in pages of 50 at a time</caption>
  * get('registry_records', { per: 50 });
  * @example <caption>Fetch at most 5000 records</caption>
  * get('registry_records', { limit: 5000 });

--- a/packages/primero/src/Adaptor.js
+++ b/packages/primero/src/Adaptor.js
@@ -926,9 +926,9 @@ export function get(path, query = {}) {
       });
 
       const { data, metadata } = response.body;
-      results = results.concat(data);
+      results.push(...data);
 
-      const next = getNextPageParams(metadata, resolvedQuery);
+      const next = getNextPageParams(metadata);
       if (!next) break;
 
       currentQuery = { ...resolvedQuery, page: next.page, per: next.per };

--- a/packages/primero/src/Adaptor.js
+++ b/packages/primero/src/Adaptor.js
@@ -902,25 +902,22 @@ export function getLocations(query, callback) {
 }
 
 /**
- * Make a GET request to any Primero endpoint. Automatically paginates through all pages.
+ * GET resources from Primero. Automatically paginates through all pages.
  * @public
  * @function
  * @example <caption>Fetch all registry records</caption>
  * get('registry_records');
  * @example <caption>Fetch with a fixed page size of 50</caption>
- * get('registry_records', { count: 50 });
+ * get('registry_records', { per: 50 });
  * @param {string} path - Path to the resource
- * @param {object} query - Query parameters to append to the URL. Use `count` (or `per`) to control the page size.
+ * @param {object} query - Query parameters to append to the URL. Use `per` to control the page size..
  * @returns {Operation}
  */
 export function get(path, query = {}) {
   return async state => {
     const [resolvedPath, resolvedQuery] = expandReferences(state, path, query);
-    const { count, per, ...queryParams } = resolvedQuery;
 
-    let currentQuery = { ...queryParams };
-    if (count ?? per) currentQuery.per = count ?? per;
-
+    let currentQuery = resolvedQuery;
     let results = [];
 
     do {
@@ -928,14 +925,13 @@ export function get(path, query = {}) {
         query: currentQuery,
       });
 
-      results.push(...(response.body.data ?? []));
+      const { data, metadata } = response.body;
+      results = results.concat(data);
 
-      const next = getNextPageParams(response.body.metadata, resolvedQuery);
-      if (next) {
-        currentQuery = { ...queryParams, page: next.page, per: next.per };
-      } else {
-        break;
-      }
+      const next = getNextPageParams(metadata, resolvedQuery);
+      if (!next) break;
+
+      currentQuery = { ...resolvedQuery, page: next.page, per: next.per };
     } while (true);
 
     return composeNextState(state, results);

--- a/packages/primero/src/Adaptor.js
+++ b/packages/primero/src/Adaptor.js
@@ -1,6 +1,6 @@
 import { execute as commonExecute } from '@openfn/language-common';
 import { expandReferences } from '@openfn/language-common/util';
-import { assembleError, scrubResponse, tryJson, getNextPageParams, request as utilRequest } from './Utils.js';
+import { assembleError, scrubResponse, tryJson, requestWithPagination } from './Utils.js';
 import request from 'request';
 
 export const composeNextState = (state, data, meta) => {
@@ -902,37 +902,31 @@ export function getLocations(query, callback) {
 }
 
 /**
- * GET resources from Primero. Automatically paginates through all pages.
+ * Get resources from Primero. Automatically paginates through all pages.
  * @public
  * @function
  * @example <caption>Fetch all registry records</caption>
  * get('registry_records');
  * @example <caption>Fetch with a fixed page size of 50</caption>
  * get('registry_records', { per: 50 });
- * @param {string} path - Path to the resource
- * @param {object} query - Query parameters to append to the URL. Use `per` to control the page size..
+ * @example <caption>Fetch at most 5000 records</caption>
+ * get('registry_records', { limit: 5000 });
+ * @example <caption>Fetch a single registry record by ID</caption>
+ * get('registry_records/fc686dff-b1ee-4206-9be6-066dbf4e3a54');
+ * @param {string} path - Path to a resource
+ * @param {object} query - Query parameters to append to the URL. Use `per` to control the page size. Use `limit` to cap the total number of records fetched.
  * @returns {Operation}
  */
 export function get(path, query = {}) {
   return async state => {
     const [resolvedPath, resolvedQuery] = expandReferences(state, path, query);
 
-    let currentQuery = resolvedQuery;
-    let results = [];
-
-    do {
-      const response = await utilRequest(state, 'GET', resolvedPath, {
-        query: currentQuery,
-      });
-
-      const { data, metadata } = response.body;
-      results.push(...data);
-
-      const next = getNextPageParams(metadata);
-      if (!next) break;
-
-      currentQuery = { ...resolvedQuery, page: next.page, per: next.per };
-    } while (true);
+    const results = await requestWithPagination(
+      state,
+      'GET',
+      resolvedPath,
+      resolvedQuery
+    );
 
     return composeNextState(state, results);
   };

--- a/packages/primero/src/Utils.js
+++ b/packages/primero/src/Utils.js
@@ -21,8 +21,7 @@ export function getNextPageParams(metadata, queryParams = {}) {
   const { total, page } = metadata ?? {};
   if (!total || !page) return null;
 
-  // If the user sets per or count, treat it as a one-page limit
-  if (queryParams.count != null || queryParams.per != null) return null;
+  if (queryParams.per >= 1) return null;
 
   const totalPages = Math.ceil(total / DEFAULT_PAGE_SIZE);
   if (page >= totalPages) return null;

--- a/packages/primero/src/Utils.js
+++ b/packages/primero/src/Utils.js
@@ -16,7 +16,6 @@ export const prepareNextState = (state, response) => {
 
 const DEFAULT_PAGE_SIZE = 1000;
 
-
 export function getNextPageParams(metadata) {
   const { total, page } = metadata ?? {};
   if (!total || !page) return null;
@@ -28,8 +27,6 @@ export function getNextPageParams(metadata) {
 }
 
 export function setUrl(configuration, path) {
-  console.log(configuration);
-
   if (configuration && configuration.url) return configuration.url + path;
   else return path;
 }
@@ -91,12 +88,10 @@ export const request = (state, method, path, options = {}) => {
 
   const { query = {}, body = {}, headers = {}, parseAs = 'json' } = options;
 
-  
-
   const opts = {
     parseAs,
     baseUrl: `${baseUrl}/api/v2/`,
-    body:{ data: body},
+    body: { data: body },
     query,
     headers: {
       'Content-type': 'application/json',
@@ -104,8 +99,6 @@ export const request = (state, method, path, options = {}) => {
       ...headers,
     },
   };
-
-  
 
   return commonRequest(method, path, opts).then(logResponse);
 };

--- a/packages/primero/src/Utils.js
+++ b/packages/primero/src/Utils.js
@@ -17,11 +17,9 @@ export const prepareNextState = (state, response) => {
 const DEFAULT_PAGE_SIZE = 1000;
 
 
-export function getNextPageParams(metadata, queryParams = {}) {
+export function getNextPageParams(metadata) {
   const { total, page } = metadata ?? {};
   if (!total || !page) return null;
-
-  if (queryParams.per >= 1) return null;
 
   const totalPages = Math.ceil(total / DEFAULT_PAGE_SIZE);
   if (page >= totalPages) return null;

--- a/packages/primero/src/Utils.js
+++ b/packages/primero/src/Utils.js
@@ -30,6 +30,10 @@ export function getNextPageParams(metadata) {
 export async function requestWithPagination(state, method, path, query = {}) {
   const { limit, ...urlQuery } = query;
 
+  if (limit && limit < urlQuery.per) {
+    urlQuery.per = limit;
+  }
+
   let currentQuery = urlQuery;
   let results = [];
 
@@ -50,7 +54,16 @@ export async function requestWithPagination(state, method, path, query = {}) {
     const next = getNextPageParams(metadata);
     if (!next) break;
 
-    currentQuery = { ...urlQuery, page: next.page, per: next.per };
+    let { page, per } = next;
+
+    if (limit) {
+      const remaining = limit - results.length;
+      if (remaining < per) {
+        per = remaining;
+      }
+    }
+
+    currentQuery = { ...urlQuery, page, per };
   } while (true);
 
   return results;

--- a/packages/primero/src/Utils.js
+++ b/packages/primero/src/Utils.js
@@ -16,15 +16,44 @@ export const prepareNextState = (state, response) => {
 
 const DEFAULT_PAGE_SIZE = 1000;
 
-
 export function getNextPageParams(metadata) {
-  const { total, page } = metadata ?? {};
+  const { total, per = DEFAULT_PAGE_SIZE, page } = metadata ?? {};
   if (!total || !page) return null;
 
-  const totalPages = Math.ceil(total / DEFAULT_PAGE_SIZE);
+  const totalPages = Math.ceil(total / per);
   if (page >= totalPages) return null;
 
-  return { page: page + 1, per: DEFAULT_PAGE_SIZE };
+  return { page: page + 1, per };
+}
+
+
+export async function requestWithPagination(state, method, path, query = {}) {
+  const { limit, ...urlQuery } = query;
+
+  let currentQuery = urlQuery;
+  let results = [];
+
+  do {
+    const response = await request(state, method, path, { query: currentQuery });
+
+    const { data, metadata } = response.body;
+
+    if (!Array.isArray(data)) return data;
+
+    results.push(...data);
+
+    if (limit && results.length >= limit) {
+      results = results.slice(0, limit);
+      break;
+    }
+
+    const next = getNextPageParams(metadata);
+    if (!next) break;
+
+    currentQuery = { ...urlQuery, page: next.page, per: next.per };
+  } while (true);
+
+  return results;
 }
 
 export function setUrl(configuration, path) {

--- a/packages/primero/src/Utils.js
+++ b/packages/primero/src/Utils.js
@@ -21,7 +21,7 @@ export function getNextPageParams(metadata, queryParams = {}) {
   const { total, page } = metadata ?? {};
   if (!total || !page) return null;
 
-  // If the user explicitly set per or count, treat it as a one-page limit
+  // If the user sets per or count, treat it as a one-page limit
   if (queryParams.count != null || queryParams.per != null) return null;
 
   const totalPages = Math.ceil(total / DEFAULT_PAGE_SIZE);

--- a/packages/primero/src/Utils.js
+++ b/packages/primero/src/Utils.js
@@ -14,6 +14,22 @@ export const prepareNextState = (state, response) => {
   };
 };
 
+const DEFAULT_PAGE_SIZE = 1000;
+
+
+export function getNextPageParams(metadata, queryParams = {}) {
+  const { total, page } = metadata ?? {};
+  if (!total || !page) return null;
+
+  // If the user explicitly set per or count, treat it as a one-page limit
+  if (queryParams.count != null || queryParams.per != null) return null;
+
+  const totalPages = Math.ceil(total / DEFAULT_PAGE_SIZE);
+  if (page >= totalPages) return null;
+
+  return { page: page + 1, per: DEFAULT_PAGE_SIZE };
+}
+
 export function setUrl(configuration, path) {
   console.log(configuration);
 

--- a/packages/primero/test/index.js
+++ b/packages/primero/test/index.js
@@ -123,16 +123,21 @@ describe('getNextPageParams', () => {
   });
 
   it('returns null when all records fit on the first page', () => {
-    expect(getNextPageParams({ total: 5, page: 1 })).to.be.null;
+    expect(getNextPageParams({ total: 5, per: 1000, page: 1 })).to.be.null;
   });
 
   it('returns next page params when more pages exist', () => {
-    const result = getNextPageParams({ total: 2500, page: 1 });
+    const result = getNextPageParams({ total: 2500, per: 1000, page: 1 });
     expect(result).to.eql({ page: 2, per: 1000 });
   });
 
+  it('respects the page size reported in metadata', () => {
+    const result = getNextPageParams({ total: 25, per: 10, page: 1 });
+    expect(result).to.eql({ page: 2, per: 10 });
+  });
+
   it('returns null on the last page', () => {
-    expect(getNextPageParams({ total: 2500, page: 3 })).to.be.null;
+    expect(getNextPageParams({ total: 2500, per: 1000, page: 3 })).to.be.null;
   });
 
 
@@ -156,15 +161,62 @@ describe('get', () => {
     expect(finalState.data).to.eql([...items1, ...items2]);
   });
 
-  it('fetches one page when per is specified', async () => {
+  it('uses per as the page size and paginates through all pages', async () => {
+    const items1 = [{ id: '1' }, { id: '2' }];
+    const items2 = [{ id: '3' }, { id: '4' }];
+
     testServer
       .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
-      .reply(200, makePage([{ id: '1' }, { id: '2' }], 1, 100, 2));
+      .reply(200, makePage(items1, 1, 4, 2));
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, makePage(items2, 2, 4, 2));
 
     const finalState = await get('cases', { per: 2 })(baseState);
 
-    expect(finalState.data).to.eql([{ id: '1' }, { id: '2' }]);
+    expect(finalState.data).to.eql([...items1, ...items2]);
   });
 
+  it('stops once the limit is reached and does not send it to the API', async () => {
+    const items1 = [{ id: '1' }, { id: '2' }];
 
+    testServer
+      .intercept({
+        path: /\/api\/v2\/cases/,
+        method: 'GET',
+      })
+      .reply(200, req => {
+        expect(req.path).to.not.include('limit');
+        return makePage(items1, 1, 100, 2);
+      });
+
+    const finalState = await get('cases', { per: 2, limit: 1 })(baseState);
+
+    expect(finalState.data).to.eql([{ id: '1' }]);
+  });
+
+  it('returns a single item when fetching by id', async () => {
+    const item = { id: '123a', name: 'Edwine' };
+
+    testServer
+      .intercept({ path: /\/api\/v2\/cases\/123a/, method: 'GET' })
+      .reply(200, { data: item });
+
+    const finalState = await get('cases/123a')(baseState);
+
+    expect(finalState.data).to.eql(item);
+  });
+
+  it('does not paginate when fetching a single item by id', async () => {
+    const item = { id: '123a', name: 'Edwine' };
+
+
+    testServer
+      .intercept({ path: /\/api\/v2\/cases\/123a/, method: 'GET' })
+      .reply(200, { data: item });
+
+    const finalState = await get('cases/123a', { per: 2 })(baseState);
+
+    expect(finalState.data).to.eql(item);
+  });
 });

--- a/packages/primero/test/index.js
+++ b/packages/primero/test/index.js
@@ -135,14 +135,8 @@ describe('getNextPageParams', () => {
     expect(getNextPageParams({ total: 2500, page: 3 })).to.be.null;
   });
 
-  it('returns null when per is provided in queryParams', () => {
-    expect(getNextPageParams({ total: 2500, page: 1 }, { per: 50 })).to.be.null;
-  });
 
-  it('returns null when count is provided in queryParams', () => {
-    expect(getNextPageParams({ total: 2500, page: 1 }, { count: 50 })).to.be
-      .null;
-  });
+
 });
 
 describe('get', () => {
@@ -172,13 +166,5 @@ describe('get', () => {
     expect(finalState.data).to.eql([{ id: '1' }, { id: '2' }]);
   });
 
-  it('fetches one page when count is specified', async () => {
-    testServer
-      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
-      .reply(200, makePage([{ id: '1' }, { id: '2' }], 1, 100, 2));
 
-    const finalState = await get('cases', { count: 2 })(baseState);
-
-    expect(finalState.data).to.eql([{ id: '1' }, { id: '2' }]);
-  });
 });

--- a/packages/primero/test/index.js
+++ b/packages/primero/test/index.js
@@ -118,6 +118,7 @@ describe('getNextPageParams', () => {
   });
 
   it('returns null when total or page is missing', () => {
+    expect(getNextPageParams({})).to.be.null;
     expect(getNextPageParams({ total: 10 })).to.be.null;
     expect(getNextPageParams({ page: 1 })).to.be.null;
   });
@@ -134,9 +135,6 @@ describe('getNextPageParams', () => {
   it('returns null on the last page', () => {
     expect(getNextPageParams({ total: 2500, page: 3 })).to.be.null;
   });
-
-
-
 });
 
 describe('get', () => {
@@ -165,6 +163,4 @@ describe('get', () => {
 
     expect(finalState.data).to.eql([{ id: '1' }, { id: '2' }]);
   });
-
-
 });

--- a/packages/primero/test/index.js
+++ b/packages/primero/test/index.js
@@ -217,4 +217,94 @@ describe('get', () => {
 
     expect(finalState.data).to.eql(item);
   });
+
+  it('returns exactly limit items when limit is smaller than a full page span', async () => {
+    const page1 = [1, 2, 3, 4, 5].map(id => ({ id: `${id}` }));
+    const page2 = [6, 7, 8, 9, 10].map(id => ({ id: `${id}` }));
+
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, makePage(page1, 1, 20, 5));
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, makePage(page2, 2, 20, 5));
+
+    const finalState = await get('cases', { per: 5, limit: 6 })(baseState);
+
+    expect(finalState.data).to.eql([...page1, { id: '6' }]);
+    expect(finalState.data).to.have.length(6);
+  });
+
+  it('caps per to limit when limit is smaller than per', async () => {
+    const page1 = [1, 2, 3].map(id => ({ id: `${id}` }));
+
+    let sentQuery;
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, req => {
+        sentQuery = req.query;
+        return makePage(page1, 1, 20, 3);
+      });
+
+    const finalState = await get('cases', { per: 5, limit: 3 })(baseState);
+
+    expect(sentQuery.per).to.eql(3);
+    expect(finalState.data).to.eql(page1);
+  });
+
+  it('shrinks per on the final page but keeps the page number from metadata', async () => {
+    const page1 = [1, 2, 3, 4, 5].map(id => ({ id: `${id}` }));
+    const page2 = [6, 7, 8, 9, 10].map(id => ({ id: `${id}` }));
+    const page3 = [11, 12].map(id => ({ id: `${id}` }));
+
+    const sentQueries = [];
+    const record = body => req => {
+      sentQueries.push(req.query);
+      return body;
+    };
+
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, record(makePage(page1, 1, 20, 5)));
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, record(makePage(page2, 2, 20, 5)));
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, record(makePage(page3, 3, 20, 2)));
+
+    const finalState = await get('cases', { per: 5, limit: 12 })(baseState);
+
+    expect(finalState.data).to.eql([...page1, ...page2, ...page3]);
+    expect(finalState.data).to.have.length(12);
+    expect(sentQueries[2]).to.include({ page: 3, per: 2 });
+  });
+
+  it('shrinks per to the remaining count on the final page regardless of alignment', async () => {
+    const page1 = [1, 2, 3, 4, 5].map(id => ({ id: `${id}` }));
+    const page2 = [6, 7, 8, 9, 10].map(id => ({ id: `${id}` }));
+    const page3 = [11, 12, 13].map(id => ({ id: `${id}` }));
+
+    const sentQueries = [];
+    const record = body => req => {
+      sentQueries.push(req.query);
+      return body;
+    };
+
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, record(makePage(page1, 1, 20, 5)));
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, record(makePage(page2, 2, 20, 5)));
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, record(makePage(page3, 3, 20, 3)));
+
+    const finalState = await get('cases', { per: 5, limit: 13 })(baseState);
+
+    expect(finalState.data).to.have.length(13);
+    expect(finalState.data).to.eql([...page1, ...page2, ...page3]);
+    expect(sentQueries[2]).to.include({ page: 3, per: 3 });
+  });
 });

--- a/packages/primero/test/index.js
+++ b/packages/primero/test/index.js
@@ -2,8 +2,30 @@ import Adaptor from '../src/index.js';
 import pkg from 'chai';
 const { expect } = pkg;
 import nock from 'nock';
+import { enableMockClient } from '@openfn/language-common/util';
+import { getNextPageParams } from '../src/Utils.js';
 
-const { execute, getCases, alterState } = Adaptor;
+const { execute, getCases, alterState, get } = Adaptor;
+
+const baseUrl = 'https://primero.example.com';
+const testServer = enableMockClient(baseUrl);
+
+const configuration = {
+  url: baseUrl,
+  user: 'admin',
+  password: 'secret',
+};
+
+const baseState = {
+  configuration,
+  data: {},
+  references: [],
+};
+
+const makePage = (items, page, total, per) => ({
+  data: items,
+  metadata: { total, per, page },
+});
 
 describe.skip('The execute() function', () => {
   it('executes each operation in sequence', done => {
@@ -86,5 +108,77 @@ describe.skip('The getCases() function', () => {
       expect(counter).to.eql(2);
       console.log(nextState);
     });
+  });
+});
+
+describe('getNextPageParams', () => {
+  it('returns null when metadata is missing', () => {
+    expect(getNextPageParams(null)).to.be.null;
+    expect(getNextPageParams(undefined)).to.be.null;
+  });
+
+  it('returns null when total or page is missing', () => {
+    expect(getNextPageParams({ total: 10 })).to.be.null;
+    expect(getNextPageParams({ page: 1 })).to.be.null;
+  });
+
+  it('returns null when all records fit on the first page', () => {
+    expect(getNextPageParams({ total: 5, page: 1 })).to.be.null;
+  });
+
+  it('returns next page params when more pages exist', () => {
+    const result = getNextPageParams({ total: 2500, page: 1 });
+    expect(result).to.eql({ page: 2, per: 1000 });
+  });
+
+  it('returns null on the last page', () => {
+    expect(getNextPageParams({ total: 2500, page: 3 })).to.be.null;
+  });
+
+  it('returns null when per is provided in queryParams', () => {
+    expect(getNextPageParams({ total: 2500, page: 1 }, { per: 50 })).to.be.null;
+  });
+
+  it('returns null when count is provided in queryParams', () => {
+    expect(getNextPageParams({ total: 2500, page: 1 }, { count: 50 })).to.be
+      .null;
+  });
+});
+
+describe('get', () => {
+  it('paginates automatically until all records are fetched', async () => {
+    const items1 = [{ id: '1' }, { id: '2' }];
+    const items2 = [{ id: '3' }];
+
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, makePage(items1, 1, 1003, 1000));
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, makePage(items2, 2, 1003, 1000));
+
+    const finalState = await get('cases')(baseState);
+
+    expect(finalState.data).to.eql([...items1, ...items2]);
+  });
+
+  it('fetches one page when per is specified', async () => {
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, makePage([{ id: '1' }, { id: '2' }], 1, 100, 2));
+
+    const finalState = await get('cases', { per: 2 })(baseState);
+
+    expect(finalState.data).to.eql([{ id: '1' }, { id: '2' }]);
+  });
+
+  it('fetches one page when count is specified', async () => {
+    testServer
+      .intercept({ path: /\/api\/v2\/cases/, method: 'GET' })
+      .reply(200, makePage([{ id: '1' }, { id: '2' }], 1, 100, 2));
+
+    const finalState = await get('cases', { count: 2 })(baseState);
+
+    expect(finalState.data).to.eql([{ id: '1' }, { id: '2' }]);
   });
 });


### PR DESCRIPTION
## Summary

- Add `get('cases', { per: 2 })` for making paginated GET requests to any Primero endpoint. 
- Added a reusable pagination function

Fixes #1765 


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Review Checklist

Before merging, the reviewer should check the following items:

- [x] Does the PR do what it claims to do?
- [ ] If this is a new adaptor, added the adaptor on marketing website ?
- [ ] If this PR includes breaking changes, do we need to update any jobs in
      production? Is it safe to release?
- [ ] Are there any unit tests?
- [ ] Is there a changeset associated with this PR? Should there be? Note that
      dev only changes don't need a changeset.
- [ ] If there is a changeset, was `pnpm run version` used to bump versions (not
      `pnpm changeset version` directly)? This ensures changelog dates are stamped correctly.
- [x] Have you ticked a box under AI Usage?
