### PR TITLE
Add tls options to openmrs and fhir

### DIFF
--- a/.changeset/quick-fhir4-tls.md
+++ b/.changeset/quick-fhir4-tls.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-fhir-4': minor
+---
+
+Add support for `tls` options in `state.configuration`

--- a/.changeset/spicy-fhir-tls.md
+++ b/.changeset/spicy-fhir-tls.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-fhir': minor
+---
+
+Add support for `tls` options in `state.configuration`

--- a/.changeset/tender-openmrs-tls.md
+++ b/.changeset/tender-openmrs-tls.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-openmrs': minor
+---
+
+Add support for `tls` options in `state.configuration`

--- a/packages/fhir-4/configuration-schema.json
+++ b/packages/fhir-4/configuration-schema.json
@@ -51,6 +51,17 @@
       "writeOnly": true,
       "minLength": 1,
       "examples": ["custom 12345"]
+    },
+    "tls": {
+      "title": "TLS Options",
+      "type": "object",
+      "description": "TLS options to use for HTTPS requests. See https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions",
+      "writeOnly": true,
+      "examples": [
+        {
+          "cert": "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAL5z1k3f4b2wMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdTYW4gSm9zZTET\n-----END CERTIFICATE-----"
+        }
+      ]
     }
   },
   "required": ["baseUrl", "apiPath"]

--- a/packages/fhir-4/src/util.ts
+++ b/packages/fhir-4/src/util.ts
@@ -76,11 +76,24 @@ type RequestOptions = {
     username?: string;
     password?: string;
     access_token?: string;
+    tls?: Record<string, any>;
   };
   query?: Record<string, string>;
+  tls?: Record<string, any>;
 };
 
-export const request = (method, path, options: RequestOptions) => {
+export function getTLSOptions(
+  configuration: RequestOptions['configuration'] = {},
+  requestOptions: Partial<RequestOptions> = {},
+) {
+  return requestOptions.tls ?? configuration.tls;
+}
+
+export const request = (
+  method: string,
+  path: string,
+  options: RequestOptions,
+) => {
   assertRelativeUrl(path);
 
   const { configuration, ...otherOptions } = options;
@@ -98,6 +111,7 @@ export const request = (method, path, options: RequestOptions) => {
     ),
     baseUrl: configuration.baseUrl,
     parseAs: 'json',
+    tls: getTLSOptions(configuration, otherOptions),
   };
 
   // TODO add common error handlers for 404, 401

--- a/packages/fhir-4/test/util.test.ts
+++ b/packages/fhir-4/test/util.test.ts
@@ -1,5 +1,11 @@
 import { expect } from 'chai';
-import { sortBundle, logValidationErrors, getTLSOptions } from '../src/util';
+import { enableMockClient } from '@openfn/language-common/util';
+import {
+  sortBundle,
+  logValidationErrors,
+  getTLSOptions,
+  request,
+} from '../src/util';
 
 const mockLogger = { log: () => {}, error: () => {} };
 
@@ -202,6 +208,31 @@ describe('logValidationErrors', () => {
         },
       },
     });
+  });
+});
+
+describe('request() with tls', () => {
+  it('should make a request using tls options from configuration', async () => {
+    const tls = { ca: 'test-ca-cert', cert: 'test-cert', key: 'test-key' };
+    const baseUrl = 'https://fhir4-tls-tests.example.com';
+    const apiPath = 'baseR4';
+
+    enableMockClient(baseUrl, { tls })
+      .intercept({
+        path: '/baseR4/Patient/123',
+        method: 'GET',
+      })
+      .reply(
+        200,
+        { resourceType: 'Patient', id: '123' },
+        { headers: { 'content-type': 'application/fhir+json' } },
+      );
+
+    const response = await request('GET', 'Patient/123', {
+      configuration: { baseUrl, apiPath, tls },
+    });
+
+    expect(response.body).to.eql({ resourceType: 'Patient', id: '123' });
   });
 });
 

--- a/packages/fhir-4/test/util.test.ts
+++ b/packages/fhir-4/test/util.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sortBundle, logValidationErrors } from '../src/util';
+import { sortBundle, logValidationErrors, getTLSOptions } from '../src/util';
 
 const mockLogger = { log: () => {}, error: () => {} };
 
@@ -202,5 +202,34 @@ describe('logValidationErrors', () => {
         },
       },
     });
+  });
+});
+
+describe('getTLSOptions', () => {
+  it('prefers requestOptions.tls over configuration.tls', () => {
+    const configuration = {
+      tls: { ca: 'config-ca', cert: 'config-cert' },
+    };
+
+    const requestOptions = {
+      tls: { ca: 'request-ca', cert: 'request-cert' },
+    };
+
+    const result = getTLSOptions(configuration, requestOptions);
+    expect(result).to.deep.equal(requestOptions.tls);
+  });
+
+  it('falls back to configuration.tls if requestOptions.tls is not provided', () => {
+    const configuration = {
+      tls: { ca: 'config-ca', cert: 'config-cert' },
+    };
+
+    const result = getTLSOptions(configuration, {});
+    expect(result).to.deep.equal(configuration.tls);
+  });
+
+  it('returns undefined if no TLS config is found', () => {
+    const result = getTLSOptions({}, {});
+    expect(result).to.be.undefined;
   });
 });

--- a/packages/fhir/configuration-schema.json
+++ b/packages/fhir/configuration-schema.json
@@ -55,6 +55,17 @@
             "examples": [
                 "the-long-access-token-from-your-auth"
             ]
+        },
+        "tls": {
+            "title": "TLS Options",
+            "type": "object",
+            "description": "TLS options to use for HTTPS requests. See https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions",
+            "writeOnly": true,
+            "examples": [
+                {
+                    "cert": "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAL5z1k3f4b2wMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdTYW4gSm9zZTET\n-----END CERTIFICATE-----"
+                }
+            ]
         }
     },
     "required": [

--- a/packages/fhir/src/Adaptor.js
+++ b/packages/fhir/src/Adaptor.js
@@ -21,6 +21,7 @@ import * as util from './Utils.js';
  * @property {object} query - Query parameters for the request. Will be encoded into the URL
  * @property {object} errors - Map of errorCodes -> error messages, ie, `{ 404: 'Resource not found;' }`. Pass `false` to suppress errors for this code.
  * @property {number} timeout - Request timeout in ms. Default: 300 seconds.
+ * @property {object} tls - TLS/SSL options for this request. Overrides `configuration.tls`. See https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
  */
 
 /**

--- a/packages/fhir/src/Utils.js
+++ b/packages/fhir/src/Utils.js
@@ -20,6 +20,10 @@ export function addAuth(configuration = {}, headers) {
   }
 }
 
+export function getTLSOptions(configuration = {}, requestOptions = {}) {
+  return requestOptions.tls ?? configuration.tls;
+}
+
 export const prepareNextState = (state, response, callback) => {
   const { body, ...responseWithoutBody } = response;
 
@@ -38,6 +42,8 @@ export const request = (configuration, method, path, options = {}) => {
 
   addAuth(configuration, headers);
 
+  const tls = getTLSOptions(configuration, otherOptions);
+
   const opts = {
     ...otherOptions,
     headers: {
@@ -47,6 +53,7 @@ export const request = (configuration, method, path, options = {}) => {
     },
     baseUrl,
     parseAs: 'json',
+    tls,
   };
 
   return commonRequest(method, fullPath, opts).then(logResponse);

--- a/packages/fhir/test/Adaptor.test.js
+++ b/packages/fhir/test/Adaptor.test.js
@@ -174,6 +174,25 @@ describe('get', () => {
     expect(path1State.data).to.eql(fixtures.patient);
     expect(path2State.data).to.eql(fixtures.patient);
   });
+
+  it('should make a request using tls options from configuration', async () => {
+    const tls = { ca: 'test-ca-cert', cert: 'test-cert', key: 'test-key' };
+
+    enableMockClient(baseUrl, { tls })
+      .intercept({
+        path: '/baseR4/Patient',
+        method: 'GET',
+      })
+      .reply(200, fixtures.patientBundle);
+
+    const state = {
+      configuration: { ...configuration, tls },
+    };
+
+    const finalState = await execute(get('Patient'))(state);
+
+    expect(finalState.data).to.eql(fixtures.patientBundle);
+  });
 });
 
 describe('getClaim', () => {

--- a/packages/fhir/test/Utils.test.js
+++ b/packages/fhir/test/Utils.test.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+
+import { getTLSOptions } from '../src/Utils.js';
+
+describe('getTLSOptions', () => {
+  it('prefers requestOptions.tls over configuration.tls', () => {
+    const configuration = {
+      tls: { ca: 'config-ca', cert: 'config-cert' },
+    };
+
+    const requestOptions = {
+      tls: { ca: 'request-ca', cert: 'request-cert' },
+    };
+
+    const result = getTLSOptions(configuration, requestOptions);
+    expect(result).to.deep.equal(requestOptions.tls);
+  });
+
+  it('falls back to configuration.tls if requestOptions.tls is not provided', () => {
+    const configuration = {
+      tls: { ca: 'config-ca', cert: 'config-cert' },
+    };
+
+    const result = getTLSOptions(configuration, {});
+    expect(result).to.deep.equal(configuration.tls);
+  });
+
+  it('returns undefined if no TLS config is found', () => {
+    const result = getTLSOptions({}, {});
+    expect(result).to.be.undefined;
+  });
+});

--- a/packages/http/test/index.js
+++ b/packages/http/test/index.js
@@ -69,6 +69,29 @@ describe('request()', () => {
     expect(result.data).to.eql('hello');
   });
 
+  it('should make a request using tls options from configuration', async () => {
+    const tls = { ca: 'test-ca-cert', cert: 'test-cert', key: 'test-key' };
+
+    enableMockClient('https://www.example.com', {
+      defaultContentType: 'text',
+      maxRedirections: 5,
+      tls,
+    })
+      .intercept({ path: '/greeting' })
+      .reply(200, 'hello');
+
+    const state = {
+      configuration: {
+        baseUrl: 'https://www.example.com',
+        tls,
+      },
+    };
+
+    const result = await execute(request('GET', '/greeting'))(state);
+
+    expect(result.data).to.eql('hello');
+  });
+
   it('should throw if no baseUrl is set and no url is provided', async () => {
     const state = {
       configuration: null,

--- a/packages/openmrs/configuration-schema.json
+++ b/packages/openmrs/configuration-schema.json
@@ -44,6 +44,17 @@
                 "R3",
                 "R2"
             ]
+        },
+        "tls": {
+            "title": "TLS Options",
+            "type": "object",
+            "description": "TLS options to use for HTTPS requests. See https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions",
+            "writeOnly": true,
+            "examples": [
+                {
+                    "cert": "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAL5z1k3f4b2wMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdTYW4gSm9zZTET\n-----END CERTIFICATE-----"
+                }
+            ]
         }
     },
     "type": "object",

--- a/packages/openmrs/src/Utils.js
+++ b/packages/openmrs/src/Utils.js
@@ -48,6 +48,10 @@ export async function fetchAndLog(method, url, opts = {}) {
   }
 }
 
+export function getTLSOptions(state, requestOptions = {}) {
+  return requestOptions.tls ?? state.configuration?.tls;
+}
+
 export function validateCredentials(state) {
   const config = state.configuration || {};
 
@@ -181,6 +185,8 @@ export async function request(state, method, path, options = {}) {
     finalHeaders['Accept-Language'] = language;
   }
 
+  const tls = getTLSOptions(state, options);
+
   const requestOptions = {
     body: data,
     headers: finalHeaders,
@@ -188,6 +194,7 @@ export async function request(state, method, path, options = {}) {
     parseAs,
     baseUrl,
     errors,
+    tls,
     _onrequest,
   };
 

--- a/packages/openmrs/src/http.js
+++ b/packages/openmrs/src/http.js
@@ -18,6 +18,7 @@ import * as util from './Utils.js';
  * @property {object} data - The request body (as JSON)
  * @property {object|boolean} errors - Pass `false` to not throw on errors. Pass a map of errorCodes: error messages, ie, `{ 404: 'Resource not found' }`, or `false` to suppress errors for a specific code.
  * @property {string} [parseAs='json'] - The response format to parse (e.g., 'json', 'text', or 'stream')
+ * @property {object} tls - TLS/SSL options for this request. Overrides `configuration.tls`. See https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
  */
 
 /**

--- a/packages/openmrs/test/http.test.js
+++ b/packages/openmrs/test/http.test.js
@@ -71,6 +71,27 @@ describe('http.request', () => {
 
     expect(result.response.statusCode).to.equal(404);
   });
+
+  it('should make a request using tls options from configuration', async () => {
+    const tls = { ca: 'test-ca-cert', cert: 'test-cert', key: 'test-key' };
+
+    enableMockClient('https://http-tests.openmrs.org', { tls })
+      .intercept({
+        path: '/ws/rest/v1/patient',
+        query: { q: 'Sarah 1' },
+        method: 'GET',
+      })
+      .reply(200, { results: testData.patientResults }, { ...jsonHeaders });
+
+    const { data } = await http.request('GET', '/ws/rest/v1/patient', {
+      query: { q: 'Sarah 1' },
+    })({
+      ...state,
+      configuration: { ...configuration, tls },
+    });
+
+    expect(data.results[0].display).to.eql(testData.patientResults[0].display);
+  });
 });
 
 describe('http.get', () => {
@@ -102,7 +123,7 @@ describe('http.get', () => {
             },
           ],
         },
-        { ...jsonHeaders }
+        { ...jsonHeaders },
       );
   });
 
@@ -150,7 +171,7 @@ describe('http.post', () => {
   it('should make http request with the "POST" verb', async () => {
     const response = await http.post(
       '/ws/rest/v1/patient',
-      testData.newPatient
+      testData.newPatient,
     )(state);
     expect(response.response.method).to.eql('POST');
   });
@@ -158,7 +179,7 @@ describe('http.post', () => {
   it('should make a successful POST request to openmrs', async () => {
     const { data } = await http.post(
       '/ws/rest/v1/patient',
-      testData.newPatient
+      testData.newPatient,
     )(state);
     expect(data.results[0].display).to.eql(testData.patientResults[0].display);
   });
@@ -186,7 +207,7 @@ describe('http.put', () => {
   it('should make http request with the PUT verb', async () => {
     const response = await http.put(
       '/ws/rest/v1/patient',
-      testData.newPatient
+      testData.newPatient,
     )(state);
     expect(response.response.statusCode).to.eql(200);
     expect(response.response.method).to.eql('PUT');

--- a/packages/openmrs/test/utils.test.js
+++ b/packages/openmrs/test/utils.test.js
@@ -3,7 +3,7 @@ import { afterEach } from 'mocha';
 
 import { enableMockClient } from '@openfn/language-common/util';
 import testData from './fixtures.json' with { type: 'json' };
-import { request, requestWithPagination } from '../src/Utils.js';
+import { request, requestWithPagination, getTLSOptions } from '../src/Utils.js';
 
 const testServer = enableMockClient('https://util-tests.openmrs.org');
 
@@ -386,6 +386,43 @@ describe('request()', () => {
       'X-Custom-Header': 'custom-value',
       'content-type': 'application/json',
     });
+  });
+});
+
+describe('getTLSOptions', () => {
+  it('prefers requestOptions.tls over configuration.tls', () => {
+    const testState = {
+      configuration: {
+        tls: { ca: 'config-ca', cert: 'config-cert' },
+      },
+    };
+
+    const requestOptions = {
+      tls: { ca: 'request-ca', cert: 'request-cert' },
+    };
+
+    const result = getTLSOptions(testState, requestOptions);
+    expect(result).to.deep.equal(requestOptions.tls);
+  });
+
+  it('falls back to configuration.tls if requestOptions.tls is not provided', () => {
+    const testState = {
+      configuration: {
+        tls: { ca: 'config-ca', cert: 'config-cert' },
+      },
+    };
+
+    const result = getTLSOptions(testState, {});
+    expect(result).to.deep.equal(testState.configuration.tls);
+  });
+
+  it('returns undefined if no TLS config is found', () => {
+    const testState = {
+      configuration: {},
+    };
+
+    const result = getTLSOptions(testState, {});
+    expect(result).to.be.undefined;
   });
 });
 


### PR DESCRIPTION
## Summary

This PR adds support for `tls` options in the openmrs, fhir, and fhir-4 adaptors. Along exactly the same lines as http.

Fixes #1779 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
