### PR TITLE
feat(collections): add setBatch for explicit key/value pairs

### DIFF
--- a/.changeset/collections-set-batch.md
+++ b/.changeset/collections-set-batch.md
@@ -1,0 +1,5 @@
+---
+'@openfn/language-collections': minor
+---
+
+Add `setBatch(name, items)`, which uploads an array of `{ key, value }` pairs. This covers the case where the key cannot be derived from the value, without having to carry the key on the value itself.

--- a/packages/collections/src/collections.js
+++ b/packages/collections/src/collections.js
@@ -152,8 +152,6 @@ export function set(name, keyGen, values) {
       throw e;
     }
 
-    const batchSize = 1000;
-
     const [resolvedName, resolvedValues] = expandReferences(
       state,
       name,
@@ -190,37 +188,111 @@ export function set(name, keyGen, values) {
       });
     }
 
-    while (kvPairs.length) {
-      const batch = kvPairs.splice(0, batchSize);
+    await uploadValues(state, resolvedName, kvPairs, name);
 
+    return state;
+  };
+}
+
+// Upload key/value pairs to a collection in batches.
+// `logName` is the name as written by the user, so log output is unchanged
+// when a lazy state reference is passed as the collection name.
+const uploadValues = async (state, resolvedName, kvPairs, logName) => {
+  const batchSize = 1000;
+
+  while (kvPairs.length) {
+    const batch = kvPairs.splice(0, batchSize);
+
+    console.log(
+      `Collections: uploading batch of ${batch.length} values to "${logName}"...`,
+    );
+    const response = await request(state, getClient(state), resolvedName, {
+      method: 'POST',
+      body: JSON.stringify({ items: batch }),
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+
+    if (response.statusCode >= 400) {
       console.log(
-        `Collections: uploading batch of ${batch.length} values to "${name}"...`,
+        `Collections: Error setting ${batch.length} values in "${logName}"`,
       );
-      const response = await request(state, getClient(state), resolvedName, {
-        method: 'POST',
-        body: JSON.stringify({ items: batch }),
-        headers: {
-          'content-type': 'application/json',
-        },
-      });
+      const text = await response.body.text();
+      const e = new Error('ERROR from collections server:' + 400);
+      e.body = text;
+      throw e;
+    }
 
-      if (response.statusCode >= 400) {
-        console.log(
-          `Collections: Error setting ${batch.length} values in "${name}"`,
-        );
-        const text = await response.body.text();
-        const e = new Error('ERROR from collections server:' + 400);
-        e.body = text;
+    const result = await response.body.json();
+    console.log(`Collections: set ${result.upserted} values in "${logName}"`);
+
+    if (result.error) {
+      console.log(`Collections: errors reported on set:`, result.error);
+    }
+  }
+};
+
+/**
+ * Adds an array of key/value pairs to a collection. If a key already exists, its
+ * value will be replaced by the new value.
+ *
+ * Use this when the key cannot be derived from the value itself, which is the
+ * case set()'s key generator does not cover: with set() the key has to be
+ * carried on the value, even when it is not part of the data being stored.
+ * @public
+ * @function
+ * @param {string} name - The name of the collection to upload to
+ * @param {Array<{key: string, value: any}>} items - an array of key/value pairs to set
+ * @example <caption>Set values whose keys are not part of the data</caption>
+ * collections.setBatch('my-collection', [
+ *   { key: 'a', value: ['some', 'strings'] },
+ *   { key: 'b', value: ['more', 'strings'] },
+ * ])
+ */
+export function setBatch(name, items) {
+  const argCount = arguments.length;
+  return async state => {
+    if (argCount < 2) {
+      const e = new Error('ILLEGAL_ARGUMENTS');
+      e.description = 'Insufficient arguments passed to setBatch()';
+      e.fix = 'Make sure to pass two arguments to: setBatch(name, items)';
+      e.args = { name, items };
+      throw e;
+    }
+
+    const [resolvedName, resolvedItems] = expandReferences(state, name, items);
+
+    if (!Array.isArray(resolvedItems)) {
+      const e = new Error('ILLEGAL_ARGUMENTS');
+      e.description = 'The second argument to setBatch() must be an array';
+      e.fix =
+        'Pass an array of key/value pairs, ie [{ key: "a", value: { ... } }]';
+      throw e;
+    }
+
+    const kvPairs = resolvedItems.map((item, index) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) {
+        const e = new Error('ILLEGAL_ARGUMENTS');
+        e.description = `Item at index ${index} is not a key/value pair`;
+        e.fix =
+          'Each item passed to setBatch() must be an object like { key: "a", value: { ... } }';
         throw e;
       }
-
-      const result = await response.body.json();
-      console.log(`Collections: set ${result.upserted} values in "${name}"`);
-
-      if (result.error) {
-        console.log(`Collections: errors reported on set:`, result.error);
+      if (typeof item.key !== 'string') {
+        const e = new Error('KEY_ERROR');
+        e.description = `Item at index ${index} does not have a string key`;
+        e.fix =
+          'Each item passed to setBatch() must have a `key` property which is a string';
+        throw e;
       }
-    }
+      return {
+        key: item.key,
+        value: JSON.stringify(item.value),
+      };
+    });
+
+    await uploadValues(state, resolvedName, kvPairs, name);
 
     return state;
   };

--- a/packages/collections/test/Adaptor.test.js
+++ b/packages/collections/test/Adaptor.test.js
@@ -468,6 +468,76 @@ describe('set', () => {
     expect(result).to.eql(item);
   });
 
+  it('setBatch: should set an array of key/value pairs', async () => {
+    const { state } = init();
+
+    await collections.setBatch(COLLECTION, [
+      { key: 'a', value: { id: 'a' } },
+      { key: 'b', value: { id: 'b' } },
+    ])(state);
+
+    expect(api.asJSON(PROJECT, COLLECTION, 'a')).to.eql({ id: 'a' });
+    expect(api.asJSON(PROJECT, COLLECTION, 'b')).to.eql({ id: 'b' });
+  });
+
+  it('setBatch: should set values which carry no key of their own', async () => {
+    const { state } = init();
+
+    await collections.setBatch(COLLECTION, [
+      { key: 'a', value: ['some', 'strings'] },
+    ])(state);
+
+    expect(api.asJSON(PROJECT, COLLECTION, 'a')).to.eql(['some', 'strings']);
+  });
+
+  it('setBatch: should throw if only one arg passed', async () => {
+    const { state } = init();
+
+    let err;
+    try {
+      await collections.setBatch(COLLECTION)(state);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).to.eql('ILLEGAL_ARGUMENTS');
+  });
+
+  it('setBatch: should throw if items is not an array', async () => {
+    const { state } = init();
+
+    let err;
+    try {
+      await collections.setBatch(COLLECTION, { key: 'a', value: 1 })(state);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).to.eql('ILLEGAL_ARGUMENTS');
+  });
+
+  it('setBatch: should throw if an item has no string key', async () => {
+    const { state } = init();
+
+    let err;
+    try {
+      await collections.setBatch(COLLECTION, [{ value: { id: 'a' } }])(state);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).to.eql('KEY_ERROR');
+  });
+
+  it('setBatch: should throw if an item is not an object', async () => {
+    const { state } = init();
+
+    let err;
+    try {
+      await collections.setBatch(COLLECTION, ['nope'])(state);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).to.eql('ILLEGAL_ARGUMENTS');
+  });
+
   it('should resolve a value reference', async () => {
     const { state } = init();
 


### PR DESCRIPTION
Closes #1613

`set()` derives every key from its value, either from a key string or a keygen function. As #1613 describes, that breaks down when the key isn't part of the data — the workaround is to attach the key to the value anyway, and sometimes to delete it again inside the keygen:

```js
collections.set('my-collection', (item) => {
  const key = item.key;
  delete item.key;
  return key;
}, items)
```

`setBatch(name, items)` takes the pairs directly:

```js
collections.setBatch('my-collection', [
  { key: 'a', value: ['some', 'strings'] },
  { key: 'b', value: ['more', 'strings'] },
])
```

## Why a separate function rather than overloading `set()`

The issue asks for `set(name, items)` but then notes overloading "isn't great in docs" and that "a `setBatch()` function might be a cleaner alternative". I went with the separate function, for a reason beyond docs: `set()` currently rejects fewer than three arguments explicitly —

```js
if (argCount < 3) {
  const e = new Error('ILLEGAL_ARGUMENTS');
  e.fix = 'Make sure to pass three arguments to: set(name, key/keygen, values)';
```

— and there's a test pinning that behaviour (`should throw if only two args passed`). A two-argument overload would have to reverse that guard and weaken the error for genuine mistakes, since `set(name, values)` with a forgotten keygen would then be indistinguishable from a batch call. Keeping the two entry points separate leaves that error intact.

Happy to switch to an overload if you'd prefer the shape in the issue title.

## Implementation notes

The batching and upload loop is now a shared `uploadValues()` helper instead of being duplicated. `set()`'s behaviour is unchanged, including its log output — the helper takes the collection name as written by the caller for logging, so a lazy state reference still logs the way it did before.

`setBatch` validates each item and fails with the same style of structured error the module already uses: `ILLEGAL_ARGUMENTS` when `items` isn't an array or an entry isn't an object, and `KEY_ERROR` when an entry has no string `key`.

Values are `JSON.stringify`'d exactly as in `set()`, so a value which is itself an array round-trips as one — that's the case the issue calls out.

## Tests

Six tests added alongside the existing `set` tests: setting multiple pairs, setting a value that carries no key of its own, and the four validation paths.

- `packages/collections`: **98 passing**, up from 92 — the six new tests, no other change.
- `pnpm lint`: identical output before and after (0 errors, 14 pre-existing warnings).

Changeset included as a minor bump.

Note for anyone building locally: `packages/collections` tests need `@openfn/language-common` built first, and that needs `pnpm build:tools` before it, otherwise the build fails on an unbuilt `@openfn/adaptor-apis`.
